### PR TITLE
feat: redesign DM file sharing with P2P share sessions

### DIFF
--- a/apps/server/drizzle/0013_file_session_receipts.sql
+++ b/apps/server/drizzle/0013_file_session_receipts.sql
@@ -1,0 +1,16 @@
+-- Add receiver_id for DM P2P share sessions (sender→receiver without a channel)
+ALTER TABLE "file_receipts" ADD COLUMN "receiver_id" text REFERENCES "user"("id") ON DELETE SET NULL;--> statement-breakpoint
+
+-- Make channel_id nullable (DM shares don't have a channel)
+ALTER TABLE "file_receipts" ALTER COLUMN "channel_id" DROP NOT NULL;--> statement-breakpoint
+
+-- Make magnet_uri and info_hash nullable (receipt history doesn't need them long-term)
+ALTER TABLE "file_receipts" ALTER COLUMN "magnet_uri" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "file_receipts" ALTER COLUMN "info_hash" DROP NOT NULL;--> statement-breakpoint
+
+-- Drop the unique constraint on message_id (DM shares don't create messages)
+ALTER TABLE "file_receipts" DROP CONSTRAINT IF EXISTS "uq_file_receipts_message_id";--> statement-breakpoint
+
+-- Add indexes for receipt queries by sender/receiver
+CREATE INDEX "idx_file_receipts_sender_id" ON "file_receipts" ("sender_id");--> statement-breakpoint
+CREATE INDEX "idx_file_receipts_receiver_id" ON "file_receipts" ("receiver_id");

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1742428800000,
       "tag": "0012_add_polls",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1742515200000,
+      "tag": "0013_file_session_receipts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -195,19 +195,21 @@ export const fileReceipts = pgTable(
   "file_receipts",
   {
     id: id(),
-    channelId: text("channel_id").notNull(),
+    channelId: text("channel_id"),
     senderId: text("sender_id").references(() => user.id, { onDelete: "set null" }),
+    receiverId: text("receiver_id").references(() => user.id, { onDelete: "set null" }),
     fileName: text("file_name").notNull(),
     fileSize: bigint("file_size", { mode: "number" }).notNull(),
     contentType: text("content_type").notNull(),
-    magnetUri: text("magnet_uri").notNull(),
-    infoHash: text("info_hash").notNull(),
+    magnetUri: text("magnet_uri"),
+    infoHash: text("info_hash"),
     messageId: text("message_id").references(() => messages.id, { onDelete: "cascade" }),
     createdAt: createdAt(),
   },
   (t) => [
     index("idx_file_receipts_channel_id").on(t.channelId),
-    unique("uq_file_receipts_message_id").on(t.messageId),
+    index("idx_file_receipts_sender_id").on(t.senderId),
+    index("idx_file_receipts_receiver_id").on(t.receiverId),
   ],
 );
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -21,6 +21,7 @@ import { safetyRoutes } from "./routes/safety.js";
 import { webhookRoutes } from "./routes/webhook.js";
 import { stripeRoutes } from "./routes/stripe.js";
 import { turnRoutes } from "./routes/turn.js";
+import { fileReceiptRoutes } from "./routes/file-receipts.js";
 import { gatewayTicketRoutes } from "./routes/gateway.js";
 import { gateway } from "./ws/gateway.js";
 import { subscribeCacheInvalidation, PubSubChannel } from "./lib/redis-pubsub.js";
@@ -77,6 +78,7 @@ const app = new Elysia()
   .use(feedbackRoutes)
   .use(pollRoutes)
   .use(safetyRoutes)
+  .use(fileReceiptRoutes)
   .use(gatewayTicketRoutes)
   .use(gateway)
   .get("/health", () => ({ status: "ok" }))

--- a/apps/server/src/routes/file-receipts.ts
+++ b/apps/server/src/routes/file-receipts.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { eq, or, desc, and, lt } from "drizzle-orm";
+import { eq, or, desc, and, lt, isNotNull } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { db } from "../db/index.js";
 import { fileReceipts, user } from "../db/schema.js";
@@ -35,10 +35,14 @@ export const fileReceiptRoutes = new Elysia({ prefix: "/api/file-receipts" })
     }
 
     // Only include DM receipts (those with receiverId set)
-    conditions.push(eq(fileReceipts.receiverId, fileReceipts.receiverId));
+    conditions.push(isNotNull(fileReceipts.receiverId));
 
     if (cursor) {
-      conditions.push(lt(fileReceipts.createdAt, new Date(cursor)));
+      const parsedDate = new Date(cursor);
+      if (Number.isNaN(parsedDate.getTime())) {
+        throw new ValidationError("Invalid cursor value");
+      }
+      conditions.push(lt(fileReceipts.createdAt, parsedDate));
     }
 
     const rows = await db

--- a/apps/server/src/routes/file-receipts.ts
+++ b/apps/server/src/routes/file-receipts.ts
@@ -1,0 +1,77 @@
+import { Elysia } from "elysia";
+import { eq, or, desc, and, lt } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { db } from "../db/index.js";
+import { fileReceipts, user } from "../db/schema.js";
+import { authResolve } from "../middleware/auth.js";
+import { ValidationError } from "@uncorded/shared";
+
+const RECEIPT_PAGE_SIZE = 20;
+
+export const fileReceiptRoutes = new Elysia({ prefix: "/api/file-receipts" })
+  .resolve(authResolve())
+  .get("/", async ({ user: sessionUser, query }) => {
+    const type = query.type ?? "all";
+    if (type !== "all" && type !== "sent" && type !== "received") {
+      throw new ValidationError("type must be 'all', 'sent', or 'received'");
+    }
+    const cursor = query.cursor ?? undefined;
+
+    const senderAlias = alias(user, "sender");
+    const receiverAlias = alias(user, "receiver");
+
+    const conditions = [];
+    if (type === "sent") {
+      conditions.push(eq(fileReceipts.senderId, sessionUser.id));
+    } else if (type === "received") {
+      conditions.push(eq(fileReceipts.receiverId, sessionUser.id));
+    } else {
+      conditions.push(
+        or(
+          eq(fileReceipts.senderId, sessionUser.id),
+          eq(fileReceipts.receiverId, sessionUser.id),
+        )!,
+      );
+    }
+
+    // Only include DM receipts (those with receiverId set)
+    conditions.push(eq(fileReceipts.receiverId, fileReceipts.receiverId));
+
+    if (cursor) {
+      conditions.push(lt(fileReceipts.createdAt, new Date(cursor)));
+    }
+
+    const rows = await db
+      .select({
+        id: fileReceipts.id,
+        fileName: fileReceipts.fileName,
+        fileSize: fileReceipts.fileSize,
+        contentType: fileReceipts.contentType,
+        senderId: fileReceipts.senderId,
+        senderUsername: senderAlias.username,
+        receiverId: fileReceipts.receiverId,
+        receiverUsername: receiverAlias.username,
+        createdAt: fileReceipts.createdAt,
+      })
+      .from(fileReceipts)
+      .leftJoin(senderAlias, eq(fileReceipts.senderId, senderAlias.id))
+      .leftJoin(receiverAlias, eq(fileReceipts.receiverId, receiverAlias.id))
+      .where(and(...conditions))
+      .orderBy(desc(fileReceipts.createdAt))
+      .limit(RECEIPT_PAGE_SIZE + 1);
+
+    const hasMore = rows.length > RECEIPT_PAGE_SIZE;
+    const receipts = rows.slice(0, RECEIPT_PAGE_SIZE).map((r) => ({
+      id: r.id,
+      fileName: r.fileName,
+      fileSize: r.fileSize,
+      contentType: r.contentType,
+      senderId: r.senderId,
+      senderUsername: r.senderUsername,
+      receiverId: r.receiverId,
+      receiverUsername: r.receiverUsername,
+      createdAt: r.createdAt?.toISOString() ?? null,
+    }));
+
+    return { receipts, hasMore };
+  });

--- a/apps/server/src/routes/report.ts
+++ b/apps/server/src/routes/report.ts
@@ -47,8 +47,10 @@ export const reportRoutes = new Elysia({ prefix: "/api/reports" })
         .where(eq(fileReceipts.id, data.fileReceiptId))
         .limit(1);
       if (!fr) throw new NotFoundError("File receipt");
-      const resolution = await resolveChannelMembership(sessionUser.id, fr.channelId);
-      if (!resolution) throw new NotFoundError("File receipt");
+      if (fr.channelId) {
+        const resolution = await resolveChannelMembership(sessionUser.id, fr.channelId);
+        if (!resolution) throw new NotFoundError("File receipt");
+      }
     } else if (data.type === "player") {
       if (data.targetUserId === sessionUser.id) {
         throw new ValidationError("You cannot report yourself");

--- a/apps/server/src/routes/report.ts
+++ b/apps/server/src/routes/report.ts
@@ -42,7 +42,7 @@ export const reportRoutes = new Elysia({ prefix: "/api/reports" })
       if (!resolution) throw new NotFoundError("Message");
     } else if (data.type === "file") {
       const [fr] = await db
-        .select({ id: fileReceipts.id, channelId: fileReceipts.channelId })
+        .select({ id: fileReceipts.id, channelId: fileReceipts.channelId, senderId: fileReceipts.senderId, receiverId: fileReceipts.receiverId })
         .from(fileReceipts)
         .where(eq(fileReceipts.id, data.fileReceiptId))
         .limit(1);
@@ -50,6 +50,11 @@ export const reportRoutes = new Elysia({ prefix: "/api/reports" })
       if (fr.channelId) {
         const resolution = await resolveChannelMembership(sessionUser.id, fr.channelId);
         if (!resolution) throw new NotFoundError("File receipt");
+      } else {
+        // DM P2P receipt — verify user is sender or receiver
+        if (fr.senderId !== sessionUser.id && fr.receiverId !== sessionUser.id) {
+          throw new NotFoundError("File receipt");
+        }
       }
     } else if (data.type === "player") {
       if (data.targetUserId === sessionUser.id) {

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -64,6 +64,15 @@ export async function handleFileSessionCreate(
     return;
   }
 
+  // Reject if session ID already exists (prevent overwriting another session)
+  if (activeSessions.has(data.sessionId)) {
+    sendToUser(senderId, {
+      op: Opcode.ERROR,
+      d: { code: "SESSION_EXISTS", message: "Session ID already in use" },
+    });
+    return;
+  }
+
   // Store session
   const session: FileSession = {
     id: data.sessionId,
@@ -178,24 +187,32 @@ export async function handleFileSessionComplete(
   if (session.completedParticipants.has(reportingUserId)) return;
   session.completedParticipants.add(reportingUserId);
 
+  // Create file receipt before notifying sender (so receipt exists if notification succeeds)
+  try {
+    await db.insert(fileReceipts).values({
+      id: createId(),
+      channelId: null,
+      senderId: session.senderId,
+      receiverId: reportingUserId,
+      fileName: session.fileName,
+      fileSize: session.fileSize,
+      contentType: session.contentType,
+      magnetUri: session.magnetUri,
+      infoHash: session.infoHash,
+      messageId: null,
+    });
+  } catch (err) {
+    console.error(
+      `[file-sessions] Failed to insert receipt: session=${session.id} sender=${session.senderId} receiver=${reportingUserId} file=${session.fileName}`,
+      err instanceof Error ? err.message : err,
+    );
+    // Still notify sender — the transfer succeeded even if the receipt failed
+  }
+
   // Forward to sender
   sendToUser(session.senderId, {
     op: Opcode.FILE_SESSION_COMPLETE,
     d: { sessionId: session.id, userId: reportingUserId },
-  });
-
-  // Create file receipt for this sender→recipient transfer
-  await db.insert(fileReceipts).values({
-    id: createId(),
-    channelId: null,
-    senderId: session.senderId,
-    receiverId: reportingUserId,
-    fileName: session.fileName,
-    fileSize: session.fileSize,
-    contentType: session.contentType,
-    magnetUri: session.magnetUri,
-    infoHash: session.infoHash,
-    messageId: null,
   });
 }
 

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -187,6 +187,7 @@ export async function handleFileSessionComplete(
   // Create file receipt for this sender→recipient transfer
   await db.insert(fileReceipts).values({
     id: createId(),
+    channelId: null,
     senderId: session.senderId,
     receiverId: reportingUserId,
     fileName: session.fileName,
@@ -194,6 +195,7 @@ export async function handleFileSessionComplete(
     contentType: session.contentType,
     magnetUri: session.magnetUri,
     infoHash: session.infoHash,
+    messageId: null,
   });
 }
 

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -261,7 +261,8 @@ export function cleanupSessionsForUser(disconnectedUserId: string): void {
       }
       activeSessions.delete(sessionId);
     } else {
-      // Recipient disconnected — notify sender and remove from session
+      // Recipient disconnected — notify sender, remove from participants
+      // but keep in invitees so they can rejoin if they reconnect
       if (session.participants.has(disconnectedUserId)) {
         session.participants.delete(disconnectedUserId);
         sendToUser(session.senderId, {
@@ -269,7 +270,6 @@ export function cleanupSessionsForUser(disconnectedUserId: string): void {
           d: { sessionId, userId: disconnectedUserId },
         });
       }
-      session.invitees.delete(disconnectedUserId);
     }
   }
 }

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -1,0 +1,259 @@
+import { Opcode } from "@uncorded/protocol";
+import type {
+  fileSessionCreateRequestSchema,
+  fileSessionJoinRequestSchema,
+  fileSessionProgressRequestSchema,
+  fileSessionCompleteRequestSchema,
+  fileSessionCloseRequestSchema,
+  fileSessionLeaveRequestSchema,
+} from "@uncorded/protocol";
+import type { z } from "zod";
+import { eq, and, or } from "drizzle-orm";
+import { createId } from "@uncorded/shared";
+import { db } from "../db/index.js";
+import { user, friendships, fileReceipts } from "../db/schema.js";
+import { sendToUser } from "./connections.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface FileSession {
+  id: string;
+  senderId: string;
+  fileName: string;
+  fileSize: number;
+  contentType: string;
+  magnetUri: string;
+  infoHash: string;
+  invitees: Set<string>;
+  participants: Set<string>;
+  createdAt: Date;
+}
+
+// ── In-Memory Store ─────────────────────────────────────────────────────────
+
+const activeSessions = new Map<string, FileSession>();
+
+// ── Handlers ────────────────────────────────────────────────────────────────
+
+export async function handleFileSessionCreate(
+  senderId: string,
+  data: z.infer<typeof fileSessionCreateRequestSchema>,
+): Promise<void> {
+  // Validate all invitees are accepted friends of sender
+  const friendRows = await db
+    .select({ usrId: friendships.userId, frdId: friendships.friendId })
+    .from(friendships)
+    .where(
+      and(
+        or(eq(friendships.userId, senderId), eq(friendships.friendId, senderId)),
+        eq(friendships.status, "accepted"),
+      ),
+    );
+
+  const friendIds = new Set(
+    friendRows.map((r) => (r.usrId === senderId ? r.frdId : r.usrId)),
+  );
+
+  const validInvitees = data.invitees.filter((id) => friendIds.has(id));
+  if (validInvitees.length === 0) {
+    sendToUser(senderId, {
+      op: Opcode.ERROR,
+      d: { code: "NO_VALID_INVITEES", message: "None of the selected users are your friends" },
+    });
+    return;
+  }
+
+  // Store session
+  const session: FileSession = {
+    id: data.sessionId,
+    senderId,
+    fileName: data.fileName,
+    fileSize: data.fileSize,
+    contentType: data.contentType,
+    magnetUri: data.magnetUri,
+    infoHash: data.infoHash,
+    invitees: new Set(validInvitees),
+    participants: new Set(),
+    createdAt: new Date(),
+  };
+  activeSessions.set(session.id, session);
+
+  // Fetch sender profile for the invite payload
+  const [sender] = await db
+    .select({
+      id: user.id,
+      username: user.username,
+      displayName: user.displayName,
+      avatarUrl: user.avatarUrl,
+    })
+    .from(user)
+    .where(eq(user.id, senderId))
+    .limit(1);
+
+  const invitePayload = {
+    sessionId: session.id,
+    senderId,
+    senderUsername: sender?.username ?? "",
+    senderDisplayName: sender?.displayName ?? null,
+    senderAvatarUrl: sender?.avatarUrl ?? null,
+    fileName: data.fileName,
+    fileSize: data.fileSize,
+    contentType: data.contentType,
+  };
+
+  // Send invite to each online invitee (offline ones are silently skipped)
+  for (const inviteeId of validInvitees) {
+    sendToUser(inviteeId, { op: Opcode.FILE_SESSION_INVITE, d: invitePayload });
+  }
+}
+
+export async function handleFileSessionJoin(
+  joiningUserId: string,
+  data: z.infer<typeof fileSessionJoinRequestSchema>,
+): Promise<void> {
+  const session = activeSessions.get(data.sessionId);
+  if (!session || !session.invitees.has(joiningUserId)) return;
+
+  session.participants.add(joiningUserId);
+
+  // Send magnetUri to the joining recipient so they can start downloading
+  sendToUser(joiningUserId, {
+    op: Opcode.FILE_SESSION_JOIN,
+    d: { sessionId: session.id, magnetUri: session.magnetUri },
+  });
+
+  // Fetch joining user's profile for the sender notification
+  const [joiner] = await db
+    .select({
+      id: user.id,
+      username: user.username,
+      displayName: user.displayName,
+      avatarUrl: user.avatarUrl,
+    })
+    .from(user)
+    .where(eq(user.id, joiningUserId))
+    .limit(1);
+
+  // Notify sender that a user joined
+  sendToUser(session.senderId, {
+    op: Opcode.FILE_SESSION_JOINED,
+    d: {
+      sessionId: session.id,
+      userId: joiningUserId,
+      username: joiner?.username ?? "",
+      displayName: joiner?.displayName ?? null,
+      avatarUrl: joiner?.avatarUrl ?? null,
+    },
+  });
+}
+
+export function handleFileSessionProgress(
+  reportingUserId: string,
+  data: z.infer<typeof fileSessionProgressRequestSchema>,
+): void {
+  const session = activeSessions.get(data.sessionId);
+  if (!session || !session.participants.has(reportingUserId)) return;
+
+  sendToUser(session.senderId, {
+    op: Opcode.FILE_SESSION_PROGRESS,
+    d: {
+      sessionId: session.id,
+      userId: reportingUserId,
+      progress: data.progress,
+      speed: data.speed,
+    },
+  });
+}
+
+export async function handleFileSessionComplete(
+  reportingUserId: string,
+  data: z.infer<typeof fileSessionCompleteRequestSchema>,
+): Promise<void> {
+  const session = activeSessions.get(data.sessionId);
+  if (!session || !session.participants.has(reportingUserId)) return;
+
+  // Forward to sender
+  sendToUser(session.senderId, {
+    op: Opcode.FILE_SESSION_COMPLETE,
+    d: { sessionId: session.id, userId: reportingUserId },
+  });
+
+  // Create file receipt for this sender→recipient transfer
+  await db.insert(fileReceipts).values({
+    id: createId(),
+    senderId: session.senderId,
+    receiverId: reportingUserId,
+    fileName: session.fileName,
+    fileSize: session.fileSize,
+    contentType: session.contentType,
+    magnetUri: session.magnetUri,
+    infoHash: session.infoHash,
+  });
+}
+
+export function handleFileSessionClose(
+  senderId: string,
+  data: z.infer<typeof fileSessionCloseRequestSchema>,
+): void {
+  const session = activeSessions.get(data.sessionId);
+  if (!session || session.senderId !== senderId) return;
+
+  // Notify all participants
+  for (const participantId of session.participants) {
+    sendToUser(participantId, {
+      op: Opcode.FILE_SESSION_CLOSE,
+      d: { sessionId: session.id },
+    });
+  }
+
+  // Also notify invited-but-not-joined users
+  for (const inviteeId of session.invitees) {
+    if (!session.participants.has(inviteeId)) {
+      sendToUser(inviteeId, {
+        op: Opcode.FILE_SESSION_CLOSE,
+        d: { sessionId: session.id },
+      });
+    }
+  }
+
+  activeSessions.delete(session.id);
+}
+
+export function handleFileSessionLeave(
+  leavingUserId: string,
+  data: z.infer<typeof fileSessionLeaveRequestSchema>,
+): void {
+  const session = activeSessions.get(data.sessionId);
+  if (!session || !session.participants.has(leavingUserId)) return;
+
+  session.participants.delete(leavingUserId);
+
+  sendToUser(session.senderId, {
+    op: Opcode.FILE_SESSION_LEAVE,
+    d: { sessionId: session.id, userId: leavingUserId },
+  });
+}
+
+/** Called on WebSocket close — cleanup all sessions owned by the disconnecting user. */
+export function cleanupSessionsForUser(disconnectedUserId: string): void {
+  for (const [sessionId, session] of activeSessions) {
+    if (session.senderId === disconnectedUserId) {
+      // Sender disconnected — close session for everyone
+      for (const participantId of session.participants) {
+        sendToUser(participantId, {
+          op: Opcode.FILE_SESSION_CLOSE,
+          d: { sessionId },
+        });
+      }
+      for (const inviteeId of session.invitees) {
+        if (!session.participants.has(inviteeId)) {
+          sendToUser(inviteeId, {
+            op: Opcode.FILE_SESSION_CLOSE,
+            d: { sessionId },
+          });
+        }
+      }
+      activeSessions.delete(sessionId);
+    }
+  }
+}

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -125,6 +125,9 @@ export async function handleFileSessionJoin(
   const session = activeSessions.get(data.sessionId);
   if (!session || !session.invitees.has(joiningUserId)) return;
 
+  // Idempotent: skip if already joined
+  if (session.participants.has(joiningUserId)) return;
+
   session.participants.add(joiningUserId);
 
   // Send magnetUri to the joining recipient so they can start downloading
@@ -185,9 +188,8 @@ export async function handleFileSessionComplete(
 
   // Dedupe: skip if already completed
   if (session.completedParticipants.has(reportingUserId)) return;
-  session.completedParticipants.add(reportingUserId);
 
-  // Create file receipt before notifying sender (so receipt exists if notification succeeds)
+  // Create file receipt before marking complete (so retries can succeed if insert fails)
   try {
     await db.insert(fileReceipts).values({
       id: createId(),
@@ -201,12 +203,14 @@ export async function handleFileSessionComplete(
       infoHash: session.infoHash,
       messageId: null,
     });
+    session.completedParticipants.add(reportingUserId);
   } catch (err) {
     console.error(
       `[file-sessions] Failed to insert receipt: session=${session.id} sender=${session.senderId} receiver=${reportingUserId} file=${session.fileName}`,
       err instanceof Error ? err.message : err,
     );
-    // Still notify sender — the transfer succeeded even if the receipt failed
+    // Don't mark as completed — allows retry on next FILE_SESSION_COMPLETE
+    return;
   }
 
   // Forward to sender

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -26,6 +26,7 @@ interface FileSession {
   infoHash: string;
   invitees: Set<string>;
   participants: Set<string>;
+  completedParticipants: Set<string>;
   createdAt: Date;
 }
 
@@ -74,6 +75,7 @@ export async function handleFileSessionCreate(
     infoHash: data.infoHash,
     invitees: new Set(validInvitees),
     participants: new Set(),
+    completedParticipants: new Set(),
     createdAt: new Date(),
   };
   activeSessions.set(session.id, session);
@@ -172,6 +174,10 @@ export async function handleFileSessionComplete(
   const session = activeSessions.get(data.sessionId);
   if (!session || !session.participants.has(reportingUserId)) return;
 
+  // Dedupe: skip if already completed
+  if (session.completedParticipants.has(reportingUserId)) return;
+  session.completedParticipants.add(reportingUserId);
+
   // Forward to sender
   sendToUser(session.senderId, {
     op: Opcode.FILE_SESSION_COMPLETE,
@@ -234,7 +240,7 @@ export function handleFileSessionLeave(
   });
 }
 
-/** Called on WebSocket close — cleanup all sessions owned by the disconnecting user. */
+/** Called on WebSocket close — cleanup all sessions involving the disconnecting user. */
 export function cleanupSessionsForUser(disconnectedUserId: string): void {
   for (const [sessionId, session] of activeSessions) {
     if (session.senderId === disconnectedUserId) {
@@ -254,6 +260,16 @@ export function cleanupSessionsForUser(disconnectedUserId: string): void {
         }
       }
       activeSessions.delete(sessionId);
+    } else {
+      // Recipient disconnected — notify sender and remove from session
+      if (session.participants.has(disconnectedUserId)) {
+        session.participants.delete(disconnectedUserId);
+        sendToUser(session.senderId, {
+          op: Opcode.FILE_SESSION_LEAVE,
+          d: { sessionId, userId: disconnectedUserId },
+        });
+      }
+      session.invitees.delete(disconnectedUserId);
     }
   }
 }

--- a/apps/server/src/ws/gateway.ts
+++ b/apps/server/src/ws/gateway.ts
@@ -9,6 +9,12 @@ import {
   fileShareRequestSchema,
   fileAvailabilityRequestSchema,
   presenceUpdateSchema,
+  fileSessionCreateRequestSchema,
+  fileSessionJoinRequestSchema,
+  fileSessionProgressRequestSchema,
+  fileSessionCompleteRequestSchema,
+  fileSessionCloseRequestSchema,
+  fileSessionLeaveRequestSchema,
 } from "@uncorded/protocol";
 import {
   createId,
@@ -19,6 +25,8 @@ import {
   RATE_LIMIT_FILE_AVAILABILITY,
   RATE_LIMIT_WEBRTC,
   RATE_LIMIT_PRESENCE_UPDATE,
+  RATE_LIMIT_FILE_SESSION,
+  RATE_LIMIT_FILE_SESSION_PROGRESS,
 } from "@uncorded/shared";
 import { checkRateLimit } from "./rate-limit.js";
 import { eq, and } from "drizzle-orm";
@@ -33,6 +41,15 @@ import {
   cleanupPresence,
   broadcastPresence,
 } from "./presence.js";
+import {
+  handleFileSessionCreate,
+  handleFileSessionJoin,
+  handleFileSessionProgress,
+  handleFileSessionComplete,
+  handleFileSessionClose,
+  handleFileSessionLeave,
+  cleanupSessionsForUser,
+} from "./file-sessions.js";
 
 const FREE_TIER = "free" as const;
 
@@ -438,6 +455,114 @@ export const gateway = new Elysia().ws("/gateway", {
           break;
         }
 
+        // ── File Share Sessions ─────────────────────────────────────────────
+
+        case Opcode.FILE_SESSION_CREATE: {
+          if (!ctx.userId) {
+            ws.close(CloseCode.NOT_IDENTIFIED, "Not identified");
+            return;
+          }
+
+          if (
+            !(await checkRateLimit(
+              ctx.userId,
+              frame.op,
+              RATE_LIMIT_FILE_SESSION.limit,
+              RATE_LIMIT_FILE_SESSION.windowMs,
+            ))
+          ) {
+            sendToUser(ctx.userId, {
+              op: Opcode.ERROR,
+              d: { code: "RATE_LIMITED", message: "Too many file session requests" },
+            });
+            break;
+          }
+
+          const parsed = fileSessionCreateRequestSchema.safeParse(frame.d);
+          if (!parsed.success) break;
+
+          resetIdleTimer(ctx.userId);
+          await handleFileSessionCreate(ctx.userId, parsed.data);
+          break;
+        }
+
+        case Opcode.FILE_SESSION_JOIN: {
+          if (!ctx.userId) {
+            ws.close(CloseCode.NOT_IDENTIFIED, "Not identified");
+            return;
+          }
+
+          const parsed = fileSessionJoinRequestSchema.safeParse(frame.d);
+          if (!parsed.success) break;
+
+          resetIdleTimer(ctx.userId);
+          await handleFileSessionJoin(ctx.userId, parsed.data);
+          break;
+        }
+
+        case Opcode.FILE_SESSION_PROGRESS: {
+          if (!ctx.userId) {
+            ws.close(CloseCode.NOT_IDENTIFIED, "Not identified");
+            return;
+          }
+
+          if (
+            !(await checkRateLimit(
+              ctx.userId,
+              frame.op,
+              RATE_LIMIT_FILE_SESSION_PROGRESS.limit,
+              RATE_LIMIT_FILE_SESSION_PROGRESS.windowMs,
+            ))
+          ) {
+            break; // Silent drop for progress — high frequency
+          }
+
+          const parsed = fileSessionProgressRequestSchema.safeParse(frame.d);
+          if (!parsed.success) break;
+
+          handleFileSessionProgress(ctx.userId, parsed.data);
+          break;
+        }
+
+        case Opcode.FILE_SESSION_COMPLETE: {
+          if (!ctx.userId) {
+            ws.close(CloseCode.NOT_IDENTIFIED, "Not identified");
+            return;
+          }
+
+          const parsed = fileSessionCompleteRequestSchema.safeParse(frame.d);
+          if (!parsed.success) break;
+
+          await handleFileSessionComplete(ctx.userId, parsed.data);
+          break;
+        }
+
+        case Opcode.FILE_SESSION_CLOSE: {
+          if (!ctx.userId) {
+            ws.close(CloseCode.NOT_IDENTIFIED, "Not identified");
+            return;
+          }
+
+          const parsed = fileSessionCloseRequestSchema.safeParse(frame.d);
+          if (!parsed.success) break;
+
+          handleFileSessionClose(ctx.userId, parsed.data);
+          break;
+        }
+
+        case Opcode.FILE_SESSION_LEAVE: {
+          if (!ctx.userId) {
+            ws.close(CloseCode.NOT_IDENTIFIED, "Not identified");
+            return;
+          }
+
+          const parsed = fileSessionLeaveRequestSchema.safeParse(frame.d);
+          if (!parsed.success) break;
+
+          handleFileSessionLeave(ctx.userId, parsed.data);
+          break;
+        }
+
         default:
           break;
       }
@@ -465,6 +590,7 @@ export const gateway = new Elysia().ws("/gateway", {
 
       if (wasLast) {
         cleanupPresence(ctx.userId);
+        cleanupSessionsForUser(ctx.userId);
         await db.update(user).set({ status: "offline" }).where(eq(user.id, ctx.userId));
         await broadcastPresence(ctx.userId, "offline");
         removeUserFromAllServers(ctx.userId);

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -3,6 +3,7 @@ import {
   onMount,
   createEffect,
   Show,
+  on,
   type ParentComponent,
 } from "solid-js";
 import { useSession } from "../lib/auth.js";
@@ -17,13 +18,19 @@ import AuthGuard from "./AuthGuard.js";
 import AppSidebar from "./AppSidebar.js";
 import ChatArea from "./ChatArea.js";
 import ShortcutsDialog from "./ShortcutsDialog.js";
-import { ToastContainer } from "./ui/toast.js";
+import { ToastContainer, showToast } from "./ui/toast.js";
 import { Empty } from "./ui/empty.js";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "./ui/sidebar.js";
 import P2PNoticeDialog from "./P2PNoticeDialog.js";
 import GiftNotification from "./modals/GiftNotification.js";
 import DeletionCountdown from "./modals/DeletionCountdown.js";
 import { getP2pDialogOpen, confirmP2pDialog, cancelP2pDialog } from "../stores/file-store.js";
+import {
+  pendingInvite,
+  joinSession,
+  activeReceiverSessionId,
+} from "../stores/share-session-store.js";
+import FileReceiveModal from "./modals/FileReceiveModal.js";
 
 const SETTINGS_PATHS = ["/home/server-settings", "/home/settings"];
 
@@ -45,6 +52,26 @@ const AppLayout: ParentComponent = (props) => {
     cleanupShortcuts();
   });
 
+  // Show persistent toast for incoming file share invites
+  createEffect(
+    on(pendingInvite, (invite) => {
+      if (!invite) return;
+      const sizeKb = invite.fileSize < 1024 * 1024
+        ? `${(invite.fileSize / 1024).toFixed(1)} KB`
+        : `${(invite.fileSize / (1024 * 1024)).toFixed(1)} MB`;
+
+      showToast(
+        `${invite.senderDisplayName ?? invite.senderUsername} wants to share "${invite.fileName}" (${sizeKb})`,
+        "info",
+        {
+          durationMs: 60_000, // Long-lived — dismissed manually or on session close
+          subtitle: "Click to join",
+          onClick: () => joinSession(invite.sessionId),
+        },
+      );
+    }),
+  );
+
   return (
     <AuthGuard>
       <ToastContainer />
@@ -56,6 +83,9 @@ const AppLayout: ParentComponent = (props) => {
         onConfirm={confirmP2pDialog}
         onCancel={cancelP2pDialog}
       />
+      <Show when={activeReceiverSessionId()}>
+        <FileReceiveModal />
+      </Show>
       <SidebarProvider class="h-screen !min-h-0">
         <AppSidebar />
         <SidebarInset>

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -35,6 +35,7 @@ import SubscriptionModal from "./modals/SubscriptionModal.js";
 import PricingModal from "./modals/PricingModal.js";
 import StatusDot, { type UserStatus } from "./StatusDot.js";
 import UnifiedReportDialog from "./modals/UnifiedReportDialog.js";
+import ShareFileModal from "./modals/ShareFileModal.js";
 import { showToast } from "./ui/toast.js";
 
 const iconBtnClass =
@@ -53,6 +54,7 @@ const AppSidebar = () => {
   const [showPricingModal, setShowPricingModal] = createSignal(false);
   const [showSubscriptionModal, setShowSubscriptionModal] = createSignal(false);
   const [showReportDialog, setShowReportDialog] = createSignal(false);
+  const [showShareModal, setShowShareModal] = createSignal(false);
 
   let copiedUsernameTimer: ReturnType<typeof setTimeout> | undefined;
   onCleanup(() => clearTimeout(copiedUsernameTimer));
@@ -184,6 +186,29 @@ const AppSidebar = () => {
               Alpha
             </span>
           </div>
+        </button>
+        <button
+          onClick={() => setShowShareModal(true)}
+          class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+          title="Send File"
+          aria-label="Send File"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+            />
+          </svg>
+          Send File
         </button>
         <ServerSwitcher
           onCreateServer={() => setModal("create")}
@@ -579,6 +604,9 @@ const AppSidebar = () => {
       </Show>
       <Show when={showReportDialog()}>
         <UnifiedReportDialog onClose={() => setShowReportDialog(false)} />
+      </Show>
+      <Show when={showShareModal()}>
+        <ShareFileModal onClose={() => setShowShareModal(false)} />
       </Show>
     </Sidebar>
   );

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -62,7 +62,9 @@ const ChatArea = () => {
   const isServerChannel = createMemo(() => !!selectedChannelId() && !!selectedServerId());
 
   const isFreeUser = createMemo(() => readyData.data?.user.subscriptionTier === "free");
-  const isFileSharingBlocked = createMemo(() => isFreeUser() && isServerChannel());
+  const isFileSharingBlocked = createMemo(() =>
+    isDm() || (isFreeUser() && isServerChannel()),
+  );
 
   const dmChannel = createMemo(() => {
     if (!isDm()) return null;
@@ -184,7 +186,7 @@ const ChatArea = () => {
                 onFileSelect={handleFileSelect}
                 class="flex min-w-0 flex-1 flex-col"
                 disabled={isFileSharingBlocked()}
-                disabledMessage="Upgrade to Supporter to share files in servers"
+                disabledMessage={isDm() ? "Use the Send File button in the sidebar to share files" : "Upgrade to Supporter to share files in servers"}
               >
                 <VirtualMessageList channelId={id()} />
                 <MessageInput

--- a/apps/web/src/components/ShareVisualization.tsx
+++ b/apps/web/src/components/ShareVisualization.tsx
@@ -1,0 +1,393 @@
+import { For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import type { ShareSession, ParticipantInfo } from "../stores/share-session-store.js";
+import { formatBytes } from "./FileMessage.js";
+
+interface Props {
+  session: ShareSession;
+}
+
+// ── Physics Constants ────────────────────────────────────────────────────────
+
+const INFLUENCE_RADIUS = 100;
+const REPULSION_STRENGTH = 3000;
+const SPRING_STIFFNESS = 0.08;
+const DAMPING = 0.85;
+
+interface PhysicsBody {
+  restX: number;
+  restY: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+// ── SVG Layout Constants ─────────────────────────────────────────────────────
+
+const SENDER_X = 80;
+const RECIPIENT_X = 520;
+const AVATAR_SIZE_SENDER = 80;
+const AVATAR_SIZE_RECIPIENT = 56;
+
+function getRecipientY(index: number, total: number): number {
+  if (total === 0) return 200;
+  const spacing = Math.min(80, 400 / Math.max(total, 1));
+  const startY = 200 - ((total - 1) * spacing) / 2;
+  return startY + index * spacing;
+}
+
+function getLineColor(status: ParticipantInfo["status"]): string {
+  switch (status) {
+    case "complete":
+      return "oklch(0.66 0.17 155)";
+    case "downloading":
+      return "oklch(0.65 0.16 255)";
+    case "error":
+      return "oklch(0.55 0.2 25)";
+    default:
+      return "oklch(0.4 0 0)";
+  }
+}
+
+function getLineStrokeDash(status: ParticipantInfo["status"]): string {
+  if (status === "invited" || status === "joined") return "6 4";
+  return "none";
+}
+
+const ShareVisualization = (props: Props) => {
+  const [mousePos, setMousePos] = createSignal({ x: -999, y: -999 });
+  let containerRef!: HTMLDivElement;
+  let svgRef!: SVGSVGElement;
+  let animFrame: number | undefined;
+  let bodies: PhysicsBody[] = [];
+  let senderBody: PhysicsBody = { restX: 0, restY: 0, x: 0, y: 0, vx: 0, vy: 0 };
+
+  const participants = createMemo(() => {
+    const p = props.session.participants;
+    return Object.values(p);
+  });
+
+  const allParticipants = createMemo((): ParticipantInfo[] => {
+    return participants();
+  });
+
+  // ── Physics Loop ───────────────────────────────────────────────────────────
+
+  const updatePhysics = () => {
+    const mouse = mousePos();
+
+    const updateBody = (body: PhysicsBody) => {
+      const dx = body.x - mouse.x;
+      const dy = body.y - mouse.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (dist < INFLUENCE_RADIUS && dist > 0) {
+        const force = REPULSION_STRENGTH / (dist * dist);
+        body.vx += (dx / dist) * force * 0.016;
+        body.vy += (dy / dist) * force * 0.016;
+      }
+
+      // Spring back to rest
+      body.vx += (body.restX - body.x) * SPRING_STIFFNESS;
+      body.vy += (body.restY - body.y) * SPRING_STIFFNESS;
+
+      // Damping
+      body.vx *= DAMPING;
+      body.vy *= DAMPING;
+
+      body.x += body.vx;
+      body.y += body.vy;
+    };
+
+    updateBody(senderBody);
+    for (const body of bodies) {
+      updateBody(body);
+    }
+
+    animFrame = requestAnimationFrame(updatePhysics);
+  };
+
+  onMount(() => {
+    // Initialize sender body
+    senderBody = { restX: SENDER_X, restY: 200, x: SENDER_X, y: 200, vx: 0, vy: 0 };
+
+    animFrame = requestAnimationFrame(updatePhysics);
+  });
+
+  onCleanup(() => {
+    if (animFrame) cancelAnimationFrame(animFrame);
+  });
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!svgRef) return;
+    const rect = svgRef.getBoundingClientRect();
+    setMousePos({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    });
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div ref={containerRef} class="relative w-full">
+      {/* File info */}
+      <div class="mb-4 text-center">
+        <p class="text-sm font-medium text-foreground">{props.session.fileName}</p>
+        <p class="text-xs text-muted-foreground">{formatBytes(props.session.fileSize)}</p>
+        <Show when={props.session.status === "complete"}>
+          <p class="mt-1 text-xs text-success-foreground">All transfers complete</p>
+        </Show>
+      </div>
+
+      {/* SVG Visualization */}
+      <svg
+        ref={svgRef}
+        viewBox="0 0 600 400"
+        class="w-full"
+        style={{ "min-height": "300px" }}
+        onMouseMove={handleMouseMove}
+      >
+        {/* Bezier lines */}
+        <For each={allParticipants()}>
+          {(participant, index) => {
+            const y = () => getRecipientY(index(), allParticipants().length);
+            const controlX1 = () => SENDER_X + 120;
+            const controlX2 = () => RECIPIENT_X - 120;
+            const path = () =>
+              `M ${senderBody.x} ${senderBody.y} C ${controlX1()} ${senderBody.y}, ${controlX2()} ${y()}, ${RECIPIENT_X} ${y()}`;
+
+            // Update physics bodies
+            if (!bodies[index()]) {
+              bodies[index()] = {
+                restX: RECIPIENT_X,
+                restY: y(),
+                x: RECIPIENT_X,
+                y: y(),
+                vx: 0,
+                vy: 0,
+              };
+            }
+            bodies[index()]!.restY = y();
+
+            return (
+              <>
+                {/* Background line */}
+                <path
+                  d={path()}
+                  fill="none"
+                  stroke={getLineColor(participant.status)}
+                  stroke-width="2"
+                  stroke-dasharray={getLineStrokeDash(participant.status)}
+                  opacity="0.3"
+                />
+
+                {/* Progress fill line */}
+                <Show when={participant.status === "downloading" && participant.progress > 0}>
+                  <path
+                    d={path()}
+                    fill="none"
+                    stroke={getLineColor(participant.status)}
+                    stroke-width="2.5"
+                    stroke-dasharray={`${participant.progress * 100}% ${100}%`}
+                    pathLength={100}
+                  />
+                </Show>
+
+                {/* Complete line */}
+                <Show when={participant.status === "complete"}>
+                  <path
+                    d={path()}
+                    fill="none"
+                    stroke={getLineColor(participant.status)}
+                    stroke-width="2.5"
+                  />
+                </Show>
+
+                {/* Flowing particles for active transfers */}
+                <Show when={participant.status === "downloading"}>
+                  <circle r="3" fill={getLineColor("downloading")} opacity="0.8">
+                    <animateMotion dur="2s" repeatCount="indefinite" path={path()} />
+                  </circle>
+                  <circle r="2" fill={getLineColor("downloading")} opacity="0.5">
+                    <animateMotion dur="2s" repeatCount="indefinite" path={path()} begin="0.7s" />
+                  </circle>
+                  <circle r="2" fill={getLineColor("downloading")} opacity="0.3">
+                    <animateMotion dur="2s" repeatCount="indefinite" path={path()} begin="1.4s" />
+                  </circle>
+                </Show>
+              </>
+            );
+          }}
+        </For>
+
+        {/* Sender avatar */}
+        <g transform={`translate(${senderBody.x - AVATAR_SIZE_SENDER / 2}, ${senderBody.y - AVATAR_SIZE_SENDER / 2})`}>
+          <circle
+            cx={AVATAR_SIZE_SENDER / 2}
+            cy={AVATAR_SIZE_SENDER / 2}
+            r={AVATAR_SIZE_SENDER / 2}
+            fill="oklch(0.21 0.018 155)"
+            stroke="oklch(0.66 0.17 155)"
+            stroke-width="2"
+          />
+          <Show
+            when={props.session.senderAvatarUrl}
+            fallback={
+              <text
+                x={AVATAR_SIZE_SENDER / 2}
+                y={AVATAR_SIZE_SENDER / 2 + 6}
+                text-anchor="middle"
+                fill="oklch(0.955 0.008 155)"
+                font-size="24"
+                font-weight="600"
+              >
+                {(props.session.senderDisplayName ?? props.session.senderUsername ?? "?").charAt(0).toUpperCase()}
+              </text>
+            }
+          >
+            {(url) => (
+              <>
+                <defs>
+                  <clipPath id="sender-clip">
+                    <circle cx={AVATAR_SIZE_SENDER / 2} cy={AVATAR_SIZE_SENDER / 2} r={AVATAR_SIZE_SENDER / 2 - 1} />
+                  </clipPath>
+                </defs>
+                <image
+                  href={url()}
+                  x="1"
+                  y="1"
+                  width={AVATAR_SIZE_SENDER - 2}
+                  height={AVATAR_SIZE_SENDER - 2}
+                  clip-path="url(#sender-clip)"
+                />
+              </>
+            )}
+          </Show>
+        </g>
+
+        {/* Sender label */}
+        <text
+          x={senderBody.x}
+          y={senderBody.y + AVATAR_SIZE_SENDER / 2 + 18}
+          text-anchor="middle"
+          fill="oklch(0.955 0.008 155)"
+          font-size="12"
+          font-weight="500"
+        >
+          {props.session.senderDisplayName ?? props.session.senderUsername ?? "You"}
+        </text>
+
+        {/* Recipient avatars */}
+        <For each={allParticipants()}>
+          {(participant, index) => {
+            const y = () => getRecipientY(index(), allParticipants().length);
+            const body = () => bodies[index()];
+
+            const statusLabel = () => {
+              switch (participant.status) {
+                case "invited": return "Invited";
+                case "joined": return "Joined";
+                case "downloading": return `${Math.round(participant.progress * 100)}%`;
+                case "complete": return "Shared";
+                case "error": return "Error";
+                default: return "";
+              }
+            };
+
+            return (
+              <g transform={`translate(${(body()?.x ?? RECIPIENT_X) - AVATAR_SIZE_RECIPIENT / 2}, ${(body()?.y ?? y()) - AVATAR_SIZE_RECIPIENT / 2})`}>
+                <circle
+                  cx={AVATAR_SIZE_RECIPIENT / 2}
+                  cy={AVATAR_SIZE_RECIPIENT / 2}
+                  r={AVATAR_SIZE_RECIPIENT / 2}
+                  fill="oklch(0.21 0.018 155)"
+                  stroke={getLineColor(participant.status)}
+                  stroke-width="2"
+                />
+                <Show
+                  when={participant.avatarUrl}
+                  fallback={
+                    <text
+                      x={AVATAR_SIZE_RECIPIENT / 2}
+                      y={AVATAR_SIZE_RECIPIENT / 2 + 5}
+                      text-anchor="middle"
+                      fill="oklch(0.955 0.008 155)"
+                      font-size="18"
+                      font-weight="600"
+                    >
+                      {(participant.displayName ?? participant.username ?? "?").charAt(0).toUpperCase()}
+                    </text>
+                  }
+                >
+                  {(url) => (
+                    <>
+                      <defs>
+                        <clipPath id={`recipient-clip-${index()}`}>
+                          <circle cx={AVATAR_SIZE_RECIPIENT / 2} cy={AVATAR_SIZE_RECIPIENT / 2} r={AVATAR_SIZE_RECIPIENT / 2 - 1} />
+                        </clipPath>
+                      </defs>
+                      <image
+                        href={url()}
+                        x="1"
+                        y="1"
+                        width={AVATAR_SIZE_RECIPIENT - 2}
+                        height={AVATAR_SIZE_RECIPIENT - 2}
+                        clip-path={`url(#recipient-clip-${index()})`}
+                      />
+                    </>
+                  )}
+                </Show>
+
+                {/* Username */}
+                <text
+                  x={AVATAR_SIZE_RECIPIENT / 2}
+                  y={AVATAR_SIZE_RECIPIENT + 14}
+                  text-anchor="middle"
+                  fill="oklch(0.955 0.008 155)"
+                  font-size="11"
+                  font-weight="500"
+                >
+                  {participant.displayName ?? participant.username}
+                </text>
+
+                {/* Status label */}
+                <text
+                  x={AVATAR_SIZE_RECIPIENT / 2}
+                  y={AVATAR_SIZE_RECIPIENT + 26}
+                  text-anchor="middle"
+                  fill={getLineColor(participant.status)}
+                  font-size="10"
+                >
+                  {statusLabel()}
+                </text>
+
+                {/* Speed for active downloads */}
+                <Show when={participant.status === "downloading" && participant.speed > 0}>
+                  <text
+                    x={AVATAR_SIZE_RECIPIENT / 2}
+                    y={AVATAR_SIZE_RECIPIENT + 38}
+                    text-anchor="middle"
+                    fill="oklch(0.62 0.008 155)"
+                    font-size="9"
+                  >
+                    {formatBytes(participant.speed)}/s
+                  </text>
+                </Show>
+              </g>
+            );
+          }}
+        </For>
+      </svg>
+
+      {/* Empty state when no participants */}
+      <Show when={allParticipants().length === 0}>
+        <div class="flex flex-col items-center justify-center py-8">
+          <p class="text-sm text-muted-foreground">Waiting for recipients to join...</p>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default ShareVisualization;

--- a/apps/web/src/components/ShareVisualization.tsx
+++ b/apps/web/src/components/ShareVisualization.tsx
@@ -6,35 +6,7 @@ interface Props {
   session: ShareSession;
 }
 
-// ── Physics Constants ────────────────────────────────────────────────────────
-
-const INFLUENCE_RADIUS = 100;
-const REPULSION_STRENGTH = 3000;
-const SPRING_STIFFNESS = 0.08;
-const DAMPING = 0.85;
-
-interface PhysicsBody {
-  restX: number;
-  restY: number;
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-}
-
-// ── SVG Layout Constants ─────────────────────────────────────────────────────
-
-const SENDER_X = 80;
-const RECIPIENT_X = 520;
-const AVATAR_SIZE_SENDER = 80;
-const AVATAR_SIZE_RECIPIENT = 56;
-
-function getRecipientY(index: number, total: number): number {
-  if (total === 0) return 200;
-  const spacing = Math.min(80, 400 / Math.max(total, 1));
-  const startY = 200 - ((total - 1) * spacing) / 2;
-  return startY + index * spacing;
-}
+// ── Line Colors ──────────────────────────────────────────────────────────────
 
 function getLineColor(status: ParticipantInfo["status"]): string {
   switch (status) {
@@ -49,90 +21,78 @@ function getLineColor(status: ParticipantInfo["status"]): string {
   }
 }
 
-function getLineStrokeDash(status: ParticipantInfo["status"]): string {
-  if (status === "invited" || status === "joined") return "6 4";
-  return "none";
+function getStatusClass(status: ParticipantInfo["status"]): string {
+  switch (status) {
+    case "complete":
+      return "text-success-foreground";
+    case "downloading":
+      return "text-info-foreground";
+    case "error":
+      return "text-destructive-foreground";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+function getStatusLabel(status: ParticipantInfo["status"], progress: number): string {
+  switch (status) {
+    case "invited":
+      return "Waiting...";
+    case "joined":
+      return "Connected";
+    case "downloading":
+      return `${Math.round(progress * 100)}%`;
+    case "complete":
+      return "Complete";
+    case "error":
+      return "Error";
+    default:
+      return "";
+  }
+}
+
+function getBorderClass(status: ParticipantInfo["status"]): string {
+  switch (status) {
+    case "complete":
+      return "ring-2 ring-success/50";
+    case "downloading":
+      return "ring-2 ring-info/50";
+    case "error":
+      return "ring-2 ring-destructive/50";
+    default:
+      return "ring-1 ring-border";
+  }
 }
 
 const ShareVisualization = (props: Props) => {
-  const [mousePos, setMousePos] = createSignal({ x: -999, y: -999 });
-  let containerRef!: HTMLDivElement;
   let svgRef!: SVGSVGElement;
-  let animFrame: number | undefined;
-  let bodies: PhysicsBody[] = [];
-  let senderBody: PhysicsBody = { restX: 0, restY: 0, x: 0, y: 0, vx: 0, vy: 0 };
+  const [dimensions, setDimensions] = createSignal({ width: 500, height: 200 });
 
-  const participants = createMemo(() => {
-    const p = props.session.participants;
-    return Object.values(p);
+  const participants = createMemo((): ParticipantInfo[] => {
+    return Object.values(props.session.participants);
   });
 
-  const allParticipants = createMemo((): ParticipantInfo[] => {
-    return participants();
-  });
+  // Measure container for SVG lines
+  let containerRef!: HTMLDivElement;
 
-  // ── Physics Loop ───────────────────────────────────────────────────────────
-
-  const updatePhysics = () => {
-    const mouse = mousePos();
-
-    const updateBody = (body: PhysicsBody) => {
-      const dx = body.x - mouse.x;
-      const dy = body.y - mouse.y;
-      const dist = Math.sqrt(dx * dx + dy * dy);
-
-      if (dist < INFLUENCE_RADIUS && dist > 0) {
-        const force = REPULSION_STRENGTH / (dist * dist);
-        body.vx += (dx / dist) * force * 0.016;
-        body.vy += (dy / dist) * force * 0.016;
-      }
-
-      // Spring back to rest
-      body.vx += (body.restX - body.x) * SPRING_STIFFNESS;
-      body.vy += (body.restY - body.y) * SPRING_STIFFNESS;
-
-      // Damping
-      body.vx *= DAMPING;
-      body.vy *= DAMPING;
-
-      body.x += body.vx;
-      body.y += body.vy;
-    };
-
-    updateBody(senderBody);
-    for (const body of bodies) {
-      updateBody(body);
+  const updateDimensions = () => {
+    if (containerRef) {
+      const rect = containerRef.getBoundingClientRect();
+      setDimensions({ width: rect.width, height: rect.height });
     }
-
-    animFrame = requestAnimationFrame(updatePhysics);
   };
 
   onMount(() => {
-    // Initialize sender body
-    senderBody = { restX: SENDER_X, restY: 200, x: SENDER_X, y: 200, vx: 0, vy: 0 };
-
-    animFrame = requestAnimationFrame(updatePhysics);
+    updateDimensions();
+    const observer = new ResizeObserver(updateDimensions);
+    if (containerRef) observer.observe(containerRef);
+    onCleanup(() => observer.disconnect());
   });
-
-  onCleanup(() => {
-    if (animFrame) cancelAnimationFrame(animFrame);
-  });
-
-  const handleMouseMove = (e: MouseEvent) => {
-    if (!svgRef) return;
-    const rect = svgRef.getBoundingClientRect();
-    setMousePos({
-      x: e.clientX - rect.left,
-      y: e.clientY - rect.top,
-    });
-  };
-
-  // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
-    <div ref={containerRef} class="relative w-full">
-      {/* File info */}
-      <div class="mb-4 text-center">
+    <div class="flex flex-col gap-4">
+      {/* File info header */}
+      <div class="text-center">
         <p class="text-sm font-medium text-foreground">{props.session.fileName}</p>
         <p class="text-xs text-muted-foreground">{formatBytes(props.session.fileSize)}</p>
         <Show when={props.session.status === "complete"}>
@@ -140,252 +100,165 @@ const ShareVisualization = (props: Props) => {
         </Show>
       </div>
 
-      {/* SVG Visualization */}
-      <svg
-        ref={svgRef}
-        viewBox="0 0 600 400"
-        class="w-full"
-        style={{ "min-height": "300px" }}
-        onMouseMove={handleMouseMove}
-      >
-        {/* Bezier lines */}
-        <For each={allParticipants()}>
-          {(participant, index) => {
-            const y = () => getRecipientY(index(), allParticipants().length);
-            const controlX1 = () => SENDER_X + 120;
-            const controlX2 = () => RECIPIENT_X - 120;
-            const path = () =>
-              `M ${senderBody.x} ${senderBody.y} C ${controlX1()} ${senderBody.y}, ${controlX2()} ${y()}, ${RECIPIENT_X} ${y()}`;
+      {/* Main layout: sender — lines — recipients */}
+      <div ref={containerRef} class="relative flex min-h-[200px] items-center gap-0">
 
-            // Update physics bodies
-            if (!bodies[index()]) {
-              bodies[index()] = {
-                restX: RECIPIENT_X,
-                restY: y(),
-                x: RECIPIENT_X,
-                y: y(),
-                vx: 0,
-                vy: 0,
-              };
-            }
-            bodies[index()]!.restY = y();
-
-            return (
-              <>
-                {/* Background line */}
-                <path
-                  d={path()}
-                  fill="none"
-                  stroke={getLineColor(participant.status)}
-                  stroke-width="2"
-                  stroke-dasharray={getLineStrokeDash(participant.status)}
-                  opacity="0.3"
+        {/* Sender (left) */}
+        <div class="z-10 flex shrink-0 flex-col items-center gap-2" style={{ width: "100px" }}>
+          <div class="relative">
+            <Show
+              when={props.session.senderAvatarUrl}
+              fallback={
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-card ring-2 ring-primary/50 text-xl font-semibold text-foreground">
+                  {(props.session.senderDisplayName ?? props.session.senderUsername ?? "?").charAt(0).toUpperCase()}
+                </div>
+              }
+            >
+              {(url) => (
+                <img
+                  src={url()}
+                  alt=""
+                  class="h-16 w-16 rounded-full object-cover ring-2 ring-primary/50"
                 />
+              )}
+            </Show>
+          </div>
+          <span class="max-w-[90px] truncate text-xs font-medium text-foreground">
+            {props.session.senderDisplayName ?? props.session.senderUsername ?? "You"}
+          </span>
+        </div>
 
-                {/* Progress fill line */}
-                <Show when={participant.status === "downloading" && participant.progress > 0}>
+        {/* SVG lines overlay */}
+        <svg
+          ref={svgRef}
+          class="pointer-events-none absolute inset-0 z-0"
+          style={{ width: "100%", height: "100%" }}
+        >
+          <For each={participants()}>
+            {(participant, index) => {
+              const total = () => participants().length;
+              // Calculate Y positions to match the recipient list layout
+              const recipientSpacing = () => {
+                const h = dimensions().height;
+                const t = total();
+                if (t <= 1) return h / 2;
+                return h / (t + 1);
+              };
+              const recipientY = () => recipientSpacing() * (index() + 1);
+              const senderY = () => dimensions().height / 2;
+              const leftX = 100;
+              const rightX = () => dimensions().width - 100;
+
+              const pathD = () => {
+                const sx = leftX;
+                const sy = senderY();
+                const ex = rightX();
+                const ey = recipientY();
+                const cx1 = sx + (ex - sx) * 0.35;
+                const cx2 = sx + (ex - sx) * 0.65;
+                return `M ${sx} ${sy} C ${cx1} ${sy}, ${cx2} ${ey}, ${ex} ${ey}`;
+              };
+
+              return (
+                <>
+                  {/* Background line */}
                   <path
-                    d={path()}
+                    d={pathD()}
                     fill="none"
                     stroke={getLineColor(participant.status)}
-                    stroke-width="2.5"
-                    stroke-dasharray={`${participant.progress * 100}% ${100}%`}
-                    pathLength={100}
+                    stroke-width="1.5"
+                    stroke-dasharray={participant.status === "invited" || participant.status === "joined" ? "6 4" : "none"}
+                    opacity="0.25"
                   />
-                </Show>
 
-                {/* Complete line */}
-                <Show when={participant.status === "complete"}>
-                  <path
-                    d={path()}
-                    fill="none"
-                    stroke={getLineColor(participant.status)}
-                    stroke-width="2.5"
-                  />
-                </Show>
+                  {/* Progress fill */}
+                  <Show when={participant.status === "downloading" && participant.progress > 0}>
+                    <path
+                      d={pathD()}
+                      fill="none"
+                      stroke={getLineColor("downloading")}
+                      stroke-width="2"
+                      stroke-dasharray={`${participant.progress * 100} ${100}`}
+                      pathLength={100}
+                    />
+                  </Show>
 
-                {/* Flowing particles for active transfers */}
-                <Show when={participant.status === "downloading"}>
-                  <circle r="3" fill={getLineColor("downloading")} opacity="0.8">
-                    <animateMotion dur="2s" repeatCount="indefinite" path={path()} />
-                  </circle>
-                  <circle r="2" fill={getLineColor("downloading")} opacity="0.5">
-                    <animateMotion dur="2s" repeatCount="indefinite" path={path()} begin="0.7s" />
-                  </circle>
-                  <circle r="2" fill={getLineColor("downloading")} opacity="0.3">
-                    <animateMotion dur="2s" repeatCount="indefinite" path={path()} begin="1.4s" />
-                  </circle>
-                </Show>
-              </>
-            );
-          }}
-        </For>
+                  {/* Complete line */}
+                  <Show when={participant.status === "complete"}>
+                    <path
+                      d={pathD()}
+                      fill="none"
+                      stroke={getLineColor("complete")}
+                      stroke-width="2"
+                    />
+                  </Show>
 
-        {/* Sender avatar */}
-        <g transform={`translate(${senderBody.x - AVATAR_SIZE_SENDER / 2}, ${senderBody.y - AVATAR_SIZE_SENDER / 2})`}>
-          <circle
-            cx={AVATAR_SIZE_SENDER / 2}
-            cy={AVATAR_SIZE_SENDER / 2}
-            r={AVATAR_SIZE_SENDER / 2}
-            fill="oklch(0.21 0.018 155)"
-            stroke="oklch(0.66 0.17 155)"
-            stroke-width="2"
-          />
+                  {/* Particles */}
+                  <Show when={participant.status === "downloading"}>
+                    <circle r="2.5" fill={getLineColor("downloading")} opacity="0.8">
+                      <animateMotion dur="2s" repeatCount="indefinite" path={pathD()} />
+                    </circle>
+                    <circle r="1.5" fill={getLineColor("downloading")} opacity="0.4">
+                      <animateMotion dur="2s" repeatCount="indefinite" path={pathD()} begin="0.7s" />
+                    </circle>
+                  </Show>
+                </>
+              );
+            }}
+          </For>
+        </svg>
+
+        {/* Spacer for lines */}
+        <div class="min-w-0 flex-1" />
+
+        {/* Recipients (right) */}
+        <div class="z-10 flex shrink-0 flex-col items-center gap-3" style={{ width: "100px" }}>
           <Show
-            when={props.session.senderAvatarUrl}
+            when={participants().length > 0}
             fallback={
-              <text
-                x={AVATAR_SIZE_SENDER / 2}
-                y={AVATAR_SIZE_SENDER / 2 + 6}
-                text-anchor="middle"
-                fill="oklch(0.955 0.008 155)"
-                font-size="24"
-                font-weight="600"
-              >
-                {(props.session.senderDisplayName ?? props.session.senderUsername ?? "?").charAt(0).toUpperCase()}
-              </text>
+              <div class="flex h-full items-center">
+                <p class="text-xs text-muted-foreground">Waiting for<br />recipients...</p>
+              </div>
             }
           >
-            {(url) => (
-              <>
-                <defs>
-                  <clipPath id="sender-clip">
-                    <circle cx={AVATAR_SIZE_SENDER / 2} cy={AVATAR_SIZE_SENDER / 2} r={AVATAR_SIZE_SENDER / 2 - 1} />
-                  </clipPath>
-                </defs>
-                <image
-                  href={url()}
-                  x="1"
-                  y="1"
-                  width={AVATAR_SIZE_SENDER - 2}
-                  height={AVATAR_SIZE_SENDER - 2}
-                  clip-path="url(#sender-clip)"
-                />
-              </>
-            )}
-          </Show>
-        </g>
-
-        {/* Sender label */}
-        <text
-          x={senderBody.x}
-          y={senderBody.y + AVATAR_SIZE_SENDER / 2 + 18}
-          text-anchor="middle"
-          fill="oklch(0.955 0.008 155)"
-          font-size="12"
-          font-weight="500"
-        >
-          {props.session.senderDisplayName ?? props.session.senderUsername ?? "You"}
-        </text>
-
-        {/* Recipient avatars */}
-        <For each={allParticipants()}>
-          {(participant, index) => {
-            const y = () => getRecipientY(index(), allParticipants().length);
-            const body = () => bodies[index()];
-
-            const statusLabel = () => {
-              switch (participant.status) {
-                case "invited": return "Invited";
-                case "joined": return "Joined";
-                case "downloading": return `${Math.round(participant.progress * 100)}%`;
-                case "complete": return "Shared";
-                case "error": return "Error";
-                default: return "";
-              }
-            };
-
-            return (
-              <g transform={`translate(${(body()?.x ?? RECIPIENT_X) - AVATAR_SIZE_RECIPIENT / 2}, ${(body()?.y ?? y()) - AVATAR_SIZE_RECIPIENT / 2})`}>
-                <circle
-                  cx={AVATAR_SIZE_RECIPIENT / 2}
-                  cy={AVATAR_SIZE_RECIPIENT / 2}
-                  r={AVATAR_SIZE_RECIPIENT / 2}
-                  fill="oklch(0.21 0.018 155)"
-                  stroke={getLineColor(participant.status)}
-                  stroke-width="2"
-                />
-                <Show
-                  when={participant.avatarUrl}
-                  fallback={
-                    <text
-                      x={AVATAR_SIZE_RECIPIENT / 2}
-                      y={AVATAR_SIZE_RECIPIENT / 2 + 5}
-                      text-anchor="middle"
-                      fill="oklch(0.955 0.008 155)"
-                      font-size="18"
-                      font-weight="600"
+            <For each={participants()}>
+              {(participant) => (
+                <div class="flex flex-col items-center gap-1">
+                  <div class="relative">
+                    <Show
+                      when={participant.avatarUrl}
+                      fallback={
+                        <div class={`flex h-12 w-12 items-center justify-center rounded-full bg-card text-sm font-semibold text-foreground ${getBorderClass(participant.status)}`}>
+                          {(participant.displayName ?? participant.username ?? "?").charAt(0).toUpperCase()}
+                        </div>
+                      }
                     >
-                      {(participant.displayName ?? participant.username ?? "?").charAt(0).toUpperCase()}
-                    </text>
-                  }
-                >
-                  {(url) => (
-                    <>
-                      <defs>
-                        <clipPath id={`recipient-clip-${index()}`}>
-                          <circle cx={AVATAR_SIZE_RECIPIENT / 2} cy={AVATAR_SIZE_RECIPIENT / 2} r={AVATAR_SIZE_RECIPIENT / 2 - 1} />
-                        </clipPath>
-                      </defs>
-                      <image
-                        href={url()}
-                        x="1"
-                        y="1"
-                        width={AVATAR_SIZE_RECIPIENT - 2}
-                        height={AVATAR_SIZE_RECIPIENT - 2}
-                        clip-path={`url(#recipient-clip-${index()})`}
-                      />
-                    </>
-                  )}
-                </Show>
-
-                {/* Username */}
-                <text
-                  x={AVATAR_SIZE_RECIPIENT / 2}
-                  y={AVATAR_SIZE_RECIPIENT + 14}
-                  text-anchor="middle"
-                  fill="oklch(0.955 0.008 155)"
-                  font-size="11"
-                  font-weight="500"
-                >
-                  {participant.displayName ?? participant.username}
-                </text>
-
-                {/* Status label */}
-                <text
-                  x={AVATAR_SIZE_RECIPIENT / 2}
-                  y={AVATAR_SIZE_RECIPIENT + 26}
-                  text-anchor="middle"
-                  fill={getLineColor(participant.status)}
-                  font-size="10"
-                >
-                  {statusLabel()}
-                </text>
-
-                {/* Speed for active downloads */}
-                <Show when={participant.status === "downloading" && participant.speed > 0}>
-                  <text
-                    x={AVATAR_SIZE_RECIPIENT / 2}
-                    y={AVATAR_SIZE_RECIPIENT + 38}
-                    text-anchor="middle"
-                    fill="oklch(0.62 0.008 155)"
-                    font-size="9"
-                  >
-                    {formatBytes(participant.speed)}/s
-                  </text>
-                </Show>
-              </g>
-            );
-          }}
-        </For>
-      </svg>
-
-      {/* Empty state when no participants */}
-      <Show when={allParticipants().length === 0}>
-        <div class="flex flex-col items-center justify-center py-8">
-          <p class="text-sm text-muted-foreground">Waiting for recipients to join...</p>
+                      {(url) => (
+                        <img
+                          src={url()}
+                          alt=""
+                          class={`h-12 w-12 rounded-full object-cover ${getBorderClass(participant.status)}`}
+                        />
+                      )}
+                    </Show>
+                  </div>
+                  <span class="max-w-[90px] truncate text-[11px] font-medium text-foreground">
+                    {participant.displayName ?? participant.username}
+                  </span>
+                  <span class={`text-[10px] ${getStatusClass(participant.status)}`}>
+                    {getStatusLabel(participant.status, participant.progress)}
+                  </span>
+                  <Show when={participant.status === "downloading" && participant.speed > 0}>
+                    <span class="text-[9px] text-muted-foreground">
+                      {formatBytes(participant.speed)}/s
+                    </span>
+                  </Show>
+                </div>
+              )}
+            </For>
+          </Show>
         </div>
-      </Show>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/modals/FileReceiveModal.tsx
+++ b/apps/web/src/components/modals/FileReceiveModal.tsx
@@ -1,0 +1,154 @@
+import { Show, onCleanup } from "solid-js";
+import { Portal } from "solid-js/web";
+import {
+  getSession,
+  activeReceiverSessionId,
+  clearReceiverSession,
+  leaveSession,
+  saveReceivedFile,
+} from "../../stores/share-session-store.js";
+import { formatBytes } from "../FileMessage.js";
+import { Button } from "../ui/button.js";
+
+const FileReceiveModal = () => {
+  const sessionId = () => activeReceiverSessionId();
+  const session = () => {
+    const id = sessionId();
+    return id ? getSession(id) : undefined;
+  };
+
+  const handleClose = () => {
+    const id = sessionId();
+    if (id) {
+      const s = session();
+      // Only send leave if session is still active (not already closed/complete)
+      if (s && s.status === "sharing") {
+        leaveSession(id);
+      }
+    }
+    clearReceiverSession();
+  };
+
+  const handleSave = () => {
+    const id = sessionId();
+    if (id) saveReceivedFile(id);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") handleClose();
+  };
+
+  const mount = () => document.addEventListener("keydown", handleKeyDown);
+  const unmount = () => document.removeEventListener("keydown", handleKeyDown);
+  mount();
+  onCleanup(unmount);
+
+  return (
+    <Show when={session()}>
+      {(s) => (
+        <Portal mount={document.body}>
+          <div class="fixed inset-0 z-50 flex items-center justify-center">
+            <div class="fixed inset-0 bg-black/50 backdrop-blur-sm" />
+
+            <div
+              class="relative z-10 mx-4 w-full max-w-md rounded-xl border border-border bg-card p-6 shadow-lg animate-scale-in sm:mx-0"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Header */}
+              <div class="mb-4 flex items-center justify-between">
+                <h2 class="text-lg font-semibold text-foreground">Receiving File</h2>
+                <button
+                  onClick={handleClose}
+                  class="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  title="Close"
+                  aria-label="Close"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+
+              {/* Sender info */}
+              <div class="mb-4 flex items-center gap-3">
+                <Show
+                  when={s().senderAvatarUrl}
+                  fallback={
+                    <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground">
+                      {(s().senderDisplayName ?? s().senderUsername ?? "?").charAt(0).toUpperCase()}
+                    </div>
+                  }
+                >
+                  {(url) => (
+                    <img src={url()} alt="" class="h-10 w-10 rounded-full object-cover" />
+                  )}
+                </Show>
+                <div>
+                  <p class="text-sm font-medium text-foreground">
+                    {s().senderDisplayName ?? s().senderUsername}
+                  </p>
+                  <p class="text-xs text-muted-foreground">is sharing a file with you</p>
+                </div>
+              </div>
+
+              {/* File info */}
+              <div class="mb-4 rounded-lg bg-muted/30 px-4 py-3">
+                <p class="text-sm font-medium text-foreground">{s().fileName}</p>
+                <p class="text-xs text-muted-foreground">{formatBytes(s().fileSize)}</p>
+              </div>
+
+              {/* Status-specific content */}
+              <Show when={s().status === "closed" && !s().downloadedFile}>
+                <div class="mb-4 rounded-lg bg-muted/30 px-4 py-3 text-center">
+                  <p class="text-sm text-muted-foreground">Share session ended</p>
+                </div>
+              </Show>
+
+              <Show when={s().status === "sharing"}>
+                {/* Progress bar */}
+                <div class="mb-2">
+                  <div class="mb-1 flex justify-between text-xs text-muted-foreground">
+                    <span>{Math.round(s().receiverProgress * 100)}%</span>
+                    <Show when={s().receiverSpeed > 0}>
+                      <span>{formatBytes(s().receiverSpeed)}/s</span>
+                    </Show>
+                  </div>
+                  <div class="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      class="h-full rounded-full bg-primary transition-all duration-300"
+                      style={{ width: `${Math.round(s().receiverProgress * 100)}%` }}
+                    />
+                  </div>
+                </div>
+                <p class="mb-4 text-xs text-muted-foreground">
+                  Downloading via P2P...
+                </p>
+              </Show>
+
+              {/* Actions */}
+              <div class="flex justify-end gap-3">
+                <Show when={s().status === "closed" || s().status === "complete"}>
+                  <Show when={s().downloadedFile}>
+                    <Button onClick={handleSave}>
+                      Save to Device
+                    </Button>
+                  </Show>
+                  <Button variant="secondary" onClick={handleClose}>
+                    Dismiss
+                  </Button>
+                </Show>
+                <Show when={s().status === "sharing" && s().receiverProgress < 1}>
+                  <Button variant="secondary" onClick={handleClose}>
+                    Leave
+                  </Button>
+                </Show>
+              </div>
+            </div>
+          </div>
+        </Portal>
+      )}
+    </Show>
+  );
+};
+
+export default FileReceiveModal;

--- a/apps/web/src/components/modals/ShareFileModal.tsx
+++ b/apps/web/src/components/modals/ShareFileModal.tsx
@@ -1,6 +1,6 @@
 import { createSignal, createMemo, For, Show, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
-// MAX_FILE_SIZE_BYTES used for server channel shares; DM sessions use MAX_SINGLE_FILE_SIZE below
+import { MAX_FILE_SIZE_BYTES } from "@uncorded/shared";
 import { readyData } from "../../lib/gateway-store.js";
 import {
   createSession,
@@ -13,7 +13,8 @@ import { Button } from "../ui/button.js";
 import { Input } from "../ui/input.js";
 import ShareVisualization from "../ShareVisualization.js";
 
-const MAX_SINGLE_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
+// Use the canonical protocol limit (1 GiB) to match server-side validation
+const MAX_SINGLE_FILE_SIZE = MAX_FILE_SIZE_BYTES;
 
 interface Props {
   onClose: () => void;
@@ -70,7 +71,10 @@ const ShareFileModal = (props: Props) => {
 
   const friends = createMemo(() => {
     const all = readyData.data?.friends ?? [];
-    return all.filter((f) => f.friendshipStatus === "accepted");
+    // P2P requires both peers online — only show online/idle friends
+    return all.filter(
+      (f) => f.friendshipStatus === "accepted" && (f.status === "online" || f.status === "idle"),
+    );
   });
 
   const filteredFriends = createMemo(() => {

--- a/apps/web/src/components/modals/ShareFileModal.tsx
+++ b/apps/web/src/components/modals/ShareFileModal.tsx
@@ -155,12 +155,8 @@ const ShareFileModal = (props: Props) => {
     if (e.key === "Escape") handleClose();
   };
 
-  // Prevent Escape from closing during active sharing
-  const onMount = () => document.addEventListener("keydown", handleKeyDown);
-  const onUnmount = () => document.removeEventListener("keydown", handleKeyDown);
-
-  onCleanup(onUnmount);
-  onMount();
+  document.addEventListener("keydown", handleKeyDown);
+  onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
 
   // ── File input ref ────────────────────────────────────────────────────
 
@@ -302,6 +298,11 @@ const ShareFileModal = (props: Props) => {
                 }
               >
                 <div class="max-h-60 space-y-1 overflow-y-auto">
+                  <Show when={filteredFriends().length === 0 && searchQuery().trim()}>
+                    <p class="py-4 text-center text-sm text-muted-foreground">
+                      No friends match your search
+                    </p>
+                  </Show>
                   <For each={filteredFriends()}>
                     {(friend) => (
                       <button

--- a/apps/web/src/components/modals/ShareFileModal.tsx
+++ b/apps/web/src/components/modals/ShareFileModal.tsx
@@ -69,11 +69,15 @@ const ShareFileModal = (props: Props) => {
 
   // ── Friend Selection ──────────────────────────────────────────────────
 
-  const friends = createMemo(() => {
+  const allAcceptedFriends = createMemo(() => {
     const all = readyData.data?.friends ?? [];
+    return all.filter((f) => f.friendshipStatus === "accepted");
+  });
+
+  const friends = createMemo(() => {
     // P2P requires both peers online — only show online/idle friends
-    return all.filter(
-      (f) => f.friendshipStatus === "accepted" && (f.status === "online" || f.status === "idle"),
+    return allAcceptedFriends().filter(
+      (f) => f.status === "online" || f.status === "idle",
     );
   });
 
@@ -291,7 +295,9 @@ const ShareFileModal = (props: Props) => {
                 when={friends().length > 0}
                 fallback={
                   <p class="py-8 text-center text-sm text-muted-foreground">
-                    No friends yet. Add friends to share files with them.
+                    {allAcceptedFriends().length === 0
+                      ? "No friends yet. Add friends to share files with them."
+                      : "No friends are currently online."}
                   </p>
                 }
               >

--- a/apps/web/src/components/modals/ShareFileModal.tsx
+++ b/apps/web/src/components/modals/ShareFileModal.tsx
@@ -173,6 +173,9 @@ const ShareFileModal = (props: Props) => {
 
         {/* Modal */}
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Send File"
           class="relative z-10 mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-border bg-card shadow-lg animate-scale-in sm:mx-0"
           onClick={(e) => e.stopPropagation()}
         >
@@ -329,8 +332,7 @@ const ShareFileModal = (props: Props) => {
                             )}
                           </Show>
                           <div class={`absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-card ${
-                            friend.status === "online" ? "bg-success" :
-                            friend.status === "idle" ? "bg-warning" : "bg-muted-foreground/30"
+                            friend.status === "online" ? "bg-success" : "bg-warning"
                           }`} />
                         </div>
                         <div class="min-w-0 flex-1">

--- a/apps/web/src/components/modals/ShareFileModal.tsx
+++ b/apps/web/src/components/modals/ShareFileModal.tsx
@@ -1,0 +1,409 @@
+import { createSignal, createMemo, For, Show, onCleanup } from "solid-js";
+import { Portal } from "solid-js/web";
+// MAX_FILE_SIZE_BYTES used for server channel shares; DM sessions use MAX_SINGLE_FILE_SIZE below
+import { readyData } from "../../lib/gateway-store.js";
+import {
+  createSession,
+  closeSession,
+  activeSenderSessionId,
+  getSession,
+} from "../../stores/share-session-store.js";
+import { formatBytes } from "../FileMessage.js";
+import { Button } from "../ui/button.js";
+import { Input } from "../ui/input.js";
+import ShareVisualization from "../ShareVisualization.js";
+
+const MAX_SINGLE_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
+
+interface Props {
+  onClose: () => void;
+}
+
+type Step = "file" | "friends" | "sharing";
+
+const ShareFileModal = (props: Props) => {
+  const [step, setStep] = createSignal<Step>("file");
+  const [selectedFile, setSelectedFile] = createSignal<File | null>(null);
+  const [selectedFriends, setSelectedFriends] = createSignal<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = createSignal("");
+  const [error, setError] = createSignal("");
+  const [loading, setLoading] = createSignal(false);
+  const [isDragging, setIsDragging] = createSignal(false);
+  const [showCloseConfirm, setShowCloseConfirm] = createSignal(false);
+
+  // ── File Selection ──────────────────────────────────────────────────────
+
+  const validateFile = (file: File): string | null => {
+    if (file.size > MAX_SINGLE_FILE_SIZE) {
+      return `File too large. Maximum size is ${formatBytes(MAX_SINGLE_FILE_SIZE)}.`;
+    }
+    if (file.size === 0) {
+      return "Cannot share an empty file.";
+    }
+    return null;
+  };
+
+  const handleFileSelect = (file: File) => {
+    const err = validateFile(file);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError("");
+    setSelectedFile(file);
+  };
+
+  const handleFileDrop = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer?.files[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleFileInput = (e: Event) => {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) handleFileSelect(file);
+  };
+
+  // ── Friend Selection ──────────────────────────────────────────────────
+
+  const friends = createMemo(() => {
+    const all = readyData.data?.friends ?? [];
+    return all.filter((f) => f.friendshipStatus === "accepted");
+  });
+
+  const filteredFriends = createMemo(() => {
+    const q = searchQuery().toLowerCase().trim();
+    if (!q) return friends();
+    return friends().filter(
+      (f) =>
+        (f.username?.toLowerCase().includes(q)) ||
+        (f.displayName?.toLowerCase().includes(q)),
+    );
+  });
+
+  const toggleFriend = (userId: string) => {
+    setSelectedFriends((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
+      } else {
+        next.add(userId);
+      }
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    const ids = new Set<string>();
+    for (const f of friends()) ids.add(f.userId);
+    setSelectedFriends(ids);
+  };
+
+  const deselectAll = () => {
+    setSelectedFriends(new Set<string>());
+  };
+
+  // ── Start Sharing ───────────────────────────────────────────────────────
+
+  const handleStartSharing = async () => {
+    const file = selectedFile();
+    if (!file || selectedFriends().size === 0) return;
+
+    setLoading(true);
+    setError("");
+
+    try {
+      await createSession(file, [...selectedFriends()]);
+      setStep("sharing");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start sharing");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // ── Close Handling ────────────────────────────────────────────────────
+
+  const handleClose = () => {
+    if (step() === "sharing" && activeSenderSessionId()) {
+      setShowCloseConfirm(true);
+      return;
+    }
+    props.onClose();
+  };
+
+  const confirmClose = () => {
+    const sessionId = activeSenderSessionId();
+    if (sessionId) {
+      closeSession(sessionId);
+    }
+    setShowCloseConfirm(false);
+    props.onClose();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") handleClose();
+  };
+
+  // Prevent Escape from closing during active sharing
+  const onMount = () => document.addEventListener("keydown", handleKeyDown);
+  const onUnmount = () => document.removeEventListener("keydown", handleKeyDown);
+
+  onCleanup(onUnmount);
+  onMount();
+
+  // ── File input ref ────────────────────────────────────────────────────
+
+  let fileInputRef!: HTMLInputElement;
+
+  return (
+    <Portal mount={document.body}>
+      <div class="fixed inset-0 z-50 flex items-center justify-center">
+        {/* Backdrop */}
+        <div
+          class="fixed inset-0 bg-black/60 backdrop-blur-sm"
+          onClick={step() !== "sharing" ? handleClose : undefined}
+        />
+
+        {/* Modal */}
+        <div
+          class="relative z-10 mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-border bg-card shadow-lg animate-scale-in sm:mx-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div class="flex items-center justify-between border-b border-border px-6 py-4">
+            <h2 class="text-xl font-semibold text-foreground">
+              <Show when={step() === "file"}>Select a File</Show>
+              <Show when={step() === "friends"}>Choose Recipients</Show>
+              <Show when={step() === "sharing"}>Sharing</Show>
+            </h2>
+            <button
+              onClick={handleClose}
+              class="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              title="Close"
+              aria-label="Close"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Content */}
+          <div class="flex-1 overflow-y-auto p-6">
+            {/* Step 1: File Selection */}
+            <Show when={step() === "file"}>
+              <div
+                class={`flex flex-col items-center justify-center rounded-lg border-2 border-dashed p-12 transition-colors ${
+                  isDragging() ? "border-primary bg-primary/5" : "border-border"
+                }`}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setIsDragging(true);
+                }}
+                onDragLeave={() => setIsDragging(false)}
+                onDrop={handleFileDrop}
+              >
+                <Show
+                  when={selectedFile()}
+                  fallback={
+                    <>
+                      <svg xmlns="http://www.w3.org/2000/svg" class="mb-4 h-12 w-12 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                      </svg>
+                      <p class="mb-2 text-sm text-foreground">Drag and drop a file here</p>
+                      <p class="mb-4 text-xs text-muted-foreground">or click to browse</p>
+                    </>
+                  }
+                >
+                  {(file) => (
+                    <div class="text-center">
+                      <p class="mb-1 text-sm font-medium text-foreground">{file().name}</p>
+                      <p class="mb-3 text-xs text-muted-foreground">{formatBytes(file().size)}</p>
+                      <button
+                        onClick={() => setSelectedFile(null)}
+                        class="text-xs text-muted-foreground underline hover:text-foreground"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  )}
+                </Show>
+
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  class="hidden"
+                  onChange={handleFileInput}
+                />
+
+                <Show when={!selectedFile()}>
+                  <Button variant="secondary" size="sm" onClick={() => fileInputRef.click()}>
+                    Browse Files
+                  </Button>
+                </Show>
+              </div>
+
+              <Show when={error()}>
+                <p class="mt-3 text-sm text-destructive-foreground">{error()}</p>
+              </Show>
+
+              <p class="mt-4 text-xs text-muted-foreground">
+                Files are transferred directly between you and your friends via P2P (peer-to-peer).
+                Your IP address will be visible to recipients.
+              </p>
+
+              <div class="mt-6 flex justify-end">
+                <Button
+                  onClick={() => setStep("friends")}
+                  disabled={!selectedFile()}
+                >
+                  Next
+                </Button>
+              </div>
+            </Show>
+
+            {/* Step 2: Friend Selection */}
+            <Show when={step() === "friends"}>
+              <div class="mb-4 flex items-center gap-2">
+                <Input
+                  type="text"
+                  placeholder="Search friends..."
+                  value={searchQuery()}
+                  onInput={(e) => setSearchQuery(e.currentTarget.value)}
+                  class="flex-1"
+                />
+                <Button variant="ghost" size="sm" onClick={selectAll}>Select All</Button>
+                <Button variant="ghost" size="sm" onClick={deselectAll}>Clear</Button>
+              </div>
+
+              <div class="mb-4 text-sm text-muted-foreground">
+                {selectedFriends().size} friend{selectedFriends().size !== 1 ? "s" : ""} selected
+              </div>
+
+              <Show
+                when={friends().length > 0}
+                fallback={
+                  <p class="py-8 text-center text-sm text-muted-foreground">
+                    No friends yet. Add friends to share files with them.
+                  </p>
+                }
+              >
+                <div class="max-h-60 space-y-1 overflow-y-auto">
+                  <For each={filteredFriends()}>
+                    {(friend) => (
+                      <button
+                        class={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors ${
+                          selectedFriends().has(friend.userId) ? "bg-primary/10" : "hover:bg-accent"
+                        }`}
+                        onClick={() => toggleFriend(friend.userId)}
+                      >
+                        <div class="relative">
+                          <Show
+                            when={friend.avatarUrl}
+                            fallback={
+                              <div class="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
+                                {(friend.displayName ?? friend.username ?? "?").charAt(0).toUpperCase()}
+                              </div>
+                            }
+                          >
+                            {(url) => (
+                              <img
+                                src={url()}
+                                alt=""
+                                class="h-8 w-8 rounded-full object-cover"
+                              />
+                            )}
+                          </Show>
+                          <div class={`absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-card ${
+                            friend.status === "online" ? "bg-success" :
+                            friend.status === "idle" ? "bg-warning" : "bg-muted-foreground/30"
+                          }`} />
+                        </div>
+                        <div class="min-w-0 flex-1">
+                          <p class="truncate text-sm font-medium text-foreground">
+                            {friend.displayName ?? friend.username}
+                          </p>
+                          <Show when={friend.displayName && friend.username}>
+                            <p class="truncate text-xs text-muted-foreground">{friend.username}</p>
+                          </Show>
+                        </div>
+                        <div class={`flex h-5 w-5 items-center justify-center rounded border transition-colors ${
+                          selectedFriends().has(friend.userId)
+                            ? "border-primary bg-primary"
+                            : "border-border"
+                        }`}>
+                          <Show when={selectedFriends().has(friend.userId)}>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-primary-foreground" viewBox="0 0 20 20" fill="currentColor">
+                              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                            </svg>
+                          </Show>
+                        </div>
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </Show>
+
+              <Show when={error()}>
+                <p class="mt-3 text-sm text-destructive-foreground">{error()}</p>
+              </Show>
+
+              <div class="mt-6 flex justify-between">
+                <Button variant="secondary" onClick={() => setStep("file")}>
+                  Back
+                </Button>
+                <Button
+                  onClick={handleStartSharing}
+                  disabled={selectedFriends().size === 0 || loading()}
+                >
+                  <Show when={loading()} fallback="Start Sharing">
+                    <div class="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
+                    Starting...
+                  </Show>
+                </Button>
+              </div>
+            </Show>
+
+            {/* Step 3: Live Transfer */}
+            <Show when={step() === "sharing" && activeSenderSessionId()}>
+              {(sessionId) => {
+                const session = () => getSession(sessionId());
+                return (
+                  <Show when={session()}>
+                    {(s) => <ShareVisualization session={s()} />}
+                  </Show>
+                );
+              }}
+            </Show>
+          </div>
+        </div>
+
+        {/* Close confirmation dialog */}
+        <Show when={showCloseConfirm()}>
+          <div class="fixed inset-0 z-[60] flex items-center justify-center">
+            <div class="fixed inset-0 bg-black/50" onClick={() => setShowCloseConfirm(false)} />
+            <div class="relative z-10 mx-4 w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-lg" onClick={(e) => e.stopPropagation()}>
+              <h3 class="mb-2 text-lg font-semibold text-foreground">End Share Session?</h3>
+              <p class="mb-4 text-sm text-muted-foreground">
+                Closing will end the share session for everyone. Recipients who haven't finished downloading will lose access.
+              </p>
+              <div class="flex justify-end gap-3">
+                <Button variant="secondary" onClick={() => setShowCloseConfirm(false)}>
+                  Cancel
+                </Button>
+                <Button variant="destructive" onClick={confirmClose}>
+                  End Session
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Show>
+      </div>
+    </Portal>
+  );
+};
+
+export default ShareFileModal;

--- a/apps/web/src/components/settings/transfer-history.tsx
+++ b/apps/web/src/components/settings/transfer-history.tsx
@@ -1,0 +1,202 @@
+import { createSignal, createResource, For, Show } from "solid-js";
+import { api } from "../../lib/api.js";
+import { readyData } from "../../lib/gateway-store.js";
+import { Button } from "../ui/button.js";
+import { Empty } from "../ui/empty.js";
+import { formatBytes } from "../FileMessage.js";
+
+type FilterType = "all" | "sent" | "received";
+
+interface FileReceiptResponse {
+  id: string;
+  fileName: string;
+  fileSize: number;
+  contentType: string;
+  senderId: string | null;
+  senderUsername: string | null;
+  receiverId: string | null;
+  receiverUsername: string | null;
+  createdAt: string | null;
+}
+
+interface ReceiptsResponse {
+  receipts: FileReceiptResponse[];
+  hasMore: boolean;
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getFileIcon(contentType: string): string {
+  if (contentType.startsWith("image/")) return "image";
+  if (contentType.startsWith("video/")) return "video";
+  if (contentType.startsWith("audio/")) return "audio";
+  return "file";
+}
+
+const TransferHistory = () => {
+  const [filter, setFilter] = createSignal<FilterType>("all");
+  const [allReceipts, setAllReceipts] = createSignal<FileReceiptResponse[]>([]);
+  const [cursor, setCursor] = createSignal<string | undefined>(undefined);
+  const [hasMore, setHasMore] = createSignal(false);
+  const [loadingMore, setLoadingMore] = createSignal(false);
+
+  const currentUserId = () => readyData.data?.user.id;
+
+  const fetchReceipts = async (type: FilterType) => {
+    const data = await api<ReceiptsResponse>(
+      `/api/file-receipts?type=${type}`,
+    );
+    setAllReceipts(data.receipts);
+    setHasMore(data.hasMore);
+    if (data.receipts.length > 0) {
+      const last = data.receipts[data.receipts.length - 1];
+      setCursor(last?.createdAt ?? undefined);
+    }
+    return data;
+  };
+
+  const [receiptsResource] = createResource(filter, fetchReceipts);
+
+  const loadMore = async () => {
+    if (!hasMore() || loadingMore()) return;
+    setLoadingMore(true);
+    try {
+      const c = cursor();
+      const data = await api<ReceiptsResponse>(
+        `/api/file-receipts?type=${filter()}${c ? `&cursor=${encodeURIComponent(c)}` : ""}`,
+      );
+      setAllReceipts((prev) => [...prev, ...data.receipts]);
+      setHasMore(data.hasMore);
+      if (data.receipts.length > 0) {
+        const last = data.receipts[data.receipts.length - 1];
+        setCursor(last?.createdAt ?? undefined);
+      }
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2 class="mb-1 text-xl font-semibold text-foreground">Transfer History</h2>
+      <p class="mb-6 text-sm text-muted-foreground">
+        Files you've sent and received via P2P sharing.
+      </p>
+
+      {/* Filter buttons */}
+      <div class="mb-4 flex gap-1">
+        {(["all", "sent", "received"] as const).map((type) => (
+          <button
+            class={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+              filter() === type
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground"
+            }`}
+            onClick={() => setFilter(type)}
+          >
+            {type.charAt(0).toUpperCase() + type.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Loading state */}
+      <Show when={receiptsResource.loading && allReceipts().length === 0}>
+        <div class="flex items-center justify-center py-12">
+          <div class="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      </Show>
+
+      {/* Empty state */}
+      <Show when={!receiptsResource.loading && allReceipts().length === 0}>
+        <Empty
+          title="No file transfers yet"
+          description="Files you send or receive will appear here."
+          icon={
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+            </svg>
+          }
+        />
+      </Show>
+
+      {/* Receipt list */}
+      <Show when={allReceipts().length > 0}>
+        <div class="space-y-2">
+          <For each={allReceipts()}>
+            {(receipt) => {
+              const isSent = () => receipt.senderId === currentUserId();
+              const otherUsername = () =>
+                isSent() ? receipt.receiverUsername : receipt.senderUsername;
+
+              return (
+                <div class="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+                  {/* File type icon */}
+                  <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+                    <Show when={getFileIcon(receipt.contentType) === "image"} fallback={
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                    }>
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                      </svg>
+                    </Show>
+                  </div>
+
+                  {/* File info */}
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate text-sm font-medium text-foreground">{receipt.fileName}</p>
+                    <div class="flex items-center gap-2 text-xs text-muted-foreground">
+                      <span>{formatBytes(receipt.fileSize)}</span>
+                      <span>·</span>
+                      <span class={isSent() ? "text-info-foreground" : "text-success-foreground"}>
+                        {isSent() ? "Sent" : "Received"}
+                      </span>
+                      <Show when={otherUsername()}>
+                        <span>·</span>
+                        <span>{isSent() ? "to" : "from"} {otherUsername()}</span>
+                      </Show>
+                    </div>
+                  </div>
+
+                  {/* Date */}
+                  <p class="shrink-0 text-xs text-muted-foreground">
+                    {formatDate(receipt.createdAt)}
+                  </p>
+                </div>
+              );
+            }}
+          </For>
+
+          {/* Load more */}
+          <Show when={hasMore()}>
+            <div class="flex justify-center pt-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={loadMore}
+                disabled={loadingMore()}
+              >
+                <Show when={loadingMore()} fallback="Load More">
+                  Loading...
+                </Show>
+              </Button>
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default TransferHistory;

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -4,13 +4,15 @@ import { useNavigate } from "@solidjs/router";
 const ProfileSettings = lazy(() => import("../components/settings/profile-settings.js"));
 const AccountSettings = lazy(() => import("../components/settings/account-settings.js"));
 const AppearanceSettings = lazy(() => import("../components/settings/appearance-settings.js"));
+const TransferHistory = lazy(() => import("../components/settings/transfer-history.js"));
 
-type Tab = "profile" | "account" | "appearance";
+type Tab = "profile" | "account" | "appearance" | "transfers";
 
 const tabs: { id: Tab; label: string }[] = [
   { id: "profile", label: "Profile" },
   { id: "account", label: "Account" },
   { id: "appearance", label: "Appearance" },
+  { id: "transfers", label: "Transfers" },
 ];
 
 const tabId = (id: Tab) => `settings-tab-${id}`;
@@ -104,6 +106,9 @@ const Settings = () => {
           </Show>
           <Show when={activeTab() === "appearance"}>
             <AppearanceSettings />
+          </Show>
+          <Show when={activeTab() === "transfers"}>
+            <TransferHistory />
           </Show>
         </div>
       </div>

--- a/apps/web/src/stores/file-store.ts
+++ b/apps/web/src/stores/file-store.ts
@@ -50,7 +50,7 @@ export function cancelP2pDialog(): void {
   p2pReject = null;
 }
 
-async function ensureP2pAcknowledged(): Promise<void> {
+export async function ensureP2pAcknowledged(): Promise<void> {
   if (localStorage.getItem(P2P_ACK_KEY) === "true") return;
 
   return new Promise<void>((resolve, reject) => {

--- a/apps/web/src/stores/index.ts
+++ b/apps/web/src/stores/index.ts
@@ -7,6 +7,7 @@ import { setupPresenceStore } from "./presence-store.js";
 import { setupNotificationStore } from "./notification-store.js";
 import { setupGiftStore } from "./gift-store.js";
 import { setupDeletionStore } from "./deletion-store.js";
+import { setupShareSessionStore } from "./share-session-store.js";
 
 export {
   setupMessageStore,
@@ -18,6 +19,7 @@ export {
   setupNotificationStore,
   setupGiftStore,
   setupDeletionStore,
+  setupShareSessionStore,
 };
 
 export function setupStores() {
@@ -30,4 +32,5 @@ export function setupStores() {
   setupNotificationStore();
   setupGiftStore();
   setupDeletionStore();
+  setupShareSessionStore();
 }

--- a/apps/web/src/stores/share-session-store.ts
+++ b/apps/web/src/stores/share-session-store.ts
@@ -67,6 +67,19 @@ const [store, setStore] = createStore<ShareSessionStoreState>({
   sessions: {},
 });
 
+// Track download versions to ignore stale callbacks after leave/close
+const downloadVersions = new Map<string, number>();
+
+function nextDownloadVersion(sessionId: string): number {
+  const v = (downloadVersions.get(sessionId) ?? 0) + 1;
+  downloadVersions.set(sessionId, v);
+  return v;
+}
+
+function isCurrentDownload(sessionId: string, version: number): boolean {
+  return downloadVersions.get(sessionId) === version;
+}
+
 // Active sender session signal (only one at a time)
 const [activeSenderSessionId, setActiveSenderSessionId] = createSignal<string | null>(null);
 // Active receiver session signal
@@ -232,6 +245,9 @@ export function leaveSession(sessionId: string): void {
   const session = store.sessions[sessionId];
   if (!session) return;
 
+  // Invalidate any in-flight download callbacks
+  nextDownloadVersion(sessionId);
+
   sendFrame({
     op: Opcode.FILE_SESSION_LEAVE,
     d: { sessionId },
@@ -339,13 +355,18 @@ export function setupShareSessionStore(): void {
 
       setStore("sessions", d.sessionId, "magnetUri", d.magnetUri);
 
+      // Track version so stale callbacks after leave/close are ignored
+      const version = nextDownloadVersion(d.sessionId);
+
       // Start downloading via WebTorrent
       downloadFromMagnet(d.magnetUri, (progress, speed) => {
+        if (!isCurrentDownload(d.sessionId, version)) return;
         setStore("sessions", d.sessionId, "receiverProgress", progress);
         setStore("sessions", d.sessionId, "receiverSpeed", speed);
         sendProgressThrottled(d.sessionId, progress, speed);
       })
         .then((files) => {
+          if (!isCurrentDownload(d.sessionId, version)) return;
           const file = files[0];
           if (file) {
             setStore("sessions", d.sessionId, "downloadedFile", file);
@@ -360,6 +381,7 @@ export function setupShareSessionStore(): void {
           });
         })
         .catch((err) => {
+          if (!isCurrentDownload(d.sessionId, version)) return;
           if (import.meta.env.DEV) console.error("[share-session] Download error:", err);
           setStore("sessions", d.sessionId, "status", "closed");
         });
@@ -437,6 +459,9 @@ export function setupShareSessionStore(): void {
 
       const session = store.sessions[d.sessionId];
       if (!session) return;
+
+      // Invalidate in-flight download callbacks
+      nextDownloadVersion(d.sessionId);
 
       setStore("sessions", d.sessionId, "status", "closed");
 

--- a/apps/web/src/stores/share-session-store.ts
+++ b/apps/web/src/stores/share-session-store.ts
@@ -1,0 +1,478 @@
+import { createSignal } from "solid-js";
+import { createStore, produce } from "solid-js/store";
+import { Opcode } from "@uncorded/protocol";
+import { createId } from "@uncorded/shared";
+import { onGatewayEvent, sendFrame } from "../lib/gateway.js";
+import { readyData } from "../lib/gateway-store.js";
+import {
+  seedFile,
+  downloadFromMagnet,
+  stopSeeding,
+} from "../lib/torrent-client.js";
+import { computePdqHash } from "../lib/pdq-hash.js";
+import { api, ApiRequestError } from "../lib/api.js";
+import { showToast } from "../components/ui/toast.js";
+import {
+  ensureP2pAcknowledged,
+} from "./file-store.js";
+import {
+  fileSessionInviteEventSchema,
+  fileSessionJoinAcceptEventSchema,
+  fileSessionJoinedEventSchema,
+  fileSessionProgressEventSchema,
+  fileSessionCompleteEventSchema,
+  fileSessionCloseEventSchema,
+  fileSessionLeaveEventSchema,
+} from "@uncorded/protocol";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface ParticipantInfo {
+  userId: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  progress: number;
+  speed: number;
+  status: "invited" | "joined" | "downloading" | "complete" | "error";
+}
+
+export interface ShareSession {
+  id: string;
+  role: "sender" | "receiver";
+  fileName: string;
+  fileSize: number;
+  contentType: string;
+  magnetUri: string | null;
+  infoHash: string | null;
+  senderId: string;
+  senderUsername: string;
+  senderDisplayName: string | null;
+  senderAvatarUrl: string | null;
+  invitees: string[];
+  participants: Record<string, ParticipantInfo>;
+  status: "selecting" | "sharing" | "complete" | "closed";
+  downloadedFile: File | null;
+  receiverProgress: number;
+  receiverSpeed: number;
+}
+
+interface ShareSessionStoreState {
+  sessions: Record<string, ShareSession>;
+}
+
+// ── Store ───────────────────────────────────────────────────────────────────
+
+const [store, setStore] = createStore<ShareSessionStoreState>({
+  sessions: {},
+});
+
+// Active sender session signal (only one at a time)
+const [activeSenderSessionId, setActiveSenderSessionId] = createSignal<string | null>(null);
+// Active receiver session signal
+const [activeReceiverSessionId, setActiveReceiverSessionId] = createSignal<string | null>(null);
+// Pending invite for toast interaction
+const [pendingInvite, setPendingInvite] = createSignal<{
+  sessionId: string;
+  senderId: string;
+  senderUsername: string;
+  senderDisplayName: string | null;
+  senderAvatarUrl: string | null;
+  fileName: string;
+  fileSize: number;
+  contentType: string;
+} | null>(null);
+
+export {
+  activeSenderSessionId,
+  activeReceiverSessionId,
+  pendingInvite,
+};
+
+export function getSession(sessionId: string): ShareSession | undefined {
+  return store.sessions[sessionId];
+}
+
+export function clearReceiverSession(): void {
+  setActiveReceiverSessionId(null);
+}
+
+// ── Sender Actions ──────────────────────────────────────────────────────────
+
+export async function createSession(
+  file: File,
+  inviteeIds: string[],
+): Promise<string> {
+  await ensureP2pAcknowledged();
+
+  // CSAM hash check for images
+  const hash = await computePdqHash(file);
+  if (hash !== null) {
+    try {
+      const res = await api<{ blocked: boolean }>("/api/safety/check-hash", {
+        method: "POST",
+        body: JSON.stringify({ hash }),
+      });
+      if (res.blocked) {
+        showToast("This file cannot be shared", "error");
+        throw new Error("File blocked by safety check");
+      }
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        showToast("Safety check failed", "error");
+        throw err;
+      }
+      if (err instanceof Error && err.message === "File blocked by safety check") {
+        throw err;
+      }
+    }
+  }
+
+  // Seed via WebTorrent
+  const seedResult = await seedFile(file);
+
+  const sessionId = createId();
+  const currentUser = readyData.data?.user;
+
+  const session: ShareSession = {
+    id: sessionId,
+    role: "sender",
+    fileName: file.name,
+    fileSize: file.size,
+    contentType: file.type || "application/octet-stream",
+    magnetUri: seedResult.magnetUri,
+    infoHash: seedResult.infoHash,
+    senderId: currentUser?.id ?? "",
+    senderUsername: currentUser?.username ?? "",
+    senderDisplayName: currentUser?.displayName ?? null,
+    senderAvatarUrl: currentUser?.avatarUrl ?? null,
+    invitees: inviteeIds,
+    participants: {},
+    status: "sharing",
+    downloadedFile: null,
+    receiverProgress: 0,
+    receiverSpeed: 0,
+  };
+
+  // Pre-populate invitees as "invited" participants so they show in visualization
+  const friends = readyData.data?.friends ?? [];
+  for (const inviteeId of inviteeIds) {
+    const friend = friends.find((f) => f.userId === inviteeId);
+    session.participants[inviteeId] = {
+      userId: inviteeId,
+      username: friend?.username ?? "",
+      displayName: friend?.displayName ?? null,
+      avatarUrl: friend?.avatarUrl ?? null,
+      progress: 0,
+      speed: 0,
+      status: "invited",
+    };
+  }
+
+  setStore("sessions", sessionId, session);
+  setActiveSenderSessionId(sessionId);
+
+  // Send to server
+  sendFrame({
+    op: Opcode.FILE_SESSION_CREATE,
+    d: {
+      sessionId,
+      fileName: file.name,
+      fileSize: file.size,
+      contentType: file.type || "application/octet-stream",
+      magnetUri: seedResult.magnetUri,
+      infoHash: seedResult.infoHash,
+      invitees: inviteeIds,
+    },
+  });
+
+  return sessionId;
+}
+
+export function closeSession(sessionId: string): void {
+  const session = store.sessions[sessionId];
+  if (!session) return;
+
+  // Stop seeding
+  if (session.infoHash) {
+    stopSeeding(session.infoHash);
+  }
+
+  sendFrame({
+    op: Opcode.FILE_SESSION_CLOSE,
+    d: { sessionId },
+  });
+
+  setStore("sessions", sessionId, "status", "closed");
+  if (activeSenderSessionId() === sessionId) {
+    setActiveSenderSessionId(null);
+  }
+}
+
+// ── Receiver Actions ────────────────────────────────────────────────────────
+
+export function joinSession(sessionId: string): void {
+  const session = store.sessions[sessionId];
+  if (!session) return;
+
+  sendFrame({
+    op: Opcode.FILE_SESSION_JOIN,
+    d: { sessionId },
+  });
+
+  setActiveReceiverSessionId(sessionId);
+  setPendingInvite(null);
+}
+
+export function dismissInvite(): void {
+  setPendingInvite(null);
+}
+
+export function leaveSession(sessionId: string): void {
+  const session = store.sessions[sessionId];
+  if (!session) return;
+
+  sendFrame({
+    op: Opcode.FILE_SESSION_LEAVE,
+    d: { sessionId },
+  });
+
+  setStore("sessions", sessionId, "status", "closed");
+  if (activeReceiverSessionId() === sessionId) {
+    setActiveReceiverSessionId(null);
+  }
+}
+
+// ── Progress Throttling ─────────────────────────────────────────────────────
+
+let lastProgressSent = 0;
+const PROGRESS_THROTTLE_MS = 500;
+
+function sendProgressThrottled(sessionId: string, progress: number, speed: number): void {
+  const now = Date.now();
+  if (now - lastProgressSent < PROGRESS_THROTTLE_MS) return;
+  lastProgressSent = now;
+
+  sendFrame({
+    op: Opcode.FILE_SESSION_PROGRESS,
+    d: { sessionId, progress, speed },
+  });
+}
+
+// ── Save Downloaded File ────────────────────────────────────────────────────
+
+export function saveReceivedFile(sessionId: string): void {
+  const session = store.sessions[sessionId];
+  if (!session?.downloadedFile) return;
+
+  const url = URL.createObjectURL(session.downloadedFile);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = session.downloadedFile.name;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+// ── WS Listener Setup ──────────────────────────────────────────────────────
+
+let unsubs: Array<() => void> = [];
+
+function teardown() {
+  for (const unsub of unsubs) unsub();
+  unsubs = [];
+}
+
+export function setupShareSessionStore(): void {
+  teardown();
+
+  // Incoming invite (we're a recipient)
+  unsubs.push(
+    onGatewayEvent(Opcode.FILE_SESSION_INVITE, (data) => {
+      const parsed = fileSessionInviteEventSchema.safeParse(data);
+      if (!parsed.success) return;
+      const d = parsed.data;
+
+      // Create a receiver session entry
+      setStore("sessions", d.sessionId, {
+        id: d.sessionId,
+        role: "receiver",
+        fileName: d.fileName,
+        fileSize: d.fileSize,
+        contentType: d.contentType,
+        magnetUri: null,
+        infoHash: null,
+        senderId: d.senderId,
+        senderUsername: d.senderUsername,
+        senderDisplayName: d.senderDisplayName,
+        senderAvatarUrl: d.senderAvatarUrl,
+        invitees: [],
+        participants: {},
+        status: "sharing",
+        downloadedFile: null,
+        receiverProgress: 0,
+        receiverSpeed: 0,
+      });
+
+      // Set pending invite for the toast
+      setPendingInvite({
+        sessionId: d.sessionId,
+        senderId: d.senderId,
+        senderUsername: d.senderUsername,
+        senderDisplayName: d.senderDisplayName,
+        senderAvatarUrl: d.senderAvatarUrl,
+        fileName: d.fileName,
+        fileSize: d.fileSize,
+        contentType: d.contentType,
+      });
+    }),
+  );
+
+  // Join accepted — server sends us the magnetUri to start downloading
+  unsubs.push(
+    onGatewayEvent(Opcode.FILE_SESSION_JOIN, (data) => {
+      const parsed = fileSessionJoinAcceptEventSchema.safeParse(data);
+      if (!parsed.success) return;
+      const d = parsed.data;
+
+      const session = store.sessions[d.sessionId];
+      if (!session || session.role !== "receiver") return;
+
+      setStore("sessions", d.sessionId, "magnetUri", d.magnetUri);
+
+      // Start downloading via WebTorrent
+      downloadFromMagnet(d.magnetUri, (progress, speed) => {
+        setStore("sessions", d.sessionId, "receiverProgress", progress);
+        setStore("sessions", d.sessionId, "receiverSpeed", speed);
+        sendProgressThrottled(d.sessionId, progress, speed);
+      })
+        .then((files) => {
+          const file = files[0];
+          if (file) {
+            setStore("sessions", d.sessionId, "downloadedFile", file);
+          }
+          setStore("sessions", d.sessionId, "receiverProgress", 1);
+          setStore("sessions", d.sessionId, "status", "complete");
+
+          // Report complete to server
+          sendFrame({
+            op: Opcode.FILE_SESSION_COMPLETE,
+            d: { sessionId: d.sessionId },
+          });
+        })
+        .catch((err) => {
+          if (import.meta.env.DEV) console.error("[share-session] Download error:", err);
+          setStore("sessions", d.sessionId, "status", "closed");
+        });
+    }),
+  );
+
+  // Sender receives: someone joined
+  unsubs.push(
+    onGatewayEvent(Opcode.FILE_SESSION_JOINED, (data) => {
+      const parsed = fileSessionJoinedEventSchema.safeParse(data);
+      if (!parsed.success) return;
+      const d = parsed.data;
+
+      const session = store.sessions[d.sessionId];
+      if (!session || session.role !== "sender") return;
+
+      setStore("sessions", d.sessionId, "participants", d.userId, {
+        userId: d.userId,
+        username: d.username,
+        displayName: d.displayName,
+        avatarUrl: d.avatarUrl,
+        progress: 0,
+        speed: 0,
+        status: "downloading",
+      });
+    }),
+  );
+
+  // Sender receives: progress from a participant
+  unsubs.push(
+    onGatewayEvent(Opcode.FILE_SESSION_PROGRESS, (data) => {
+      const parsed = fileSessionProgressEventSchema.safeParse(data);
+      if (!parsed.success) return;
+      const d = parsed.data;
+
+      const session = store.sessions[d.sessionId];
+      if (!session || session.role !== "sender") return;
+      if (!session.participants[d.userId]) return;
+
+      setStore("sessions", d.sessionId, "participants", d.userId, "progress", d.progress);
+      setStore("sessions", d.sessionId, "participants", d.userId, "speed", d.speed);
+    }),
+  );
+
+  // Sender receives: participant completed download
+  unsubs.push(
+    onGatewayEvent(Opcode.FILE_SESSION_COMPLETE, (data) => {
+      const parsed = fileSessionCompleteEventSchema.safeParse(data);
+      if (!parsed.success) return;
+      const d = parsed.data;
+
+      const session = store.sessions[d.sessionId];
+      if (!session || session.role !== "sender") return;
+      if (!session.participants[d.userId]) return;
+
+      setStore("sessions", d.sessionId, "participants", d.userId, "status", "complete");
+      setStore("sessions", d.sessionId, "participants", d.userId, "progress", 1);
+
+      // Check if all participants are complete
+      const allDone = Object.values(store.sessions[d.sessionId]?.participants ?? {}).every(
+        (p) => p.status === "complete" || p.status === "invited",
+      );
+      if (allDone) {
+        setStore("sessions", d.sessionId, "status", "complete");
+      }
+    }),
+  );
+
+  // Session closed (by sender or sender disconnect)
+  unsubs.push(
+    onGatewayEvent(Opcode.FILE_SESSION_CLOSE, (data) => {
+      const parsed = fileSessionCloseEventSchema.safeParse(data);
+      if (!parsed.success) return;
+      const d = parsed.data;
+
+      const session = store.sessions[d.sessionId];
+      if (!session) return;
+
+      setStore("sessions", d.sessionId, "status", "closed");
+
+      // Clear invite if it was still pending
+      if (pendingInvite()?.sessionId === d.sessionId) {
+        setPendingInvite(null);
+      }
+    }),
+  );
+
+  // Sender receives: participant left
+  unsubs.push(
+    onGatewayEvent(Opcode.FILE_SESSION_LEAVE, (data) => {
+      const parsed = fileSessionLeaveEventSchema.safeParse(data);
+      if (!parsed.success) return;
+      const d = parsed.data;
+
+      const session = store.sessions[d.sessionId];
+      if (!session || session.role !== "sender") return;
+
+      setStore(
+        "sessions",
+        d.sessionId,
+        "participants",
+        produce((participants) => {
+          delete participants[d.userId];
+        }),
+      );
+    }),
+  );
+}
+
+// ── HMR cleanup ─────────────────────────────────────────────────────────────
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    teardown();
+  });
+}

--- a/apps/web/src/stubs/bittorrent-dht.ts
+++ b/apps/web/src/stubs/bittorrent-dht.ts
@@ -1,0 +1,5 @@
+// Stub: bittorrent-dht requires UDP sockets (Node-only).
+// WebTorrent disables DHT in browsers via { dht: false }, but
+// torrent-discovery still imports it at the module level.
+export default null;
+export const Client = null;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
 import tailwindcss from "@tailwindcss/vite";
@@ -16,7 +17,7 @@ export default defineConfig({
       // bittorrent-dht is Node-only (UDP sockets). WebTorrent disables DHT in
       // browsers via { dht: false }, but torrent-discovery still imports it at
       // the module level. Stub it out so Vite can bundle without errors.
-      "bittorrent-dht": "data:text/javascript,export default null; export const Client = null;",
+      "bittorrent-dht": resolve(__dirname, "src/stubs/bittorrent-dht.ts"),
     },
   },
   server: {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -8,5 +8,14 @@ export type {
   FileShareRequest,
   FileShareBroadcast,
   FileAvailabilityPayload,
+  FileSessionCreatePayload,
+  FileSessionInvitePayload,
+  FileSessionJoinPayload,
+  FileSessionJoinAcceptPayload,
+  FileSessionJoinedPayload,
+  FileSessionProgressPayload,
+  FileSessionCompletePayload,
+  FileSessionClosePayload,
+  FileSessionLeavePayload,
 } from "./signaling.js";
 export * from "./schemas.js";

--- a/packages/protocol/src/opcodes.ts
+++ b/packages/protocol/src/opcodes.ts
@@ -72,4 +72,23 @@ export enum Opcode {
 
   /** Server -> Client: error notification (e.g., tier restriction) */
   ERROR = 99,
+
+  // ── File Share Sessions (DM P2P) ──────────────────────────────────────────
+
+  /** Sender -> Server: create a share session */
+  FILE_SESSION_CREATE = 100,
+  /** Server -> Recipients: you've been invited to a share session */
+  FILE_SESSION_INVITE = 101,
+  /** Recipient -> Server: joining the share session */
+  FILE_SESSION_JOIN = 102,
+  /** Server -> Sender: a user joined the session */
+  FILE_SESSION_JOINED = 103,
+  /** Recipient -> Server -> Sender: download progress update */
+  FILE_SESSION_PROGRESS = 104,
+  /** Recipient -> Server -> Sender: download complete */
+  FILE_SESSION_COMPLETE = 105,
+  /** Sender -> Server -> All: session ended */
+  FILE_SESSION_CLOSE = 106,
+  /** Recipient -> Server -> Sender: user left the session */
+  FILE_SESSION_LEAVE = 107,
 }

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -265,3 +265,95 @@ export const presenceUpdateEventSchema = z.object({
   userId: z.string(),
   status: z.enum(["online", "idle", "offline"]),
 });
+
+// ── File Share Session Schemas ──────────────────────────────────────────────
+
+/** Client → Server: create a share session */
+export const fileSessionCreateRequestSchema = z.object({
+  sessionId: z.string().min(1),
+  fileName: z.string().min(1).max(MAX_FILE_NAME_LENGTH),
+  fileSize: z.number().int().positive().max(MAX_FILE_SIZE_BYTES),
+  contentType: z.string().min(1).max(MAX_CONTENT_TYPE_LENGTH),
+  magnetUri: z.string().min(1).max(MAX_MAGNET_URI_LENGTH).startsWith("magnet:"),
+  infoHash: z.string().min(1).max(MAX_INFO_HASH_LENGTH),
+  invitees: z.array(z.string().min(1)).min(1).max(50),
+});
+
+/** Client → Server: join a session */
+export const fileSessionJoinRequestSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+/** Client → Server: report download progress */
+export const fileSessionProgressRequestSchema = z.object({
+  sessionId: z.string().min(1),
+  progress: z.number().min(0).max(1),
+  speed: z.number().nonnegative(),
+});
+
+/** Client → Server: report download complete */
+export const fileSessionCompleteRequestSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+/** Client → Server: close session */
+export const fileSessionCloseRequestSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+/** Client → Server: leave session */
+export const fileSessionLeaveRequestSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+/** Server → Client: session invite */
+export const fileSessionInviteEventSchema = z.object({
+  sessionId: z.string(),
+  senderId: z.string(),
+  senderUsername: z.string(),
+  senderDisplayName: z.string().nullable(),
+  senderAvatarUrl: z.string().nullable(),
+  fileName: z.string(),
+  fileSize: z.number(),
+  contentType: z.string(),
+});
+
+/** Server → Client: magnetUri for the joining recipient */
+export const fileSessionJoinAcceptEventSchema = z.object({
+  sessionId: z.string(),
+  magnetUri: z.string(),
+});
+
+/** Server → Client: a user joined the session */
+export const fileSessionJoinedEventSchema = z.object({
+  sessionId: z.string(),
+  userId: z.string(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+});
+
+/** Server → Client: progress update for a participant */
+export const fileSessionProgressEventSchema = z.object({
+  sessionId: z.string(),
+  userId: z.string(),
+  progress: z.number(),
+  speed: z.number(),
+});
+
+/** Server → Client: participant completed download */
+export const fileSessionCompleteEventSchema = z.object({
+  sessionId: z.string(),
+  userId: z.string(),
+});
+
+/** Server → Client: session closed */
+export const fileSessionCloseEventSchema = z.object({
+  sessionId: z.string(),
+});
+
+/** Server → Client: participant left the session */
+export const fileSessionLeaveEventSchema = z.object({
+  sessionId: z.string(),
+  userId: z.string(),
+});

--- a/packages/protocol/src/signaling.ts
+++ b/packages/protocol/src/signaling.ts
@@ -34,3 +34,73 @@ export interface FileAvailabilityPayload {
   channelId: ChannelId;
   available: boolean;
 }
+
+// ── File Share Session Payloads ─────────────────────────────────────────────
+
+/** Sender -> Server: create a share session */
+export interface FileSessionCreatePayload {
+  sessionId: string;
+  fileName: string;
+  fileSize: number;
+  contentType: string;
+  magnetUri: string;
+  infoHash: string;
+  invitees: UserId[];
+}
+
+/** Server -> Recipients: invitation to a share session */
+export interface FileSessionInvitePayload {
+  sessionId: string;
+  senderId: UserId;
+  senderUsername: string;
+  senderDisplayName: string | null;
+  senderAvatarUrl: string | null;
+  fileName: string;
+  fileSize: number;
+  contentType: string;
+}
+
+/** Recipient -> Server: joining a session */
+export interface FileSessionJoinPayload {
+  sessionId: string;
+}
+
+/** Server -> Recipient: magnetUri to start downloading */
+export interface FileSessionJoinAcceptPayload {
+  sessionId: string;
+  magnetUri: string;
+}
+
+/** Server -> Sender: a user joined the session */
+export interface FileSessionJoinedPayload {
+  sessionId: string;
+  userId: UserId;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+/** Recipient -> Server -> Sender: download progress */
+export interface FileSessionProgressPayload {
+  sessionId: string;
+  userId: UserId;
+  progress: number;
+  speed: number;
+}
+
+/** Recipient -> Server -> Sender: download complete */
+export interface FileSessionCompletePayload {
+  sessionId: string;
+  userId: UserId;
+}
+
+/** Sender -> Server -> All: session ended */
+export interface FileSessionClosePayload {
+  sessionId: string;
+}
+
+/** Recipient -> Server -> Sender: user left the session */
+export interface FileSessionLeavePayload {
+  sessionId: string;
+  userId: UserId;
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,8 @@ export const RATE_LIMIT_FILE_SHARE = { limit: 10, windowMs: 60_000 };
 export const RATE_LIMIT_FILE_AVAILABILITY = { limit: 20, windowMs: 60_000 };
 export const RATE_LIMIT_WEBRTC = { limit: 30, windowMs: 60_000 };
 export const RATE_LIMIT_PRESENCE_UPDATE = { limit: 5, windowMs: 30_000 };
+export const RATE_LIMIT_FILE_SESSION = { limit: 5, windowMs: 60_000 };
+export const RATE_LIMIT_FILE_SESSION_PROGRESS = { limit: 10, windowMs: 5_000 };
 
 // ── HTTP rate limits ──────────────────────────────────────────────────────
 export const RATE_LIMIT_MESSAGE_CREATE = { limit: 5, windowMs: 5_000 };


### PR DESCRIPTION
## Summary

Replace inline DM file sharing with a dedicated share session system featuring real-time transfer visualization. Server channel file sharing remains unchanged.

### Phase 1: Protocol Types
- 8 new WebSocket opcodes (`FILE_SESSION_CREATE` through `FILE_SESSION_LEAVE`, 100-107)
- 9 payload interfaces in `signaling.ts` with branded `UserId` types
- 12 Zod schemas for request validation and event parsing

### Phase 2: DB Schema Migration
- Added `receiver_id` column to `file_receipts` (nullable FK to user)
- Made `channel_id`, `magnet_uri`, `info_hash` nullable (DM shares don't use channels)
- Dropped unique constraint on `message_id`
- Added indexes on `sender_id` and `receiver_id` for receipt queries

### Phase 3: Server Session Handlers
- New `file-sessions.ts` with in-memory `Map<string, FileSession>` store
- 7 handler functions: create, join, progress, complete, close, leave, cleanup
- Friendship validation on session creation (bidirectional accepted check)
- Auto-cleanup on sender WebSocket disconnect
- New `GET /api/file-receipts` endpoint with pagination and sent/received/all filter
- Rate limiting on session create and progress updates

### Phase 4: Frontend Store
- New `share-session-store.ts` with SolidJS reactive store
- WebSocket listeners for all 7 FILE_SESSION_* opcodes
- Torrent client integration (seed on create, download on join)
- Throttled progress reporting (500ms)
- P2P IP disclosure and CSAM hash check before seeding

### Phase 5: Sender Modal
- 3-step `ShareFileModal`: pick file → pick friends → live transfer
- Drag-and-drop file selection with size validation (max 5GB)
- Friend list with search, select all/deselect all, online status
- Close confirmation dialog during active transfers
- "Send File" button added to sidebar header

### Phase 6: Receiver Experience
- Persistent toast notification on incoming invites (60s, click to join)
- `FileReceiveModal` with sender info, progress bar, download speed
- "Save to Device" button on completion
- "Session ended" state if sender closes early

### Phase 7: Transfer Visualization
- SVG bezier lines connecting sender to each recipient
- Color-coded line states: gray dashed (invited), blue animated (downloading), green (complete)
- Flowing particle animation along active transfer paths
- Spring physics: cursor repulsion on avatars and line control points
- `requestAnimationFrame` loop with damping for smooth 60fps

### Phase 8: Transfer History
- New "Transfers" tab in Settings page
- Paginated file receipt list with sent/received filter
- File type icons, size, date, other party's username
- Load more pagination

### Phase 9: Disable DM Inline Sharing
- `FileDropZone` and `MessageInput` file attachment disabled for DMs
- Contextual message: "Use the Send File button in the sidebar to share files"
- Old DM file messages still render in chat history (no data breakage)
- Server channel file sharing completely unchanged

## Files Changed

**New files (8):** file-sessions.ts, file-receipts.ts, migration SQL, share-session-store.ts, ShareFileModal.tsx, FileReceiveModal.tsx, ShareVisualization.tsx, transfer-history.tsx

**Modified files (16):** opcodes.ts, signaling.ts, schemas.ts, protocol index.ts, constants.ts, db schema.ts, gateway.ts, server index.ts, report.ts, journal.json, AppLayout.tsx, AppSidebar.tsx, ChatArea.tsx, Settings.tsx, file-store.ts, stores index.ts

## Test plan

- [ ] Typecheck passes (`bun run typecheck` — verified, 5/5 packages clean)
- [ ] Lint passes (`bun run lint` — verified, 0 errors)
- [ ] Sender flow: click Send File → select file → select friends → see visualization
- [ ] Receiver flow: receive toast → click Join → see progress → save file
- [ ] Sender disconnect closes session for all participants
- [ ] Non-friends cannot be invited (friendship validation)
- [ ] Transfer history shows in Settings > Transfers tab
- [ ] Server channel file sharing still works (unchanged)
- [ ] Old DM file messages still render in chat history
- [ ] DM chat area shows disabled message for inline file sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer-to-peer multi-recipient file sharing in DMs: live per-recipient progress, SVG visualization, clickable toast invites, three-step Send File flow, in-app receive modal (save/leave/dismiss), sidebar Send File action, and a Transfers settings tab with paginated sent/received history.
  * Real-time session flows: create/join/progress/complete/close/leave with rate-limited progress updates.

* **Chores**
  * Database migration to record DM file receipts and improve lookup performance.
  * Protocol and client/server signaling additions to support session lifecycle and payload schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->