### PR TITLE
feat: admin delete user + self-deletion countdown

### DIFF
--- a/apps/admin/src/pages/Users.tsx
+++ b/apps/admin/src/pages/Users.tsx
@@ -48,6 +48,12 @@ const Users = () => {
     onConfirm: () => Promise<void>;
   } | null>(null);
 
+  // Delete modal state
+  const [deleteOpen, setDeleteOpen] = createSignal(false);
+  const [deleteTarget, setDeleteTarget] = createSignal<UserRow | null>(null);
+  const [deleteConfirmInput, setDeleteConfirmInput] = createSignal("");
+  const [deleteSubmitting, setDeleteSubmitting] = createSignal(false);
+
   let fetchRequestId = 0;
 
   async function fetchUsers(page: number, searchQuery?: string) {
@@ -161,6 +167,36 @@ const Users = () => {
     }
   }
 
+  // ── Delete actions ──────────────────────────────────
+
+  function confirmDelete(userRow: UserRow) {
+    setDeleteTarget(userRow);
+    setDeleteConfirmInput("");
+    setDeleteOpen(true);
+  }
+
+  async function handleDelete() {
+    const target = deleteTarget();
+    if (!target || deleteSubmitting() || actionInFlight()) return;
+    const expectedName = target.username ?? target.email;
+    if (deleteConfirmInput() !== expectedName) return;
+
+    setDeleteSubmitting(true);
+    setActionInFlight("delete");
+    try {
+      await api(`/api/admin/users/${target.id}`, { method: "DELETE" });
+      showToast("User deleted", "info");
+      setDeleteOpen(false);
+      await fetchUsers(data().page, search());
+    } catch (err) {
+      const msg = err instanceof ApiRequestError ? err.body.message : "Failed to delete user";
+      showToast(msg, "error");
+    } finally {
+      setDeleteSubmitting(false);
+      setActionInFlight(null);
+    }
+  }
+
   // ── Table columns ─────────────────────────────────
 
   const columns: Column<UserRow>[] = [
@@ -225,6 +261,14 @@ const Users = () => {
             onClick={() => confirmBan(row)}
           >
             {row.banned ? "Unban" : "Ban"}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="text-destructive"
+            onClick={() => confirmDelete(row)}
+          >
+            Delete
           </Button>
         </div>
       ),
@@ -365,6 +409,71 @@ const Users = () => {
               disabled={actionInFlight() !== null}
             >
               {actionInFlight() ? "Processing..." : "Confirm"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Delete User Modal ────────────────────── */}
+      <Dialog
+        open={deleteOpen()}
+        onOpenChange={(open) => {
+          if (!open) setDeleteConfirmInput("");
+          setDeleteOpen(open);
+        }}
+      >
+        <DialogContent
+          onClose={() => {
+            setDeleteConfirmInput("");
+            setDeleteOpen(false);
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Delete User</DialogTitle>
+            <DialogDescription>
+              This will permanently delete{" "}
+              <span class="font-semibold">{deleteTarget()?.username ?? deleteTarget()?.email}</span>'s
+              account and all associated data. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div class="space-y-3 py-2">
+            <div>
+              <label for="delete-confirm" class="mb-1.5 block text-sm font-medium text-foreground">
+                Type{" "}
+                <span class="font-mono text-destructive">
+                  {deleteTarget()?.username ?? deleteTarget()?.email}
+                </span>{" "}
+                to confirm
+              </label>
+              <Input
+                id="delete-confirm"
+                value={deleteConfirmInput()}
+                onInput={(e) => setDeleteConfirmInput(e.currentTarget.value)}
+                placeholder={deleteTarget()?.username ?? deleteTarget()?.email ?? ""}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setDeleteConfirmInput("");
+                setDeleteOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={
+                deleteSubmitting() ||
+                deleteConfirmInput() !== (deleteTarget()?.username ?? deleteTarget()?.email)
+              }
+            >
+              {deleteSubmitting() ? "Deleting..." : "Delete"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -386,7 +386,12 @@ export const userRoutes = new Elysia()
 
     return { success: true, pending: true, expiresAt: expiresAt.toISOString() };
   })
-  .post("/@me/cancel-deletion", async ({ user: sessionUser }) => {
+  .post("/@me/cancel-deletion", async ({ user: sessionUser, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 5, 900_000, "acct-del-cancel"))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
+
     const pending = pendingDeletions.get(sessionUser.id);
     if (!pending) {
       throw new ConflictError("NO_PENDING_DELETION", "No pending deletion to cancel");

--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -27,17 +27,17 @@ import { sendToUser, disconnectUser } from "../ws/connections.js";
 
 // ── Pending deletion state (in-memory, single-server) ──────────
 interface PendingDeletion {
-  timer: ReturnType<typeof setTimeout>;
+  timer: ReturnType<typeof setTimeout> | null;
   avatarUrl: string | null;
 }
 
 const pendingDeletions = new Map<string, PendingDeletion>();
 
 function executeDeletion(targetUserId: string, avatarUrl: string | null) {
-  pendingDeletions.delete(targetUserId);
   db.delete(user)
     .where(eq(user.id, targetUserId))
     .then(() => {
+      pendingDeletions.delete(targetUserId);
       disconnectUser(targetUserId);
       if (avatarUrl && isR2Configured()) {
         deleteAvatar(avatarUrl).catch((err) =>
@@ -47,6 +47,11 @@ function executeDeletion(targetUserId: string, avatarUrl: string | null) {
     })
     .catch((err) => {
       console.error("[deletion] Failed to delete user:", err);
+      pendingDeletions.delete(targetUserId);
+      sendToUser(targetUserId, {
+        op: Opcode.ACCOUNT_DELETION_CANCELLED,
+        d: null,
+      });
     });
 }
 
@@ -326,51 +331,62 @@ export const userRoutes = new Elysia()
       throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
     }
 
-    const [dbUser] = await db
-      .select({ avatarUrl: user.avatarUrl })
-      .from(user)
-      .where(eq(user.id, sessionUser.id))
-      .limit(1);
+    // Reserve the slot atomically before any awaits to prevent races
+    pendingDeletions.set(sessionUser.id, { timer: null, avatarUrl: null });
 
-    if (!dbUser) {
-      throw new NotFoundError("User");
-    }
-
-    // Verify password without creating a session
+    let dbUser: { avatarUrl: string | null };
     try {
-      const result = await auth.api.verifyPassword({
-        body: { password: parsed.data.password },
-        headers: request.headers,
-      });
-      if (!result.status) {
+      const [row] = await db
+        .select({ avatarUrl: user.avatarUrl })
+        .from(user)
+        .where(eq(user.id, sessionUser.id))
+        .limit(1);
+
+      if (!row) {
+        throw new NotFoundError("User");
+      }
+      dbUser = row;
+
+      // Verify password without creating a session
+      try {
+        const result = await auth.api.verifyPassword({
+          body: { password: parsed.data.password },
+          headers: request.headers,
+        });
+        if (!result.status) {
+          throw new UnauthorizedError("Incorrect password");
+        }
+      } catch (err) {
+        if (err instanceof UnauthorizedError) throw err;
+        const code = err instanceof Error && "code" in err ? (err as { code: string }).code : null;
+        if (code === "INVALID_PASSWORD") {
+          throw new UnauthorizedError("Incorrect password");
+        }
+        if (code === "CREDENTIAL_ACCOUNT_NOT_FOUND") {
+          throw new ValidationError("No password set — account uses OAuth only");
+        }
         throw new UnauthorizedError("Incorrect password");
+      }
+
+      // Check server ownership — servers have onDelete: "restrict"
+      const [ownedServer] = await db
+        .select({ id: servers.id })
+        .from(servers)
+        .where(eq(servers.ownerId, sessionUser.id))
+        .limit(1);
+
+      if (ownedServer) {
+        throw new AppError(
+          "ServerOwnerError",
+          409,
+          "SERVER_OWNER",
+          "You must transfer or delete all servers you own before deleting your account",
+        );
       }
     } catch (err) {
-      if (err instanceof UnauthorizedError) throw err;
-      const code = err instanceof Error && "code" in err ? (err as { code: string }).code : null;
-      if (code === "INVALID_PASSWORD") {
-        throw new UnauthorizedError("Incorrect password");
-      }
-      if (code === "CREDENTIAL_ACCOUNT_NOT_FOUND") {
-        throw new ValidationError("No password set — account uses OAuth only");
-      }
-      throw new UnauthorizedError("Incorrect password");
-    }
-
-    // Check server ownership — servers have onDelete: "restrict"
-    const [ownedServer] = await db
-      .select({ id: servers.id })
-      .from(servers)
-      .where(eq(servers.ownerId, sessionUser.id))
-      .limit(1);
-
-    if (ownedServer) {
-      throw new AppError(
-        "ServerOwnerError",
-        409,
-        "SERVER_OWNER",
-        "You must transfer or delete all servers you own before deleting your account",
-      );
+      // Validation failed — release the reservation
+      pendingDeletions.delete(sessionUser.id);
+      throw err;
     }
 
     // Schedule deletion with 10-second countdown
@@ -397,7 +413,7 @@ export const userRoutes = new Elysia()
       throw new ConflictError("NO_PENDING_DELETION", "No pending deletion to cancel");
     }
 
-    clearTimeout(pending.timer);
+    if (pending.timer !== null) clearTimeout(pending.timer);
     pendingDeletions.delete(sessionUser.id);
 
     sendToUser(sessionUser.id, {

--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -14,7 +14,7 @@ import {
   ALLOWED_AVATAR_TYPES,
   RATE_LIMIT_USER_SEARCH,
 } from "@uncorded/shared";
-import { userId } from "@uncorded/protocol";
+import { userId, Opcode } from "@uncorded/protocol";
 import { db } from "../db/index.js";
 import { user, servers } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
@@ -23,6 +23,32 @@ import { isR2Configured, uploadAvatar, deleteAvatar } from "../lib/r2.js";
 import { AppError } from "@uncorded/shared";
 import { checkIpRateLimit } from "../middleware/ip-rate-limit.js";
 import { checkUserRateLimit } from "../helpers/rate-limit.js";
+import { sendToUser, disconnectUser } from "../ws/connections.js";
+
+// ── Pending deletion state (in-memory, single-server) ──────────
+interface PendingDeletion {
+  timer: ReturnType<typeof setTimeout>;
+  avatarUrl: string | null;
+}
+
+const pendingDeletions = new Map<string, PendingDeletion>();
+
+function executeDeletion(targetUserId: string, avatarUrl: string | null) {
+  pendingDeletions.delete(targetUserId);
+  db.delete(user)
+    .where(eq(user.id, targetUserId))
+    .then(() => {
+      disconnectUser(targetUserId);
+      if (avatarUrl && isR2Configured()) {
+        deleteAvatar(avatarUrl).catch((err) =>
+          console.error("[r2] avatar cleanup on account delete failed:", err),
+        );
+      }
+    })
+    .catch((err) => {
+      console.error("[deletion] Failed to delete user:", err);
+    });
+}
 
 function getClientIp(request: Request): string {
   return (
@@ -290,6 +316,11 @@ export const userRoutes = new Elysia()
       throw new RateLimitError("Too many requests, try again later");
     }
 
+    // If there's already a pending deletion, reject
+    if (pendingDeletions.has(sessionUser.id)) {
+      throw new ConflictError("DELETION_PENDING", "Account deletion is already in progress");
+    }
+
     const parsed = deleteAccountSchema.safeParse(body);
     if (!parsed.success) {
       throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
@@ -342,15 +373,32 @@ export const userRoutes = new Elysia()
       );
     }
 
-    // Delete user first (cascades: sessions, accounts, memberships, dm_members, messages set null)
-    await db.delete(user).where(eq(user.id, sessionUser.id));
+    // Schedule deletion with 10-second countdown
+    const expiresAt = new Date(Date.now() + 10_000);
+    const timer = setTimeout(() => executeDeletion(sessionUser.id, dbUser.avatarUrl), 10_000);
+    pendingDeletions.set(sessionUser.id, { timer, avatarUrl: dbUser.avatarUrl });
 
-    // Clean up avatar from R2 after successful DB delete (fire-and-forget)
-    if (dbUser.avatarUrl && isR2Configured()) {
-      deleteAvatar(dbUser.avatarUrl).catch((err) =>
-        console.error("[r2] avatar cleanup on account delete failed:", err),
-      );
+    // Notify the user via WebSocket
+    sendToUser(sessionUser.id, {
+      op: Opcode.ACCOUNT_DELETION_PENDING,
+      d: { expiresAt: expiresAt.toISOString() },
+    });
+
+    return { success: true, pending: true, expiresAt: expiresAt.toISOString() };
+  })
+  .post("/@me/cancel-deletion", async ({ user: sessionUser }) => {
+    const pending = pendingDeletions.get(sessionUser.id);
+    if (!pending) {
+      throw new ConflictError("NO_PENDING_DELETION", "No pending deletion to cancel");
     }
+
+    clearTimeout(pending.timer);
+    pendingDeletions.delete(sessionUser.id);
+
+    sendToUser(sessionUser.id, {
+      op: Opcode.ACCOUNT_DELETION_CANCELLED,
+      d: null,
+    });
 
     return { success: true };
   }));

--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -14,7 +14,7 @@ import {
   ALLOWED_AVATAR_TYPES,
   RATE_LIMIT_USER_SEARCH,
 } from "@uncorded/shared";
-import { userId, Opcode } from "@uncorded/protocol";
+import { userId, Opcode, CloseCode } from "@uncorded/protocol";
 import { db } from "../db/index.js";
 import { user, servers } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
@@ -26,19 +26,29 @@ import { checkUserRateLimit } from "../helpers/rate-limit.js";
 import { sendToUser, disconnectUser } from "../ws/connections.js";
 
 // ── Pending deletion state (in-memory, single-server) ──────────
+type DeletionStatus = "reserved" | "pending" | "executing";
+
 interface PendingDeletion {
   timer: ReturnType<typeof setTimeout> | null;
   avatarUrl: string | null;
+  status: DeletionStatus;
 }
 
 const pendingDeletions = new Map<string, PendingDeletion>();
 
 function executeDeletion(targetUserId: string, avatarUrl: string | null) {
+  const entry = pendingDeletions.get(targetUserId);
+  if (!entry || entry.status === "reserved") {
+    // Entry removed by cancel handler or still reserving — abort
+    return;
+  }
+  entry.status = "executing";
+
   db.delete(user)
     .where(eq(user.id, targetUserId))
     .then(() => {
       pendingDeletions.delete(targetUserId);
-      disconnectUser(targetUserId);
+      disconnectUser(targetUserId, CloseCode.ACCOUNT_DELETED, "Account deleted");
       if (avatarUrl && isR2Configured()) {
         deleteAvatar(avatarUrl).catch((err) =>
           console.error("[r2] avatar cleanup on account delete failed:", err),
@@ -332,7 +342,7 @@ export const userRoutes = new Elysia()
     }
 
     // Reserve the slot atomically before any awaits to prevent races
-    pendingDeletions.set(sessionUser.id, { timer: null, avatarUrl: null });
+    pendingDeletions.set(sessionUser.id, { timer: null, avatarUrl: null, status: "reserved" });
 
     let dbUser: { avatarUrl: string | null };
     try {
@@ -376,9 +386,7 @@ export const userRoutes = new Elysia()
         .limit(1);
 
       if (ownedServer) {
-        throw new AppError(
-          "ServerOwnerError",
-          409,
+        throw new ConflictError(
           "SERVER_OWNER",
           "You must transfer or delete all servers you own before deleting your account",
         );
@@ -392,7 +400,7 @@ export const userRoutes = new Elysia()
     // Schedule deletion with 10-second countdown
     const expiresAt = new Date(Date.now() + 10_000);
     const timer = setTimeout(() => executeDeletion(sessionUser.id, dbUser.avatarUrl), 10_000);
-    pendingDeletions.set(sessionUser.id, { timer, avatarUrl: dbUser.avatarUrl });
+    pendingDeletions.set(sessionUser.id, { timer, avatarUrl: dbUser.avatarUrl, status: "pending" });
 
     // Notify the user via WebSocket
     sendToUser(sessionUser.id, {
@@ -411,6 +419,9 @@ export const userRoutes = new Elysia()
     const pending = pendingDeletions.get(sessionUser.id);
     if (!pending) {
       throw new ConflictError("NO_PENDING_DELETION", "No pending deletion to cancel");
+    }
+    if (pending.status === "executing") {
+      throw new ConflictError("DELETION_EXECUTING", "Deletion is already in progress and cannot be cancelled");
     }
 
     if (pending.timer !== null) clearTimeout(pending.timer);

--- a/apps/server/src/ws/connections.ts
+++ b/apps/server/src/ws/connections.ts
@@ -39,12 +39,16 @@ export function getConnections(userId: string): Set<AnyServerWebSocket> | undefi
 }
 
 /** Close all WS connections for a user, forcing reconnect with fresh context. */
-export function disconnectUser(targetUserId: string): void {
+export function disconnectUser(
+  targetUserId: string,
+  closeCode: CloseCode = CloseCode.SESSION_UPDATED,
+  reason = "Session updated",
+): void {
   const set = clients.get(targetUserId);
   if (!set) return;
   for (const ws of set) {
     try {
-      ws.close(CloseCode.SESSION_UPDATED, "Session updated");
+      ws.close(closeCode, reason);
     } catch {
       // Already closed — ignore
     }

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -22,6 +22,7 @@ import { Empty } from "./ui/empty.js";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "./ui/sidebar.js";
 import P2PNoticeDialog from "./P2PNoticeDialog.js";
 import GiftNotification from "./modals/GiftNotification.js";
+import DeletionCountdown from "./modals/DeletionCountdown.js";
 import { getP2pDialogOpen, confirmP2pDialog, cancelP2pDialog } from "../stores/file-store.js";
 
 const SETTINGS_PATHS = ["/home/server-settings", "/home/settings"];
@@ -49,6 +50,7 @@ const AppLayout: ParentComponent = (props) => {
       <ToastContainer />
       <ShortcutsDialog />
       <GiftNotification />
+      <DeletionCountdown />
       <P2PNoticeDialog
         open={getP2pDialogOpen()}
         onConfirm={confirmP2pDialog}

--- a/apps/web/src/components/modals/DeletionCountdown.tsx
+++ b/apps/web/src/components/modals/DeletionCountdown.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createEffect, onCleanup, Show } from "solid-js";
 import { deletionState, dismissDeletion } from "../../stores/deletion-store.js";
+import { gatewayStatus } from "../../lib/gateway-store.js";
 import { api, ApiRequestError } from "../../lib/api.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
@@ -17,9 +18,11 @@ const DeletionCountdown = () => {
   const [secondsLeft, setSecondsLeft] = createSignal(COUNTDOWN_SECONDS);
   const [cancelling, setCancelling] = createSignal(false);
   const [deleted, setDeleted] = createSignal(false);
+  const [expired, setExpired] = createSignal(false);
 
   let countdownInterval: ReturnType<typeof setInterval> | undefined;
 
+  // Start/stop the visual countdown based on store state
   createEffect(() => {
     const state = deletionState();
     if (state.show && state.expiresAt) {
@@ -29,6 +32,7 @@ const DeletionCountdown = () => {
       );
       setSecondsLeft(remaining);
       setDeleted(false);
+      setExpired(false);
 
       if (countdownInterval !== undefined) clearInterval(countdownInterval);
       countdownInterval = setInterval(() => {
@@ -36,10 +40,7 @@ const DeletionCountdown = () => {
           if (prev <= 1) {
             if (countdownInterval !== undefined) clearInterval(countdownInterval);
             countdownInterval = undefined;
-            setDeleted(true);
-            setTimeout(() => {
-              window.location.href = "/";
-            }, 2000);
+            setExpired(true);
             return 0;
           }
           return prev - 1;
@@ -50,6 +51,18 @@ const DeletionCountdown = () => {
         clearInterval(countdownInterval);
         countdownInterval = undefined;
       }
+      setExpired(false);
+    }
+  });
+
+  // Server-driven confirmation: when WS disconnects after countdown expired,
+  // the server has successfully deleted the account and called disconnectUser()
+  createEffect(() => {
+    if (expired() && deletionState().show && gatewayStatus() === "disconnected") {
+      setDeleted(true);
+      setTimeout(() => {
+        window.location.href = "/";
+      }, 2000);
     }
   });
 
@@ -107,30 +120,44 @@ const DeletionCountdown = () => {
 
           {/* Large countdown number */}
           <div class="my-8 text-center">
-            <span class="text-7xl font-bold tabular-nums text-destructive">
-              {secondsLeft()}
-            </span>
+            <Show
+              when={!expired()}
+              fallback={
+                <div class="flex flex-col items-center gap-2">
+                  <div class="h-8 w-8 animate-spin rounded-full border-2 border-destructive border-t-transparent" />
+                  <span class="text-sm text-muted-foreground">Deleting...</span>
+                </div>
+              }
+            >
+              <span class="text-7xl font-bold tabular-nums text-destructive">
+                {secondsLeft()}
+              </span>
+            </Show>
           </div>
 
           {/* Progress bar */}
-          <div class="mb-6 h-2 w-full overflow-hidden rounded-full bg-muted">
-            <div
-              class="h-full rounded-full bg-destructive transition-all duration-1000 ease-linear"
-              style={{ width: `${progress()}%` }}
-            />
-          </div>
+          <Show when={!expired()}>
+            <div class="mb-6 h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                class="h-full rounded-full bg-destructive transition-all duration-1000 ease-linear"
+                style={{ width: `${progress()}%` }}
+              />
+            </div>
+          </Show>
 
           {/* Cancel button — prominent, large, autofocused by DialogContent */}
-          <div class="flex justify-center">
-            <Button
-              size="lg"
-              onClick={handleCancel}
-              disabled={cancelling()}
-              class="w-full text-base"
-            >
-              {cancelling() ? "Cancelling..." : "Cancel Deletion"}
-            </Button>
-          </div>
+          <Show when={!expired()}>
+            <div class="flex justify-center">
+              <Button
+                size="lg"
+                onClick={handleCancel}
+                disabled={cancelling()}
+                class="w-full text-base"
+              >
+                {cancelling() ? "Cancelling..." : "Cancel Deletion"}
+              </Button>
+            </div>
+          </Show>
         </Show>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/modals/DeletionCountdown.tsx
+++ b/apps/web/src/components/modals/DeletionCountdown.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createEffect, onCleanup, Show } from "solid-js";
 import { deletionState, dismissDeletion } from "../../stores/deletion-store.js";
-import { gatewayStatus } from "../../lib/gateway-store.js";
+import { lastCloseCode } from "../../lib/gateway-store.js";
+import { CloseCode } from "@uncorded/protocol";
 import { api, ApiRequestError } from "../../lib/api.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
@@ -55,10 +56,10 @@ const DeletionCountdown = () => {
     }
   });
 
-  // Server-driven confirmation: when WS disconnects after countdown expired,
-  // the server has successfully deleted the account and called disconnectUser()
+  // Server-driven confirmation: when the server closes the WS with ACCOUNT_DELETED
+  // close code, it means db.delete() succeeded and disconnectUser() was called
   createEffect(() => {
-    if (expired() && deletionState().show && gatewayStatus() === "disconnected") {
+    if (expired() && deletionState().show && lastCloseCode() === CloseCode.ACCOUNT_DELETED) {
       setDeleted(true);
       setTimeout(() => {
         window.location.href = "/";

--- a/apps/web/src/components/modals/DeletionCountdown.tsx
+++ b/apps/web/src/components/modals/DeletionCountdown.tsx
@@ -3,6 +3,13 @@ import { deletionState, dismissDeletion } from "../../stores/deletion-store.js";
 import { api, ApiRequestError } from "../../lib/api.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "../ui/dialog.js";
 
 const COUNTDOWN_SECONDS = 10;
 
@@ -16,7 +23,6 @@ const DeletionCountdown = () => {
   createEffect(() => {
     const state = deletionState();
     if (state.show && state.expiresAt) {
-      // Calculate remaining seconds from server's expiresAt
       const remaining = Math.max(
         0,
         Math.ceil((new Date(state.expiresAt).getTime() - Date.now()) / 1000),
@@ -74,56 +80,60 @@ const DeletionCountdown = () => {
   const progress = () => (secondsLeft() / COUNTDOWN_SECONDS) * 100;
 
   return (
-    <Show when={deletionState().show}>
-      <div class="fixed inset-0 z-[100] flex items-center justify-center bg-background/80 backdrop-blur-sm">
-        <div class="mx-4 w-full max-w-md rounded-xl border border-destructive/30 bg-card p-8 shadow-2xl">
-          <Show
-            when={!deleted()}
-            fallback={
-              <div class="text-center">
-                <p class="text-2xl font-bold text-destructive">Account Deleted</p>
-                <p class="mt-2 text-sm text-muted-foreground">Redirecting...</p>
-              </div>
-            }
-          >
-            <h2 class="text-center text-lg font-semibold text-foreground">
+    <Dialog
+      open={deletionState().show}
+      onOpenChange={() => {
+        /* prevent Escape from closing — user must cancel or wait */
+      }}
+    >
+      <DialogContent class="border-destructive/30">
+        <Show
+          when={!deleted()}
+          fallback={
+            <div class="text-center py-4">
+              <p class="text-2xl font-bold text-destructive">Account Deleted</p>
+              <p class="mt-2 text-sm text-muted-foreground">Redirecting...</p>
+            </div>
+          }
+        >
+          <DialogHeader>
+            <DialogTitle class="text-center">
               Account Deletion in Progress
-            </h2>
-
-            {/* Large countdown number */}
-            <div class="my-8 text-center">
-              <span class="text-7xl font-bold tabular-nums text-destructive">
-                {secondsLeft()}
-              </span>
-            </div>
-
-            {/* Progress bar */}
-            <div class="mb-6 h-2 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                class="h-full rounded-full bg-destructive transition-all duration-1000 ease-linear"
-                style={{ width: `${progress()}%` }}
-              />
-            </div>
-
-            <p class="mb-8 text-center text-sm text-muted-foreground">
+            </DialogTitle>
+            <DialogDescription class="text-center">
               Your account will be permanently deleted. All your data will be removed.
-            </p>
+            </DialogDescription>
+          </DialogHeader>
 
-            {/* Cancel button — prominent, large */}
-            <div class="flex justify-center">
-              <Button
-                size="lg"
-                onClick={handleCancel}
-                disabled={cancelling()}
-                class="w-full text-base"
-              >
-                {cancelling() ? "Cancelling..." : "Cancel Deletion"}
-              </Button>
-            </div>
-          </Show>
-        </div>
-      </div>
-    </Show>
+          {/* Large countdown number */}
+          <div class="my-8 text-center">
+            <span class="text-7xl font-bold tabular-nums text-destructive">
+              {secondsLeft()}
+            </span>
+          </div>
+
+          {/* Progress bar */}
+          <div class="mb-6 h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              class="h-full rounded-full bg-destructive transition-all duration-1000 ease-linear"
+              style={{ width: `${progress()}%` }}
+            />
+          </div>
+
+          {/* Cancel button — prominent, large, autofocused by DialogContent */}
+          <div class="flex justify-center">
+            <Button
+              size="lg"
+              onClick={handleCancel}
+              disabled={cancelling()}
+              class="w-full text-base"
+            >
+              {cancelling() ? "Cancelling..." : "Cancel Deletion"}
+            </Button>
+          </div>
+        </Show>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/apps/web/src/components/modals/DeletionCountdown.tsx
+++ b/apps/web/src/components/modals/DeletionCountdown.tsx
@@ -1,0 +1,130 @@
+import { createSignal, createEffect, onCleanup, Show } from "solid-js";
+import { deletionState, dismissDeletion } from "../../stores/deletion-store.js";
+import { api, ApiRequestError } from "../../lib/api.js";
+import { showToast } from "../ui/toast.js";
+import { Button } from "../ui/button.js";
+
+const COUNTDOWN_SECONDS = 10;
+
+const DeletionCountdown = () => {
+  const [secondsLeft, setSecondsLeft] = createSignal(COUNTDOWN_SECONDS);
+  const [cancelling, setCancelling] = createSignal(false);
+  const [deleted, setDeleted] = createSignal(false);
+
+  let countdownInterval: ReturnType<typeof setInterval> | undefined;
+
+  createEffect(() => {
+    const state = deletionState();
+    if (state.show && state.expiresAt) {
+      // Calculate remaining seconds from server's expiresAt
+      const remaining = Math.max(
+        0,
+        Math.ceil((new Date(state.expiresAt).getTime() - Date.now()) / 1000),
+      );
+      setSecondsLeft(remaining);
+      setDeleted(false);
+
+      if (countdownInterval !== undefined) clearInterval(countdownInterval);
+      countdownInterval = setInterval(() => {
+        setSecondsLeft((prev) => {
+          if (prev <= 1) {
+            if (countdownInterval !== undefined) clearInterval(countdownInterval);
+            countdownInterval = undefined;
+            setDeleted(true);
+            setTimeout(() => {
+              window.location.href = "/";
+            }, 2000);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    } else {
+      if (countdownInterval !== undefined) {
+        clearInterval(countdownInterval);
+        countdownInterval = undefined;
+      }
+    }
+  });
+
+  onCleanup(() => {
+    if (countdownInterval !== undefined) clearInterval(countdownInterval);
+  });
+
+  async function handleCancel() {
+    if (cancelling()) return;
+    setCancelling(true);
+    try {
+      await api("/api/users/@me/cancel-deletion", { method: "POST" });
+      if (countdownInterval !== undefined) {
+        clearInterval(countdownInterval);
+        countdownInterval = undefined;
+      }
+      dismissDeletion();
+      showToast("Account deletion cancelled", "info");
+    } catch (err) {
+      const msg =
+        err instanceof ApiRequestError ? err.body.message : "Failed to cancel deletion";
+      showToast(msg, "error");
+    } finally {
+      setCancelling(false);
+    }
+  }
+
+  const progress = () => (secondsLeft() / COUNTDOWN_SECONDS) * 100;
+
+  return (
+    <Show when={deletionState().show}>
+      <div class="fixed inset-0 z-[100] flex items-center justify-center bg-background/80 backdrop-blur-sm">
+        <div class="mx-4 w-full max-w-md rounded-xl border border-destructive/30 bg-card p-8 shadow-2xl">
+          <Show
+            when={!deleted()}
+            fallback={
+              <div class="text-center">
+                <p class="text-2xl font-bold text-destructive">Account Deleted</p>
+                <p class="mt-2 text-sm text-muted-foreground">Redirecting...</p>
+              </div>
+            }
+          >
+            <h2 class="text-center text-lg font-semibold text-foreground">
+              Account Deletion in Progress
+            </h2>
+
+            {/* Large countdown number */}
+            <div class="my-8 text-center">
+              <span class="text-7xl font-bold tabular-nums text-destructive">
+                {secondsLeft()}
+              </span>
+            </div>
+
+            {/* Progress bar */}
+            <div class="mb-6 h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                class="h-full rounded-full bg-destructive transition-all duration-1000 ease-linear"
+                style={{ width: `${progress()}%` }}
+              />
+            </div>
+
+            <p class="mb-8 text-center text-sm text-muted-foreground">
+              Your account will be permanently deleted. All your data will be removed.
+            </p>
+
+            {/* Cancel button — prominent, large */}
+            <div class="flex justify-center">
+              <Button
+                size="lg"
+                onClick={handleCancel}
+                disabled={cancelling()}
+                class="w-full text-base"
+              >
+                {cancelling() ? "Cancelling..." : "Cancel Deletion"}
+              </Button>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default DeletionCountdown;

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -1,6 +1,6 @@
 import { createSignal, For, onMount } from "solid-js";
 import { api, ApiRequestError } from "../../lib/api.js";
-import { authClient, signIn, signOut } from "../../lib/auth.js";
+import { authClient, signIn } from "../../lib/auth.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
 import { GoogleIcon, DiscordIcon } from "../ui/oauth-buttons.js";
@@ -178,13 +178,10 @@ const AccountSettings = () => {
       return;
     }
 
-    // Account deleted — sign out and redirect (ignore errors, redirect clears session)
-    try {
-      await signOut();
-    } catch {
-      // Session cleanup is best-effort
-    }
-    window.location.href = "/";
+    // Close dialog — the server sends a WS frame that triggers the DeletionCountdown modal
+    setDeletePassword("");
+    setShowDeleteDialog(false);
+    setDeleting(false);
   }
 
   return (

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -4,6 +4,7 @@ import { authClient, signIn } from "../../lib/auth.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
 import { GoogleIcon, DiscordIcon } from "../ui/oauth-buttons.js";
+import { showPendingDeletion } from "../../stores/deletion-store.js";
 import {
   Dialog,
   DialogContent,
@@ -165,11 +166,16 @@ const AccountSettings = () => {
     }
 
     setDeleting(true);
+    let expiresAt: string | undefined;
     try {
-      await api("/api/users/@me", {
-        method: "DELETE",
-        body: JSON.stringify({ password: deletePassword() }),
-      });
+      const res = await api<{ success: boolean; pending?: boolean; expiresAt?: string }>(
+        "/api/users/@me",
+        {
+          method: "DELETE",
+          body: JSON.stringify({ password: deletePassword() }),
+        },
+      );
+      expiresAt = res.expiresAt;
     } catch (err) {
       const message =
         err instanceof ApiRequestError ? err.body.message : "Failed to delete account";
@@ -178,7 +184,10 @@ const AccountSettings = () => {
       return;
     }
 
-    // Close dialog — the server sends a WS frame that triggers the DeletionCountdown modal
+    // Show countdown immediately from REST response (WS frame reconciles later)
+    if (expiresAt) {
+      showPendingDeletion(expiresAt);
+    }
     setDeletePassword("");
     setShowDeleteDialog(false);
     setDeleting(false);

--- a/apps/web/src/lib/gateway-store.ts
+++ b/apps/web/src/lib/gateway-store.ts
@@ -61,6 +61,7 @@ export interface ReadyData {
 }
 
 const [gatewayStatus, setGatewayStatus] = createSignal<GatewayStatus>("disconnected");
+const [lastCloseCode, setLastCloseCode] = createSignal<number | null>(null);
 const [readyData, setReadyData] = createStore<{ data: ReadyData | null }>({ data: null });
 
 // Separate channel cache — channels are fetched lazily per server
@@ -203,4 +204,6 @@ export {
   updateFriendStatus,
   updatePresence,
   updateCurrentUser,
+  lastCloseCode,
+  setLastCloseCode,
 };

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -5,6 +5,7 @@ import {
   setGatewayStatus,
   setReadyPayload,
   clearReadyPayload,
+  setLastCloseCode,
   type ReadyData,
 } from "./gateway-store.js";
 import { setupStores } from "../stores/index.js";
@@ -147,12 +148,19 @@ function handleClose(event: CloseEvent) {
 
   clearTimers();
   setGatewayStatus("disconnected");
+  setLastCloseCode(event.code);
   ws = null;
 
   if (intentionalClose) return;
 
   // Auth failures — reconnecting won't help
   if (event.code === CloseCode.MISSING_TOKEN || event.code === CloseCode.INVALID_SESSION) {
+    clearReadyPayload();
+    return;
+  }
+
+  // Account deleted — reconnecting won't help
+  if (event.code === CloseCode.ACCOUNT_DELETED) {
     clearReadyPayload();
     return;
   }

--- a/apps/web/src/stores/deletion-store.ts
+++ b/apps/web/src/stores/deletion-store.ts
@@ -18,10 +18,21 @@ export function dismissDeletion() {
   setDeletionState({ show: false, expiresAt: null });
 }
 
+function isValidDateString(value: string): boolean {
+  const d = new Date(value);
+  return !Number.isNaN(d.getTime());
+}
+
+export function showPendingDeletion(expiresAt: string) {
+  if (!isValidDateString(expiresAt)) return;
+  setDeletionState({ show: true, expiresAt });
+}
+
 export function setupDeletionStore() {
   onGatewayEvent(Opcode.ACCOUNT_DELETION_PENDING, (data) => {
     const d = data as Record<string, unknown>;
     const expiresAt = typeof d.expiresAt === "string" ? d.expiresAt : null;
+    if (!expiresAt || !isValidDateString(expiresAt)) return;
 
     setDeletionState({ show: true, expiresAt });
   });

--- a/apps/web/src/stores/deletion-store.ts
+++ b/apps/web/src/stores/deletion-store.ts
@@ -1,0 +1,32 @@
+import { createSignal } from "solid-js";
+import { Opcode } from "@uncorded/protocol";
+import { onGatewayEvent } from "../lib/gateway.js";
+
+interface DeletionState {
+  show: boolean;
+  expiresAt: string | null;
+}
+
+const [deletionState, setDeletionState] = createSignal<DeletionState>({
+  show: false,
+  expiresAt: null,
+});
+
+export { deletionState };
+
+export function dismissDeletion() {
+  setDeletionState({ show: false, expiresAt: null });
+}
+
+export function setupDeletionStore() {
+  onGatewayEvent(Opcode.ACCOUNT_DELETION_PENDING, (data) => {
+    const d = data as Record<string, unknown>;
+    const expiresAt = typeof d.expiresAt === "string" ? d.expiresAt : null;
+
+    setDeletionState({ show: true, expiresAt });
+  });
+
+  onGatewayEvent(Opcode.ACCOUNT_DELETION_CANCELLED, () => {
+    setDeletionState({ show: false, expiresAt: null });
+  });
+}

--- a/apps/web/src/stores/index.ts
+++ b/apps/web/src/stores/index.ts
@@ -6,6 +6,7 @@ import { setupMemberStore } from "./member-store.js";
 import { setupPresenceStore } from "./presence-store.js";
 import { setupNotificationStore } from "./notification-store.js";
 import { setupGiftStore } from "./gift-store.js";
+import { setupDeletionStore } from "./deletion-store.js";
 
 export {
   setupMessageStore,
@@ -16,6 +17,7 @@ export {
   setupPresenceStore,
   setupNotificationStore,
   setupGiftStore,
+  setupDeletionStore,
 };
 
 export function setupStores() {
@@ -27,4 +29,5 @@ export function setupStores() {
   setupPresenceStore();
   setupNotificationStore();
   setupGiftStore();
+  setupDeletionStore();
 }

--- a/packages/protocol/src/close-codes.ts
+++ b/packages/protocol/src/close-codes.ts
@@ -15,4 +15,6 @@ export enum CloseCode {
   HEARTBEAT_TIMEOUT = 4007,
   /** Server-side session/context changed — client should reconnect to refresh */
   SESSION_UPDATED = 4010,
+  /** Account was permanently deleted — client should not reconnect */
+  ACCOUNT_DELETED = 4011,
 }

--- a/packages/protocol/src/opcodes.ts
+++ b/packages/protocol/src/opcodes.ts
@@ -65,6 +65,11 @@ export enum Opcode {
   /** Server -> Client: subscription tier was gifted */
   SUBSCRIPTION_GIFT = 85,
 
+  /** Server -> Client: account deletion countdown started */
+  ACCOUNT_DELETION_PENDING = 90,
+  /** Server -> Client: account deletion was cancelled */
+  ACCOUNT_DELETION_CANCELLED = 91,
+
   /** Server -> Client: error notification (e.g., tier restriction) */
   ERROR = 99,
 }


### PR DESCRIPTION
## Summary

- **Admin panel**: Added Delete button to Users page with username-typing confirmation dialog. Calls existing `DELETE /api/admin/users/:id` endpoint (immediate, no countdown).
- **Self-deletion countdown**: `DELETE /api/users/@me` now schedules a 10-second pending deletion instead of immediately deleting. Server sends `ACCOUNT_DELETION_PENDING` WebSocket frame; user sees a full-screen countdown modal with a prominent "Cancel Deletion" button.
- **Cancel endpoint**: New `POST /api/users/@me/cancel-deletion` cancels the pending deletion and sends `ACCOUNT_DELETION_CANCELLED` WS frame.
- **New opcodes**: `ACCOUNT_DELETION_PENDING` (90) and `ACCOUNT_DELETION_CANCELLED` (91) in the protocol package.

## Files changed

| Area | File | Change |
|------|------|--------|
| Protocol | `packages/protocol/src/opcodes.ts` | +2 opcodes |
| Admin | `apps/admin/src/pages/Users.tsx` | Delete button + confirmation dialog |
| Server | `apps/server/src/routes/user.ts` | Pending deletion logic, cancel endpoint |
| Web | `apps/web/src/stores/deletion-store.ts` | New store for WS listeners |
| Web | `apps/web/src/components/modals/DeletionCountdown.tsx` | New countdown modal |
| Web | `apps/web/src/components/AppLayout.tsx` | Wire up modal |
| Web | `apps/web/src/stores/index.ts` | Register deletion store |
| Web | `apps/web/src/components/settings/account-settings.tsx` | Delegate to countdown modal |

## Design decisions

- **In-memory Map** for pending deletions (vs Redis) — simpler, sufficient for single-server deployment
- **Server-authoritative deletion** — client countdown is purely visual; the server's `setTimeout` controls actual deletion
- **Admin delete remains immediate** — no countdown for intentional admin actions

## Test plan

- [ ] Admin panel: click Delete on a user → confirm dialog appears, requires typing username
- [ ] Admin panel: type wrong username → Delete button stays disabled
- [ ] Admin panel: type correct username → deletion succeeds, user removed from list
- [ ] Admin panel: delete user who owns servers → error toast about server ownership
- [ ] Self-delete: enter password → dialog closes, countdown modal appears with 10s timer
- [ ] Self-delete: click "Cancel Deletion" during countdown → modal dismisses, toast confirms cancellation
- [ ] Self-delete: let countdown expire → "Account Deleted" message, redirect to `/`
- [ ] Self-delete: double-tap delete → second request returns conflict error
- [ ] Cancel with no pending deletion → error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account deletion now defers completion for a short grace period with a visible 10s countdown, live notification, and ability to cancel the pending deletion.

* **Admin**
  * Admins can delete users via a confirmation dialog requiring typed confirmation (username or email) before deletion.

* **UI Improvements**
  * Clear toasts, progress UI, and automatic redirect/disconnect flow after deletion or cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->