### PR TITLE
fix: OAuth link session loss + onboarding for OAuth signups

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ const ForgotPassword = lazy(() => import("./pages/ForgotPassword.js"));
 const ResetPassword = lazy(() => import("./pages/ResetPassword.js"));
 const Privacy = lazy(() => import("./pages/Privacy.js"));
 const Terms = lazy(() => import("./pages/Terms.js"));
+const Onboarding = lazy(() => import("./pages/Onboarding.js"));
 const Home = lazy(() => import("./pages/Home.js"));
 const Friends = lazy(() => import("./pages/Friends.js"));
 const Settings = lazy(() => import("./pages/Settings.js"));
@@ -26,6 +27,7 @@ const App = () => {
       <Route path="/reset-password" component={ResetPassword} />
       <Route path="/privacy" component={Privacy} />
       <Route path="/terms" component={Terms} />
+      <Route path="/onboarding" component={Onboarding} />
       <Route path="/home" component={AppLayout}>
         <Route path="/" component={Home} />
         <Route path="/friends" component={Friends} />

--- a/apps/web/src/components/AuthGuard.tsx
+++ b/apps/web/src/components/AuthGuard.tsx
@@ -19,6 +19,8 @@ const AuthGuard: ParentComponent = (props) => {
     // OAuth users without a username need onboarding
     if (!s.data.user.username && location.pathname !== "/onboarding") {
       navigate("/onboarding", { replace: true });
+    } else if (s.data.user.username && location.pathname === "/onboarding") {
+      navigate("/home", { replace: true });
     }
   });
 

--- a/apps/web/src/components/AuthGuard.tsx
+++ b/apps/web/src/components/AuthGuard.tsx
@@ -1,15 +1,24 @@
 import { createEffect, type ParentComponent } from "solid-js";
