### PR TITLE
feat: Google & Discord OAuth UI

### DIFF
--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -27,8 +27,11 @@ const AccountSettings = () => {
   const [accountsLoading, setAccountsLoading] = createSignal(true);
   const [unlinking, setUnlinking] = createSignal<string | null>(null);
   const [connecting, setConnecting] = createSignal(false);
+  const [accountsFetchError, setAccountsFetchError] = createSignal(false);
 
   async function fetchLinkedAccounts() {
+    setAccountsFetchError(false);
+    setAccountsLoading(true);
     try {
       const result = await authClient.listAccounts();
       if (result.data) {
@@ -40,6 +43,7 @@ const AccountSettings = () => {
       }
     } catch (err) {
       if (import.meta.env.DEV) console.error("[settings] Failed to fetch accounts:", err);
+      setAccountsFetchError(true);
     } finally {
       setAccountsLoading(false);
     }
@@ -242,12 +246,20 @@ const AccountSettings = () => {
         <h3 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           Connected Accounts
         </h3>
+        {accountsFetchError() ? (
+          <div class="rounded-lg border border-border bg-card p-4 text-center">
+            <p class="text-sm text-muted-foreground">Failed to load connected accounts.</p>
+            <Button variant="outline" size="sm" class="mt-2" onClick={fetchLinkedAccounts}>
+              Retry
+            </Button>
+          </div>
+        ) : (
         <div class="space-y-2">
           <For
             each={
               [
-                { id: "discord", name: "Discord", bgClass: "bg-[#5865F2]", icon: DiscordIcon },
-                { id: "google", name: "Google", bgClass: "bg-white", icon: GoogleIcon },
+                { id: "discord", name: "Discord", bgClass: "bg-[#5865F2] text-white", icon: DiscordIcon },
+                { id: "google", name: "Google", bgClass: "bg-white text-foreground", icon: GoogleIcon },
               ] as const
             }
           >
@@ -307,6 +319,7 @@ const AccountSettings = () => {
             }}
           </For>
         </div>
+        )}
       </div>
 
       {/* Danger zone */}

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -1,8 +1,9 @@
-import { createSignal, onMount } from "solid-js";
+import { createSignal, For, onMount } from "solid-js";
 import { api, ApiRequestError } from "../../lib/api.js";
-import { signOut } from "../../lib/auth.js";
+import { authClient, signIn, signOut } from "../../lib/auth.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
+import { GoogleIcon, DiscordIcon } from "../ui/oauth-buttons.js";
 import {
   Dialog,
   DialogContent,
@@ -22,6 +23,26 @@ const AccountSettings = () => {
   const [showDeleteDialog, setShowDeleteDialog] = createSignal(false);
   const [deletePassword, setDeletePassword] = createSignal("");
   const [deleting, setDeleting] = createSignal(false);
+  const [linkedProviders, setLinkedProviders] = createSignal<Set<string>>(new Set());
+  const [accountsLoading, setAccountsLoading] = createSignal(true);
+  const [unlinking, setUnlinking] = createSignal<string | null>(null);
+
+  async function fetchLinkedAccounts() {
+    try {
+      const result = await authClient.listAccounts();
+      if (result.data) {
+        const providers = new Set<string>();
+        for (const account of result.data) {
+          providers.add(account.providerId);
+        }
+        setLinkedProviders(providers);
+      }
+    } catch (err) {
+      if (import.meta.env.DEV) console.error("[settings] Failed to fetch accounts:", err);
+    } finally {
+      setAccountsLoading(false);
+    }
+  }
 
   onMount(async () => {
     try {
@@ -32,6 +53,7 @@ const AccountSettings = () => {
     } finally {
       setEmailLoading(false);
     }
+    fetchLinkedAccounts();
   });
 
   async function handleChangePassword() {
@@ -71,6 +93,44 @@ const AccountSettings = () => {
       showToast(message, "error");
     } finally {
       setChangingPassword(false);
+    }
+  }
+
+  function totalAuthMethods(): number {
+    let count = linkedProviders().size;
+    // "credential" is counted in the set if the user has email/password
+    return count;
+  }
+
+  async function handleConnect(provider: "google" | "discord") {
+    try {
+      await signIn.social({ provider, callbackURL: "/settings" });
+    } catch {
+      showToast("Failed to connect account", "error");
+    }
+  }
+
+  async function handleDisconnect(providerId: string) {
+    if (totalAuthMethods() <= 1) {
+      showToast("Can't disconnect — this is your only sign-in method", "error");
+      return;
+    }
+
+    setUnlinking(providerId);
+    try {
+      const result = await authClient.unlinkAccount({ providerId });
+      if (result.error) {
+        showToast(result.error.message ?? "Failed to disconnect account", "error");
+      } else {
+        const updated = new Set(linkedProviders());
+        updated.delete(providerId);
+        setLinkedProviders(updated);
+        showToast("Account disconnected", "info");
+      }
+    } catch {
+      showToast("Failed to disconnect account", "error");
+    } finally {
+      setUnlinking(null);
     }
   }
 
@@ -179,48 +239,68 @@ const AccountSettings = () => {
           Connected Accounts
         </h3>
         <div class="space-y-2">
-          <div class="flex items-center justify-between rounded-lg border border-border bg-card p-3">
-            <div class="flex items-center gap-3">
-              <div class="flex h-8 w-8 items-center justify-center rounded-full bg-[#5865F2]">
-                <svg
-                  class="h-4 w-4 text-white"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z" />
-                </svg>
-              </div>
-              <span class="text-sm text-foreground">Discord</span>
-            </div>
-            <span class="text-xs text-muted-foreground">Coming soon</span>
-          </div>
-          <div class="flex items-center justify-between rounded-lg border border-border bg-card p-3">
-            <div class="flex items-center gap-3">
-              <div class="flex h-8 w-8 items-center justify-center rounded-full bg-white">
-                <svg class="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-              </div>
-              <span class="text-sm text-foreground">Google</span>
-            </div>
-            <span class="text-xs text-muted-foreground">Coming soon</span>
-          </div>
+          <For
+            each={
+              [
+                { id: "discord", name: "Discord", bgClass: "bg-[#5865F2]", icon: DiscordIcon },
+                { id: "google", name: "Google", bgClass: "bg-white", icon: GoogleIcon },
+              ] as const
+            }
+          >
+            {(provider) => {
+              const connected = () => linkedProviders().has(provider.id);
+              const isUnlinking = () => unlinking() === provider.id;
+              return (
+                <div class="flex items-center justify-between rounded-lg border border-border bg-card p-3">
+                  <div class="flex items-center gap-3">
+                    <div
+                      class={`flex h-8 w-8 items-center justify-center rounded-full ${provider.bgClass}`}
+                    >
+                      <provider.icon />
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <span class="text-sm text-foreground">{provider.name}</span>
+                      {connected() && (
+                        <span class="flex items-center gap-1 text-xs text-success-foreground">
+                          <svg
+                            class="h-3 w-3"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="3"
+                            aria-hidden="true"
+                          >
+                            <path d="M5 13l4 4L19 7" />
+                          </svg>
+                          Connected
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  {accountsLoading() ? (
+                    <span class="text-xs text-muted-foreground">Loading...</span>
+                  ) : connected() ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={isUnlinking()}
+                      onClick={() => handleDisconnect(provider.id)}
+                    >
+                      {isUnlinking() ? "Disconnecting..." : "Disconnect"}
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleConnect(provider.id)}
+                    >
+                      Connect
+                    </Button>
+                  )}
+                </div>
+              );
+            }}
+          </For>
         </div>
       </div>
 

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -114,6 +114,7 @@ const AccountSettings = () => {
   }
 
   async function handleDisconnect(providerId: string) {
+    if (unlinking()) return;
     if (totalAuthMethods() <= 1) {
       showToast("Can't disconnect — this is your only sign-in method", "error");
       return;
@@ -286,7 +287,7 @@ const AccountSettings = () => {
                     <Button
                       variant="ghost"
                       size="sm"
-                      disabled={isUnlinking()}
+                      disabled={!!unlinking()}
                       onClick={() => handleDisconnect(provider.id)}
                     >
                       {isUnlinking() ? "Disconnecting..." : "Disconnect"}

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -26,6 +26,7 @@ const AccountSettings = () => {
   const [linkedProviders, setLinkedProviders] = createSignal<Set<string>>(new Set());
   const [accountsLoading, setAccountsLoading] = createSignal(true);
   const [unlinking, setUnlinking] = createSignal<string | null>(null);
+  const [connecting, setConnecting] = createSignal(false);
 
   async function fetchLinkedAccounts() {
     try {
@@ -103,10 +104,12 @@ const AccountSettings = () => {
   }
 
   async function handleConnect(provider: "google" | "discord") {
+    setConnecting(true);
     try {
       await signIn.social({ provider, callbackURL: "/settings" });
     } catch {
       showToast("Failed to connect account", "error");
+      setConnecting(false);
     }
   }
 
@@ -292,9 +295,10 @@ const AccountSettings = () => {
                     <Button
                       variant="outline"
                       size="sm"
+                      disabled={connecting()}
                       onClick={() => handleConnect(provider.id)}
                     >
-                      Connect
+                      {connecting() ? "Connecting..." : "Connect"}
                     </Button>
                   )}
                 </div>

--- a/apps/web/src/components/ui/oauth-buttons.tsx
+++ b/apps/web/src/components/ui/oauth-buttons.tsx
@@ -65,6 +65,7 @@ export function GoogleButton(props: OAuthButtonProps) {
   );
 }
 
+// Discord brand guidelines require #5865F2 "blurple" background — raw colors intentional
 export function DiscordButton(props: OAuthButtonProps) {
   const [local, rest] = splitProps(props, ["onClick", "disabled", "label", "class"]);
   return (

--- a/apps/web/src/components/ui/oauth-buttons.tsx
+++ b/apps/web/src/components/ui/oauth-buttons.tsx
@@ -1,0 +1,95 @@
+import { type JSX, splitProps } from "solid-js";
+import { cn } from "../../lib/cn.js";
+
+type OAuthButtonProps = {
+  onClick: () => void;
+  disabled?: boolean;
+  label?: string;
+  class?: string;
+};
+
+const baseClass =
+  "relative flex w-full items-center justify-center gap-3 rounded-lg border px-4 h-10 text-sm font-medium transition-all duration-200 active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0";
+
+export function GoogleIcon(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
+  return (
+    <svg class="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+export function DiscordIcon(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      class="h-4 w-4 text-white"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z" />
+    </svg>
+  );
+}
+
+export function GoogleButton(props: OAuthButtonProps) {
+  const [local, rest] = splitProps(props, ["onClick", "disabled", "label", "class"]);
+  return (
+    <button
+      type="button"
+      class={cn(baseClass, "border-border bg-white text-gray-700 hover:bg-gray-50", local.class)}
+      onClick={local.onClick}
+      disabled={local.disabled}
+      {...rest}
+    >
+      <GoogleIcon />
+      {local.label ?? "Continue with Google"}
+    </button>
+  );
+}
+
+export function DiscordButton(props: OAuthButtonProps) {
+  const [local, rest] = splitProps(props, ["onClick", "disabled", "label", "class"]);
+  return (
+    <button
+      type="button"
+      class={cn(
+        baseClass,
+        "border-[#5865F2] bg-[#5865F2] text-white hover:bg-[#4752C4]",
+        local.class,
+      )}
+      onClick={local.onClick}
+      disabled={local.disabled}
+      {...rest}
+    >
+      <DiscordIcon />
+      {local.label ?? "Continue with Discord"}
+    </button>
+  );
+}
+
+export function OAuthDivider() {
+  return (
+    <div class="flex items-center gap-3">
+      <div class="h-px flex-1 bg-border" />
+      <span class="text-xs text-muted-foreground">or</span>
+      <div class="h-px flex-1 bg-border" />
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/oauth-buttons.tsx
+++ b/apps/web/src/components/ui/oauth-buttons.tsx
@@ -37,7 +37,7 @@ export function GoogleIcon(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
 export function DiscordIcon(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
   return (
     <svg
-      class="h-4 w-4 text-white"
+      class="h-4 w-4"
       viewBox="0 0 24 24"
       fill="currentColor"
       aria-hidden="true"

--- a/apps/web/src/components/ui/oauth-buttons.tsx
+++ b/apps/web/src/components/ui/oauth-buttons.tsx
@@ -48,6 +48,7 @@ export function DiscordIcon(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
   );
 }
 
+// Google brand guidelines require white bg with dark text — raw colors intentional
 export function GoogleButton(props: OAuthButtonProps) {
   const [local, rest] = splitProps(props, ["onClick", "disabled", "label", "class"]);
   return (

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { signIn } from "../lib/auth.js";
 import AuthLayout from "../components/AuthLayout.js";
 import { Input } from "../components/ui/input.js";
 import { Button } from "../components/ui/button.js";
+import { GoogleButton, DiscordButton, OAuthDivider } from "../components/ui/oauth-buttons.js";
 
 const Login = () => {
   const navigate = useNavigate();
@@ -11,6 +12,18 @@ const Login = () => {
   const [password, setPassword] = createSignal("");
   const [error, setError] = createSignal("");
   const [loading, setLoading] = createSignal(false);
+  const [oauthLoading, setOauthLoading] = createSignal(false);
+
+  const handleOAuth = async (provider: "google" | "discord") => {
+    setError("");
+    setOauthLoading(true);
+    try {
+      await signIn.social({ provider, callbackURL: "/home" });
+    } catch {
+      setError("Something went wrong");
+      setOauthLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: SubmitEvent) => {
     e.preventDefault();
@@ -48,6 +61,19 @@ const Login = () => {
           {error()}
         </div>
       </Show>
+
+      <div class="animate-fade-in space-y-3">
+        <GoogleButton
+          onClick={() => handleOAuth("google")}
+          disabled={oauthLoading() || loading()}
+        />
+        <DiscordButton
+          onClick={() => handleOAuth("discord")}
+          disabled={oauthLoading() || loading()}
+        />
+      </div>
+
+      <OAuthDivider />
 
       <form onSubmit={handleSubmit} class="animate-fade-in space-y-4">
         <div>

--- a/apps/web/src/pages/Register.tsx
+++ b/apps/web/src/pages/Register.tsx
@@ -1,10 +1,11 @@
 import { createSignal, Show } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
 import { USERNAME_MIN, USERNAME_MAX, PASSWORD_MIN } from "@uncorded/shared";
-import { signUp } from "../lib/auth.js";
+import { signIn, signUp } from "../lib/auth.js";
 import AuthLayout from "../components/AuthLayout.js";
 import { Input } from "../components/ui/input.js";
 import { Button } from "../components/ui/button.js";
+import { GoogleButton, DiscordButton, OAuthDivider } from "../components/ui/oauth-buttons.js";
 
 function calculateAge(dob: string): number {
   // Parse as local date to avoid UTC timezone shift (e.g., "2013-03-16" in UTC-5 becoming Mar 15)
@@ -28,6 +29,18 @@ const Register = () => {
   const [tosAgreed, setTosAgreed] = createSignal(false);
   const [error, setError] = createSignal("");
   const [loading, setLoading] = createSignal(false);
+  const [oauthLoading, setOauthLoading] = createSignal(false);
+
+  const handleOAuth = async (provider: "google" | "discord") => {
+    setError("");
+    setOauthLoading(true);
+    try {
+      await signIn.social({ provider, callbackURL: "/home" });
+    } catch {
+      setError("Something went wrong");
+      setOauthLoading(false);
+    }
+  };
 
   const now = new Date();
   const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -86,6 +99,19 @@ const Register = () => {
           {error()}
         </div>
       </Show>
+
+      <div class="animate-fade-in space-y-3">
+        <GoogleButton
+          onClick={() => handleOAuth("google")}
+          disabled={oauthLoading() || loading()}
+        />
+        <DiscordButton
+          onClick={() => handleOAuth("discord")}
+          disabled={oauthLoading() || loading()}
+        />
+      </div>
+
+      <OAuthDivider />
 
       <form onSubmit={handleSubmit} class="animate-fade-in space-y-4">
         <div>


### PR DESCRIPTION
## Summary
- Add Google and Discord social sign-in buttons to Login and Register pages, placed above the email/password form with an "or" divider
- Extract shared `GoogleButton`, `DiscordButton`, and `OAuthDivider` components into `oauth-buttons.tsx`
- Replace "Coming soon" placeholders in account settings with working connect/disconnect for linked OAuth providers
- Fetch linked accounts via `authClient.listAccounts()` on settings mount, show connected state with checkmark
- Prevent users from unlinking their only auth method with a toast warning

## Test plan
- [ ] Click "Continue with Google" on login page — redirects to Google consent, then back to `/home`
- [ ] Click "Continue with Discord" on register page — creates account via Discord OAuth
- [ ] Open account settings — linked providers show "Connected" badge with disconnect option
- [ ] Connect an unlinked provider from settings — redirects to provider, returns to `/settings` with provider now connected
- [ ] Disconnect a provider when multiple auth methods exist — succeeds with toast
- [ ] Attempt to disconnect the only auth method — blocked with "only sign-in method" toast
- [ ] Verify buttons disable while an OAuth flow is in progress
- [ ] Verify typecheck and lint pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google and Discord OAuth buttons and divider added to Login and Register.
  * Account Settings now list connected providers with icons and per-provider Connect/Disconnect controls.

* **Improvements**
  * Loading states, in-flight labels, and disabled controls for connect/disconnect and OAuth flows.
  * Toasted success/error feedback and protection against removing the last sign-in method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->