### PR TITLE
feat(admin): add dev environment branch switcher

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -11,6 +11,7 @@ const Feedback = lazy(() => import("./pages/Feedback.js"));
 const Polls = lazy(() => import("./pages/Polls.js"));
 const Admins = lazy(() => import("./pages/Admins.js"));
 const AuditLog = lazy(() => import("./pages/AuditLog.js"));
+const DevEnvironment = lazy(() => import("./pages/DevEnvironment.js"));
 
 const NotFound = () => (
   <div class="flex min-h-screen items-center justify-center">
@@ -34,6 +35,7 @@ const App = () => {
             <Route path="/polls" component={Polls} />
             <Route path="/admins" component={Admins} />
             <Route path="/audit-log" component={AuditLog} />
+            <Route path="/dev" component={DevEnvironment} />
           </Route>
         </Route>
         <Route path="*" component={NotFound} />

--- a/apps/admin/src/components/AdminLayout.tsx
+++ b/apps/admin/src/components/AdminLayout.tsx
@@ -68,6 +68,15 @@ const NAV_ITEMS = [
       </svg>
     ),
   },
+  {
+    href: "/dev",
+    label: "Dev Environment",
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="6" y1="3" x2="6" y2="15" /><circle cx="18" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><path d="M18 9a9 9 0 0 1-9 9" />
+      </svg>
+    ),
+  },
 ] as const;
 
 const PAGE_TITLES: Record<string, string> = {
@@ -78,6 +87,7 @@ const PAGE_TITLES: Record<string, string> = {
   "/polls": "Polls",
   "/admins": "Admins",
   "/audit-log": "Audit Log",
+  "/dev": "Dev Environment",
 };
 
 const AdminLayout: ParentComponent = (props) => {

--- a/apps/admin/src/pages/DevEnvironment.tsx
+++ b/apps/admin/src/pages/DevEnvironment.tsx
@@ -47,9 +47,10 @@ const DevEnvironment = () => {
 
       const branchesParsed = branchesSchema.safeParse(branchesRes);
       if (branchesParsed.success) {
-        setBranches(branchesParsed.data.branches);
-        if (!selectedBranch()) {
-          setSelectedBranch(branchesParsed.data.branches[0] ?? "");
+        const newBranches = branchesParsed.data.branches;
+        setBranches(newBranches);
+        if (!selectedBranch() || !newBranches.includes(selectedBranch())) {
+          setSelectedBranch(newBranches[0] ?? "");
         }
       } else {
         console.warn("branches parse failed:", branchesParsed.error.message);

--- a/apps/admin/src/pages/DevEnvironment.tsx
+++ b/apps/admin/src/pages/DevEnvironment.tsx
@@ -1,0 +1,189 @@
+import { createSignal, onMount, Show, For } from "solid-js";
+import { z } from "zod";
+import { api } from "../lib/api.js";
+import { showToast } from "../components/ui/toast.js";
+import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card.js";
+
+const devStatusSchema = z.object({
+  branch: z.string(),
+  switchedAt: z.string().nullable(),
+  switchedBy: z.string().nullable(),
+  status: z.enum(["active", "pending"]),
+});
+
+const branchesSchema = z.object({
+  branches: z.array(z.string()),
+});
+
+type DevStatus = z.infer<typeof devStatusSchema>;
+
+const formatDate = (iso: string | null) => {
+  if (!iso) return "Never";
+  return new Date(iso).toLocaleString();
+};
+
+const DevEnvironment = () => {
+  const [status, setStatus] = createSignal<DevStatus | null>(null);
+  const [branches, setBranches] = createSignal<string[]>([]);
+  const [selectedBranch, setSelectedBranch] = createSignal("");
+  const [loading, setLoading] = createSignal(true);
+  const [switching, setSwitching] = createSignal(false);
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const [statusRes, branchesRes] = await Promise.all([
+        api<unknown>("/api/admin/dev-status"),
+        api<unknown>("/api/admin/branches"),
+      ]);
+
+      const statusParsed = devStatusSchema.safeParse(statusRes);
+      if (statusParsed.success) {
+        setStatus(statusParsed.data);
+      }
+
+      const branchesParsed = branchesSchema.safeParse(branchesRes);
+      if (branchesParsed.success) {
+        setBranches(branchesParsed.data.branches);
+        if (!selectedBranch()) {
+          setSelectedBranch(branchesParsed.data.branches[0] ?? "");
+        }
+      }
+    } catch {
+      showToast("Failed to load dev environment data", "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  onMount(fetchData);
+
+  const handleSwitch = async () => {
+    const branch = selectedBranch();
+    if (!branch) return;
+
+    setSwitching(true);
+    try {
+      await api("/api/admin/switch-dev", {
+        method: "POST",
+        body: JSON.stringify({ branch }),
+      });
+      showToast(`Branch marked for switch to "${branch}"`, "info");
+      await fetchData();
+    } catch {
+      showToast("Failed to switch branch", "error");
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1 class="mb-6 text-xl font-semibold">Dev Environment</h1>
+
+      <Show
+        when={!loading()}
+        fallback={
+          <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <Card>
+              <CardContent class="p-5">
+                <div class="h-24 animate-pulse rounded-lg bg-muted" />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent class="p-5">
+                <div class="h-24 animate-pulse rounded-lg bg-muted" />
+              </CardContent>
+            </Card>
+          </div>
+        }
+      >
+        <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {/* Current Status */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Current Status</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Show when={status()} fallback={<p class="text-sm text-muted-foreground">No status available</p>}>
+                {(s) => (
+                  <div class="space-y-3">
+                    <div class="flex items-center justify-between">
+                      <span class="text-sm text-muted-foreground">Active Branch</span>
+                      <span class="rounded-md bg-primary/10 px-2.5 py-1 text-sm font-medium text-primary">
+                        {s().branch}
+                      </span>
+                    </div>
+                    <div class="flex items-center justify-between">
+                      <span class="text-sm text-muted-foreground">Status</span>
+                      <span
+                        class={`rounded-md px-2.5 py-1 text-sm font-medium ${
+                          s().status === "active"
+                            ? "bg-success/10 text-success"
+                            : "bg-warning/10 text-warning"
+                        }`}
+                      >
+                        {s().status === "active" ? "Active" : "Pending Rebuild"}
+                      </span>
+                    </div>
+                    <div class="flex items-center justify-between">
+                      <span class="text-sm text-muted-foreground">Switched At</span>
+                      <span class="text-sm">{formatDate(s().switchedAt)}</span>
+                    </div>
+                    <div class="flex items-center justify-between">
+                      <span class="text-sm text-muted-foreground">Switched By</span>
+                      <span class="text-sm">{s().switchedBy ?? "—"}</span>
+                    </div>
+                  </div>
+                )}
+              </Show>
+            </CardContent>
+          </Card>
+
+          {/* Branch Selector */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Switch Branch</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div class="space-y-4">
+                <div>
+                  <label for="branch-select" class="mb-1.5 block text-sm font-medium text-muted-foreground">
+                    Target Branch
+                  </label>
+                  <select
+                    id="branch-select"
+                    value={selectedBranch()}
+                    onChange={(e) => setSelectedBranch(e.currentTarget.value)}
+                    disabled={switching()}
+                    class="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-primary focus:ring-1 focus:ring-primary disabled:opacity-50"
+                  >
+                    <For each={branches()}>
+                      {(branch) => <option value={branch}>{branch}</option>}
+                    </For>
+                  </select>
+                </div>
+
+                <button
+                  onClick={handleSwitch}
+                  disabled={switching() || !selectedBranch() || selectedBranch() === status()?.branch}
+                  class="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {switching() ? "Marking..." : "Mark for Switch"}
+                </button>
+
+                <Show when={status()?.status === "pending"}>
+                  <p class="rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-xs text-warning">
+                    Rebuild pending — tell Git Manager: <span class="font-mono">switch dev to {status()?.branch}</span>
+                  </p>
+                </Show>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default DevEnvironment;

--- a/apps/admin/src/pages/DevEnvironment.tsx
+++ b/apps/admin/src/pages/DevEnvironment.tsx
@@ -116,7 +116,9 @@ const DevEnvironment = () => {
                 {(s) => (
                   <div class="space-y-3">
                     <div class="flex items-center justify-between">
-                      <span class="text-sm text-muted-foreground">Active Branch</span>
+                      <span class="text-sm text-muted-foreground">
+                        {s().status === "pending" ? "Pending Branch" : "Active Branch"}
+                      </span>
                       <span class="rounded-md bg-primary/10 px-2.5 py-1 text-sm font-medium text-primary">
                         {s().branch}
                       </span>

--- a/apps/admin/src/pages/DevEnvironment.tsx
+++ b/apps/admin/src/pages/DevEnvironment.tsx
@@ -40,6 +40,9 @@ const DevEnvironment = () => {
       const statusParsed = devStatusSchema.safeParse(statusRes);
       if (statusParsed.success) {
         setStatus(statusParsed.data);
+      } else {
+        console.warn("dev-status parse failed:", statusParsed.error.message);
+        showToast("Dev status response has unexpected shape", "error");
       }
 
       const branchesParsed = branchesSchema.safeParse(branchesRes);
@@ -48,6 +51,9 @@ const DevEnvironment = () => {
         if (!selectedBranch()) {
           setSelectedBranch(branchesParsed.data.branches[0] ?? "");
         }
+      } else {
+        console.warn("branches parse failed:", branchesParsed.error.message);
+        showToast("Branches response has unexpected shape", "error");
       }
     } catch {
       showToast("Failed to load dev environment data", "error");

--- a/apps/admin/src/pages/DevEnvironment.tsx
+++ b/apps/admin/src/pages/DevEnvironment.tsx
@@ -41,6 +41,7 @@ const DevEnvironment = () => {
       if (statusParsed.success) {
         setStatus(statusParsed.data);
       } else {
+        setStatus(null);
         console.warn("dev-status parse failed:", statusParsed.error.message);
         showToast("Dev status response has unexpected shape", "error");
       }
@@ -53,10 +54,15 @@ const DevEnvironment = () => {
           setSelectedBranch(newBranches[0] ?? "");
         }
       } else {
+        setBranches([]);
+        setSelectedBranch("");
         console.warn("branches parse failed:", branchesParsed.error.message);
         showToast("Branches response has unexpected shape", "error");
       }
     } catch {
+      setStatus(null);
+      setBranches([]);
+      setSelectedBranch("");
       showToast("Failed to load dev environment data", "error");
     } finally {
       setLoading(false);

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -779,7 +779,9 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
       if (!exists) throw new NotFoundError("Branch");
     } catch (err) {
       if (err instanceof NotFoundError) throw err;
-      throw new NotFoundError("Branch");
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") throw new NotFoundError("Branch");
+      throw new InternalError("Failed to read worktrees directory");
     }
 
     const state = {
@@ -790,7 +792,9 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     };
 
     await Bun.write("/app/dev-state/branch.json", JSON.stringify(state, null, 2));
-    await logAudit(sessionUser.id, "switch_dev", "dev_environment", branch);
+    logAudit(sessionUser.id, "switch_dev", "dev_environment", branch).catch((err) =>
+      console.error("audit log failed for switch_dev:", err),
+    );
 
     return {
       success: true,

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -767,6 +767,11 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     }
     const { branch } = parsed.data;
 
+    // Reject path traversal characters before touching the filesystem
+    if (/[/\\]/.test(branch) || branch === ".." || branch === ".") {
+      throw new ValidationError("Invalid branch name");
+    }
+
     // Validate the branch exists as a worktree directory
     try {
       const entries = await readdir("/app/worktrees", { withFileTypes: true });

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -770,7 +770,7 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
   .get("/dev-status", async () => loadDevState())
 
   .post("/switch-dev", async ({ body, user: sessionUser }) => {
-    const switchSchema = z.object({ branch: z.string().min(1).max(200) });
+    const switchSchema = z.object({ branch: z.string().min(1) });
     const parsed = switchSchema.safeParse(body);
     if (!parsed.success) {
       throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
@@ -795,8 +795,6 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
       if (!exists) throw new NotFoundError("Branch");
     } catch (err) {
       if (err instanceof NotFoundError) throw err;
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ENOENT") throw new NotFoundError("Branch");
       throw new InternalError("Failed to read worktrees directory");
     }
 

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -731,8 +731,9 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
       const entries = await readdir("/app/worktrees", { withFileTypes: true });
       const branches = entries.filter((e) => e.isDirectory()).map((e) => e.name).toSorted();
       return { branches };
-    } catch {
-      return { branches: [] };
+    } catch (err) {
+      console.error("Failed to read worktrees directory:", err);
+      throw new InternalError("Failed to list branches");
     }
   })
 
@@ -741,22 +742,25 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     if (!(await stateFile.exists())) {
       return { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
     }
+    const schema = z.object({
+      branch: z.string(),
+      switchedAt: z.string().nullable(),
+      switchedBy: z.string().nullable(),
+      status: z.enum(["active", "pending"]),
+    });
+    let raw: unknown;
     try {
-      const raw: unknown = await stateFile.json();
-      const schema = z.object({
-        branch: z.string(),
-        switchedAt: z.string().nullable(),
-        switchedBy: z.string().nullable(),
-        status: z.enum(["active", "pending"]),
-      });
-      const parsed = schema.safeParse(raw);
-      if (!parsed.success) {
-        return { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
-      }
-      return parsed.data;
-    } catch {
-      return { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
+      raw = await stateFile.json();
+    } catch (err) {
+      console.error("Failed to read dev-state/branch.json:", err);
+      throw new InternalError("Failed to read dev environment state");
     }
+    const parsed = schema.safeParse(raw);
+    if (!parsed.success) {
+      console.error("Corrupt dev-state/branch.json:", parsed.error.message);
+      throw new InternalError("Dev environment state file is corrupt");
+    }
+    return parsed.data;
   })
 
   .post("/switch-dev", async ({ body, user: sessionUser }) => {
@@ -766,6 +770,20 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
       throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
     }
     const { branch } = parsed.data;
+
+    // Reject switching to the already-active branch
+    const currentState = Bun.file("/app/dev-state/branch.json");
+    if (await currentState.exists()) {
+      try {
+        const current = (await currentState.json()) as { branch?: string };
+        if (current.branch === branch) {
+          throw new ValidationError(`Dev environment is already set to "${branch}"`);
+        }
+      } catch (err) {
+        if (err instanceof ValidationError) throw err;
+        // State file unreadable — proceed with the switch
+      }
+    }
 
     // Reject path traversal characters before touching the filesystem
     if (/[/\\]/.test(branch) || branch === ".." || branch === ".") {

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -31,6 +31,36 @@ import { computeEffectiveTier } from "../helpers/resolve-tier.js";
 
 const PAGE_SIZE = 50;
 
+const devStateSchema = z.object({
+  branch: z.string(),
+  switchedAt: z.string().nullable(),
+  switchedBy: z.string().nullable(),
+  status: z.enum(["active", "pending"]),
+});
+
+type DevState = z.infer<typeof devStateSchema>;
+
+const DEV_STATE_DEFAULT: DevState = { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
+const DEV_STATE_PATH = "/app/dev-state/branch.json";
+
+async function loadDevState(): Promise<DevState> {
+  const stateFile = Bun.file(DEV_STATE_PATH);
+  if (!(await stateFile.exists())) return DEV_STATE_DEFAULT;
+  let raw: unknown;
+  try {
+    raw = await stateFile.json();
+  } catch (err) {
+    console.error("Failed to read dev-state/branch.json:", err);
+    throw new InternalError("Failed to read dev environment state");
+  }
+  const parsed = devStateSchema.safeParse(raw);
+  if (!parsed.success) {
+    console.error("Corrupt dev-state/branch.json:", parsed.error.message);
+    throw new InternalError("Dev environment state file is corrupt");
+  }
+  return parsed.data;
+}
+
 async function logAudit(
   adminId: string,
   action: string,
@@ -737,31 +767,7 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     }
   })
 
-  .get("/dev-status", async () => {
-    const stateFile = Bun.file("/app/dev-state/branch.json");
-    if (!(await stateFile.exists())) {
-      return { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
-    }
-    const schema = z.object({
-      branch: z.string(),
-      switchedAt: z.string().nullable(),
-      switchedBy: z.string().nullable(),
-      status: z.enum(["active", "pending"]),
-    });
-    let raw: unknown;
-    try {
-      raw = await stateFile.json();
-    } catch (err) {
-      console.error("Failed to read dev-state/branch.json:", err);
-      throw new InternalError("Failed to read dev environment state");
-    }
-    const parsed = schema.safeParse(raw);
-    if (!parsed.success) {
-      console.error("Corrupt dev-state/branch.json:", parsed.error.message);
-      throw new InternalError("Dev environment state file is corrupt");
-    }
-    return parsed.data;
-  })
+  .get("/dev-status", async () => loadDevState())
 
   .post("/switch-dev", async ({ body, user: sessionUser }) => {
     const switchSchema = z.object({ branch: z.string().min(1).max(200) });
@@ -772,17 +778,9 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     const { branch } = parsed.data;
 
     // Reject switching to the already-active branch
-    const currentState = Bun.file("/app/dev-state/branch.json");
-    if (await currentState.exists()) {
-      try {
-        const current = (await currentState.json()) as { branch?: string };
-        if (current.branch === branch) {
-          throw new ValidationError(`Dev environment is already set to "${branch}"`);
-        }
-      } catch (err) {
-        if (err instanceof ValidationError) throw err;
-        // State file unreadable — proceed with the switch
-      }
+    const currentState = await loadDevState();
+    if (currentState.branch === branch) {
+      throw new ValidationError(`Dev environment is already set to "${branch}"`);
     }
 
     // Reject path traversal characters before touching the filesystem
@@ -809,7 +807,7 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
       status: "pending" as const,
     };
 
-    await Bun.write("/app/dev-state/branch.json", JSON.stringify(state, null, 2));
+    await Bun.write(DEV_STATE_PATH, JSON.stringify(state, null, 2));
     logAudit(sessionUser.id, "switch_dev", "dev_environment", branch).catch((err) =>
       console.error("audit log failed for switch_dev:", err),
     );

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -23,6 +23,7 @@ import {
   giftedSubscriptions,
 } from "../db/schema.js";
 
+import { readdir } from "node:fs/promises";
 import { adminResolve } from "../middleware/admin.js";
 import { disconnectUser, sendToUser } from "../ws/connections.js";
 import { Opcode } from "@uncorded/protocol";
@@ -722,6 +723,75 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     await logAudit(sessionUser.id, "close_poll", "poll", params.id);
 
     return { success: true };
+  })
+
+  // ── Dev Environment (Branch Switcher) ────────────────────────────────────
+  .get("/branches", async () => {
+    try {
+      const entries = await readdir("/app/worktrees", { withFileTypes: true });
+      const branches = entries.filter((e) => e.isDirectory()).map((e) => e.name).toSorted();
+      return { branches };
+    } catch {
+      return { branches: [] };
+    }
+  })
+
+  .get("/dev-status", async () => {
+    const stateFile = Bun.file("/app/dev-state/branch.json");
+    if (!(await stateFile.exists())) {
+      return { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
+    }
+    try {
+      const raw: unknown = await stateFile.json();
+      const schema = z.object({
+        branch: z.string(),
+        switchedAt: z.string().nullable(),
+        switchedBy: z.string().nullable(),
+        status: z.enum(["active", "pending"]),
+      });
+      const parsed = schema.safeParse(raw);
+      if (!parsed.success) {
+        return { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
+      }
+      return parsed.data;
+    } catch {
+      return { branch: "dev", switchedAt: null, switchedBy: null, status: "active" };
+    }
+  })
+
+  .post("/switch-dev", async ({ body, user: sessionUser }) => {
+    const switchSchema = z.object({ branch: z.string().min(1).max(200) });
+    const parsed = switchSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
+    }
+    const { branch } = parsed.data;
+
+    // Validate the branch exists as a worktree directory
+    try {
+      const entries = await readdir("/app/worktrees", { withFileTypes: true });
+      const exists = entries.some((e) => e.isDirectory() && e.name === branch);
+      if (!exists) throw new NotFoundError("Branch");
+    } catch (err) {
+      if (err instanceof NotFoundError) throw err;
+      throw new NotFoundError("Branch");
+    }
+
+    const state = {
+      branch,
+      switchedAt: new Date().toISOString(),
+      switchedBy: sessionUser.email ?? sessionUser.id,
+      status: "pending" as const,
+    };
+
+    await Bun.write("/app/dev-state/branch.json", JSON.stringify(state, null, 2));
+    await logAudit(sessionUser.id, "switch_dev", "dev_environment", branch);
+
+    return {
+      success: true,
+      branch,
+      message: "Branch marked for switch. Tell Git Manager to run the rebuild.",
+    };
   })
 
   // ── Audit Log ─────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
-# DEPRECATED: Use ../docker-compose.yml from the orchestrator root instead.
-# This file is kept for reference only.
+# Legacy single-repo compose — the authoritative file is C:\Projects\UnCorded-Dev\docker-compose.yml
+# (orchestrator root). Keep this copy in sync for reference when reviewing PRs.
 
 services:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
-# Legacy single-repo compose — the authoritative file is C:\Projects\UnCorded-Dev\docker-compose.yml
-# (orchestrator root). Keep this copy in sync for reference when reviewing PRs.
+# Legacy single-repo compose — the authoritative file is ../docker-compose.yml
+# (orchestrator root, one level above the repo). Keep in sync for PR reference.
 
 services:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
     env_file: .env
     environment:
       - REDIS_URL=redis://redis:6379
+    volumes:
+      - ./worktrees:/app/worktrees:ro
+      - ./docker/dev-state:/app/dev-state
     depends_on:
       redis:
         condition: service_healthy

--- a/docker/dev-state/branch.json
+++ b/docker/dev-state/branch.json
@@ -1,0 +1,6 @@
+{
+  "branch": "dev",
+  "switchedAt": null,
+  "switchedBy": null,
+  "status": "active"
+}


### PR DESCRIPTION
## Summary

- Adds branch switcher UI to the admin panel at `/dev` — shows current dev branch status and lets admins mark a different worktree for switching
- 3 new API endpoints: `GET /api/admin/branches` (lists worktrees), `GET /api/admin/dev-status` (reads state file), `POST /api/admin/switch-dev` (writes pending state + audit logs)
- Adds Docker volume mounts for `worktrees/` (read-only) and `docker/dev-state/` to the server service
- No shell execution — the API only reads directories and writes a JSON state file. Actual rebuild is triggered manually via Git Manager running `switch-dev.sh`

## Test plan

- [ ] Verify `GET /api/admin/branches` returns worktree folder names
- [ ] Verify `GET /api/admin/dev-status` returns default `dev/active` when no state file exists
- [ ] Verify `POST /api/admin/switch-dev` validates branch exists, writes `branch.json`, logs audit entry
- [ ] Verify admin panel `/dev` page loads, shows status card and branch selector
- [ ] Verify "Mark for Switch" button is disabled when selected branch matches current
- [ ] Verify pending rebuild warning banner appears after switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev Environment admin page: view current dev branch status, list available branches, mark a branch for switch, see pending-rebuild notices, and get success/error toasts with controls disabled while actions run.
  * Admin navigation updated so the Dev Environment page is reachable.

* **Chores**
  * Persisted dev-state added so branch status survives restarts and supports the branch-switch workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->