-import { useNavigate } from "@solidjs/router";
+import { useLocation, useNavigate } from "@solidjs/router";
 import { useSession } from "../lib/auth.js";
 
 const AuthGuard: ParentComponent = (props) => {
   const session = useSession();
   const navigate = useNavigate();
+  const location = useLocation();
 
   createEffect(() => {
     const s = session();
-    if (!s.isPending && !s.data) {
+    if (s.isPending) return;
+
+    if (!s.data) {
       navigate("/login", { replace: true });
+      return;
+    }
+
+    // OAuth users without a username need onboarding
+    if (!s.data.user.username && location.pathname !== "/onboarding") {
+      navigate("/onboarding", { replace: true });
     }
   });
 

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -56,8 +56,12 @@ const AccountSettings = () => {
       params.delete("linked");
       const clean = `${window.location.pathname}${params.size ? `?${params}` : ""}`;
       window.history.replaceState(null, "", clean);
-      // Force the auth client to re-read the session cookie
-      await authClient.getSession({ fetchOptions: { throw: false } });
+      // Force the auth client to re-read the session cookie (best-effort)
+      try {
+        await authClient.getSession({ fetchOptions: { throw: false } });
+      } catch {
+        if (import.meta.env.DEV) console.error("[settings] Session refresh after link failed");
+      }
     }
 
     try {

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -50,6 +50,16 @@ const AccountSettings = () => {
   }
 
   onMount(async () => {
+    // After OAuth link redirect, force session refresh and clean up URL
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("linked")) {
+      params.delete("linked");
+      const clean = `${window.location.pathname}${params.size ? `?${params}` : ""}`;
+      window.history.replaceState(null, "", clean);
+      // Force the auth client to re-read the session cookie
+      await authClient.getSession({ fetchOptions: { throw: false } });
+    }
+
     try {
       const me = await api<{ email: string }>("/api/users/@me");
       setEmail(me.email);
@@ -110,7 +120,7 @@ const AccountSettings = () => {
   async function handleConnect(provider: "google" | "discord") {
     setConnecting(true);
     try {
-      await signIn.social({ provider, callbackURL: `${window.location.origin}/settings` });
+      await signIn.social({ provider, callbackURL: `${window.location.origin}/home/settings?linked=1` });
     } catch {
       showToast("Failed to connect account", "error");
       setConnecting(false);

--- a/apps/web/src/components/settings/profile-settings.tsx
+++ b/apps/web/src/components/settings/profile-settings.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createEffect, Show, onCleanup } from "solid-js";
-import { MAX_AVATAR_SIZE_BYTES, ALLOWED_AVATAR_TYPES } from "@uncorded/shared";
+import { MAX_AVATAR_SIZE_BYTES, ALLOWED_AVATAR_TYPES, DISPLAY_NAME_MAX } from "@uncorded/shared";
 import { api, apiUpload, ApiRequestError } from "../../lib/api.js";
 import { readyData, updateCurrentUser } from "../../lib/gateway-store.js";
 import { showToast } from "../ui/toast.js";
@@ -263,7 +263,7 @@ const ProfileSettings = () => {
           type="text"
           value={displayName()}
           onInput={(e) => setDisplayName(e.currentTarget.value)}
-          maxLength={64}
+          maxLength={DISPLAY_NAME_MAX}
           placeholder="How others see you"
           class="block w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-ring"
         />

--- a/apps/web/src/components/settings/profile-settings.tsx
+++ b/apps/web/src/components/settings/profile-settings.tsx
@@ -1,11 +1,9 @@
 import { createSignal, createEffect, Show, onCleanup } from "solid-js";
-import { MAX_AVATAR_SIZE_BYTES, ALLOWED_AVATAR_TYPES, DISPLAY_NAME_MAX } from "@uncorded/shared";
+import { MAX_AVATAR_SIZE_BYTES, ALLOWED_AVATAR_TYPES, DISPLAY_NAME_MAX, USERNAME_REGEX } from "@uncorded/shared";
 import { api, apiUpload, ApiRequestError } from "../../lib/api.js";
 import { readyData, updateCurrentUser } from "../../lib/gateway-store.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
-
-const USERNAME_RE = /^[a-zA-Z0-9_]+$/;
 
 const ProfileSettings = () => {
   const user = () => readyData.data?.user;
@@ -39,7 +37,7 @@ const ProfileSettings = () => {
   function validateUsername(val: string): string {
     if (val.length < 2) return "Username must be at least 2 characters";
     if (val.length > 32) return "Username must be at most 32 characters";
-    if (!USERNAME_RE.test(val)) return "Only letters, numbers, and underscores";
+    if (!USERNAME_REGEX.test(val)) return "Only letters, numbers, and underscores";
     return "";
   }
 

--- a/apps/web/src/components/settings/profile-settings.tsx
+++ b/apps/web/src/components/settings/profile-settings.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createEffect, Show, onCleanup } from "solid-js";
-import { MAX_AVATAR_SIZE_BYTES, ALLOWED_AVATAR_TYPES, DISPLAY_NAME_MAX, USERNAME_REGEX } from "@uncorded/shared";
+import { MAX_AVATAR_SIZE_BYTES, ALLOWED_AVATAR_TYPES, DISPLAY_NAME_MAX, USERNAME_REGEX, USERNAME_MIN, USERNAME_MAX } from "@uncorded/shared";
 import { api, apiUpload, ApiRequestError } from "../../lib/api.js";
 import { readyData, updateCurrentUser } from "../../lib/gateway-store.js";
 import { showToast } from "../ui/toast.js";
@@ -35,8 +35,8 @@ const ProfileSettings = () => {
   });
 
   function validateUsername(val: string): string {
-    if (val.length < 2) return "Username must be at least 2 characters";
-    if (val.length > 32) return "Username must be at most 32 characters";
+    if (val.length < USERNAME_MIN) return `Username must be at least ${USERNAME_MIN} characters`;
+    if (val.length > USERNAME_MAX) return `Username must be at most ${USERNAME_MAX} characters`;
     if (!USERNAME_REGEX.test(val)) return "Only letters, numbers, and underscores";
     return "";
   }
@@ -243,7 +243,7 @@ const ProfileSettings = () => {
           type="text"
           value={username()}
           onInput={(e) => handleUsernameInput(e.currentTarget.value)}
-          maxLength={32}
+          maxLength={USERNAME_MAX}
           class="block w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-ring"
         />
         <Show when={usernameError()}>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -1,0 +1,119 @@
+import { createSignal, Show } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import { USERNAME_MIN, USERNAME_MAX } from "@uncorded/shared";
+import { authClient } from "../lib/auth.js";
+import { api, ApiRequestError } from "../lib/api.js";
+import AuthLayout from "../components/AuthLayout.js";
+import AuthGuard from "../components/AuthGuard.js";
+import { Input } from "../components/ui/input.js";
+import { Button } from "../components/ui/button.js";
+
+const Onboarding = () => {
+  const navigate = useNavigate();
+
+  const [username, setUsername] = createSignal("");
+  const [displayName, setDisplayName] = createSignal("");
+  const [error, setError] = createSignal("");
+  const [loading, setLoading] = createSignal(false);
+
+  const handleSubmit = async (e: SubmitEvent) => {
+    e.preventDefault();
+    setError("");
+
+    const trimmed = username().trim();
+    if (trimmed.length < USERNAME_MIN || trimmed.length > USERNAME_MAX) {
+      setError(`Username must be between ${USERNAME_MIN} and ${USERNAME_MAX} characters`);
+      return;
+    }
+    if (!/^[a-zA-Z0-9_]+$/.test(trimmed)) {
+      setError("Username can only contain letters, numbers, and underscores");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const body: Record<string, string> = { username: trimmed };
+      const dn = displayName().trim();
+      if (dn) body.displayName = dn;
+
+      await api("/api/users/@me", {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      });
+
+      // Refresh session so AuthGuard sees the username
+      await authClient.getSession({ fetchOptions: { throw: false } });
+      navigate("/home", { replace: true });
+    } catch (err) {
+      const message =
+        err instanceof ApiRequestError ? err.body.message : "Something went wrong";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthGuard>
+      <AuthLayout>
+        <h1 class="mb-2 text-center text-2xl font-bold text-foreground">
+          Welcome to UnCorded!
+        </h1>
+        <p class="mb-6 text-center text-sm text-secondary-foreground">
+          Let's set up your profile.
+        </p>
+
+        <Show when={error()}>
+          <div
+            role="alert"
+            class="mb-4 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error()}
+          </div>
+        </Show>
+
+        <form onSubmit={handleSubmit} class="animate-fade-in space-y-4">
+          <div>
+            <label
+              for="onboarding-username"
+              class="mb-1 block text-sm font-medium text-muted-foreground"
+            >
+              Username <span class="text-destructive">*</span>
+            </label>
+            <Input
+              id="onboarding-username"
+              type="text"
+              required
+              minLength={USERNAME_MIN}
+              maxLength={USERNAME_MAX}
+              value={username()}
+              onInput={(e) => setUsername(e.currentTarget.value)}
+              placeholder="your_username"
+            />
+          </div>
+          <div>
+            <label
+              for="onboarding-displayname"
+              class="mb-1 block text-sm font-medium text-muted-foreground"
+            >
+              Display Name <span class="text-xs text-muted-foreground">(optional)</span>
+            </label>
+            <Input
+              id="onboarding-displayname"
+              type="text"
+              maxLength={64}
+              value={displayName()}
+              onInput={(e) => setDisplayName(e.currentTarget.value)}
+              placeholder="How others see you"
+            />
+          </div>
+          <Button type="submit" disabled={loading()} size="lg" class="w-full">
+            {loading() ? "Setting up..." : "Continue"}
+          </Button>
+        </form>
+      </AuthLayout>
+    </AuthGuard>
+  );
+};
+
+export default Onboarding;

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -1,6 +1,6 @@
 import { createSignal, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
-import { USERNAME_MIN, USERNAME_MAX, DISPLAY_NAME_MAX } from "@uncorded/shared";
+import { USERNAME_MIN, USERNAME_MAX, USERNAME_REGEX, DISPLAY_NAME_MAX } from "@uncorded/shared";
 import { authClient } from "../lib/auth.js";
 import { api, ApiRequestError } from "../lib/api.js";
 import AuthLayout from "../components/AuthLayout.js";
@@ -25,7 +25,7 @@ const Onboarding = () => {
       setError(`Username must be between ${USERNAME_MIN} and ${USERNAME_MAX} characters`);
       return;
     }
-    if (!/^[a-zA-Z0-9_]+$/.test(trimmed)) {
+    if (!USERNAME_REGEX.test(trimmed)) {
       setError("Username can only contain letters, numbers, and underscores");
       return;
     }
@@ -50,7 +50,7 @@ const Onboarding = () => {
       navigate("/home", { replace: true });
     } catch (err) {
       const message =
-        err instanceof ApiRequestError ? err.body.message : "Something went wrong";
+        err instanceof ApiRequestError ? err.body.message ?? "Something went wrong" : "Something went wrong";
       setError(message);
     } finally {
       setLoading(false);

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -41,8 +41,12 @@ const Onboarding = () => {
         body: JSON.stringify(body),
       });
 
-      // Refresh session so AuthGuard sees the username
-      await authClient.getSession({ fetchOptions: { throw: false } });
+      // Refresh session so AuthGuard sees the username (best-effort)
+      try {
+        await authClient.getSession({ fetchOptions: { throw: false } });
+      } catch {
+        // Session will refresh on next navigation anyway
+      }
       navigate("/home", { replace: true });
     } catch (err) {
       const message =

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -18,6 +18,7 @@ const Onboarding = () => {
 
   const handleSubmit = async (e: SubmitEvent) => {
     e.preventDefault();
+    if (loading()) return;
     setError("");
 
     const trimmed = username().trim();

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -1,6 +1,6 @@
 import { createSignal, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
-import { USERNAME_MIN, USERNAME_MAX } from "@uncorded/shared";
+import { USERNAME_MIN, USERNAME_MAX, DISPLAY_NAME_MAX } from "@uncorded/shared";
 import { authClient } from "../lib/auth.js";
 import { api, ApiRequestError } from "../lib/api.js";
 import AuthLayout from "../components/AuthLayout.js";
@@ -105,7 +105,7 @@ const Onboarding = () => {
             <Input
               id="onboarding-displayname"
               type="text"
-              maxLength={64}
+              maxLength={DISPLAY_NAME_MAX}
               value={displayName()}
               onInput={(e) => setDisplayName(e.currentTarget.value)}
               placeholder="How others see you"

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const USERNAME_MIN = 2;
 export const USERNAME_MAX = 32;
+export const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
 export const DISPLAY_NAME_MAX = 64;
 export const PASSWORD_MIN = 8;
 
@@ -29,7 +30,7 @@ export const updateUserSchema = z.object({
     .trim()
     .min(USERNAME_MIN)
     .max(USERNAME_MAX)
-    .regex(/^[a-zA-Z0-9_]+$/, "Username can only contain letters, numbers, and underscores")
+    .regex(USERNAME_REGEX, "Username can only contain letters, numbers, and underscores")
     .optional(),
   displayName: z.string().trim().min(1).max(DISPLAY_NAME_MAX).nullable().optional(),
   status: userStatusSchema.optional(),

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const USERNAME_MIN = 2;
 export const USERNAME_MAX = 32;
+export const DISPLAY_NAME_MAX = 64;
 export const PASSWORD_MIN = 8;
 
 export const userStatusSchema = z.enum(["online", "idle", "dnd", "offline"]);
@@ -11,7 +12,7 @@ export type UserStatus = z.infer<typeof userStatusSchema>;
 export const userSchema = z.object({
   id: z.string(),
   username: z.string().trim().min(USERNAME_MIN).max(USERNAME_MAX),
-  displayName: z.string().trim().min(1).max(64).nullable(),
+  displayName: z.string().trim().min(1).max(DISPLAY_NAME_MAX).nullable(),
   email: z.string().email(),
   avatarUrl: z.string().url().nullable(),
   status: userStatusSchema,
@@ -30,7 +31,7 @@ export const updateUserSchema = z.object({
     .max(USERNAME_MAX)
     .regex(/^[a-zA-Z0-9_]+$/, "Username can only contain letters, numbers, and underscores")
     .optional(),
-  displayName: z.string().trim().min(1).max(64).nullable().optional(),
+  displayName: z.string().trim().min(1).max(DISPLAY_NAME_MAX).nullable().optional(),
   status: userStatusSchema.optional(),
 });
 


### PR DESCRIPTION
## Summary

- **OAuth link redirect session loss**: Account linking from settings redirected back with a dead session. Now includes `?linked=1` in the callbackURL and forces a session refresh on mount when detected.
- **OAuth signup missing onboarding**: Users signing up via Google/Discord landed on `/home` with no username. AuthGuard now redirects users without a username to a new `/onboarding` page where they set a username (required) and display name (optional) before continuing.

## Changes

- `account-settings.tsx` — Fixed callbackURL (`/home/settings?linked=1`), added session refresh on `?linked` detection
- `AuthGuard.tsx` — Added username check → redirect to `/onboarding`
- `Onboarding.tsx` — New page (AuthLayout, same validation as Register)
- `App.tsx` — Added `/onboarding` route

## Test plan

- [ ] Link Google/Discord from settings → verify redirect back keeps session alive
- [ ] Disconnect and re-link → same behavior
- [ ] Sign up with Google (new account) → should redirect to `/onboarding`
- [ ] Complete onboarding → should land on `/home` with username set
- [ ] Navigate to `/onboarding` with existing username → should redirect to `/home`
- [ ] Existing email/password signup flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lazily-loaded onboarding page and /onboarding route for new users to set username and display name; validates input, saves profile, refreshes session, and redirects to the main app.

* **Bug Fixes**
  * Improved auth guard routing to handle auth state and avoid navigation loops; ensures users without usernames are sent to onboarding and users with usernames are routed away.
  * OAuth linking now cleans up redirect URLs and performs a session refresh after social sign-in.

* **Chores**
  * Centralized username and display-name rules into shared constants and applied them in profile settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->