### PR TITLE
feat: UI overhaul — Terminal Dark theme, route restructure, sidebar redesign

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,16 +22,30 @@ const ServerView = lazy(() => import("./pages/ServerView.js"));
 const ServerSettings = lazy(() => import("./pages/ServerSettings.js"));
 const Features = lazy(() => import("./pages/Feedback.js"));
 
-// Settings
+// Settings (route entry-points under pages/settings/)
 const SettingsLayout = lazy(() => import("./pages/SettingsLayout.js"));
 const SettingsRedirect = lazy(() => import("./pages/SettingsRedirect.js"));
-const ProfileSettings = lazy(() => import("./components/settings/profile-settings.js"));
-const AccountSettings = lazy(() => import("./components/settings/account-settings.js"));
-const AppearanceSettings = lazy(() => import("./components/settings/appearance-settings.js"));
-const TransferHistory = lazy(() => import("./components/settings/transfer-history.js"));
+const ProfileSettings = lazy(() => import("./pages/settings/profile-settings.js"));
+const AccountSettings = lazy(() => import("./pages/settings/account-settings.js"));
+const AppearanceSettings = lazy(() => import("./pages/settings/appearance-settings.js"));
+const TransferHistory = lazy(() => import("./pages/settings/transfer-history.js"));
+const NotificationSettings = lazy(() => import("./pages/settings/notification-settings.js"));
 const Upgrade = lazy(() => import("./pages/Upgrade.js"));
 const Billing = lazy(() => import("./pages/Billing.js"));
-const FallbackPage = lazy(() => import("./pages/FallbackPage.js"));
+
+// 404 page (passes different props to FallbackPage)
+const NotFound = lazy(async () => {
+  const mod = await import("./pages/FallbackPage.js");
+  const Comp = () => (
+    <mod.default
+      title="Not Found"
+      description="We couldn't find that page."
+      ctaLabel="Go home"
+      ctaTarget="/"
+    />
+  );
+  return { default: Comp };
+});
 
 const App = () => {
   return (
@@ -63,12 +77,12 @@ const App = () => {
           <Route path="/transfers" component={TransferHistory} />
           <Route path="/upgrade" component={Upgrade} />
           <Route path="/billing" component={Billing} />
-          <Route path="/notifications" component={FallbackPage} />
+          <Route path="/notifications" component={NotificationSettings} />
         </Route>
       </Route>
 
-      {/* Fallback */}
-      <Route path="/*" component={FallbackPage} />
+      {/* 404 */}
+      <Route path="/*" component={NotFound} />
     </Router>
   );
 };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Router, Route } from "@solidjs/router";
 import AppLayout from "./components/AppLayout.js";
 import "./stores/theme-store.js"; // Initialize theme on app load
 
+// Public pages
 const Landing = lazy(() => import("./pages/Landing.js"));
 const Login = lazy(() => import("./pages/Login.js"));
 const Register = lazy(() => import("./pages/Register.js"));
@@ -11,30 +12,63 @@ const ResetPassword = lazy(() => import("./pages/ResetPassword.js"));
 const Privacy = lazy(() => import("./pages/Privacy.js"));
 const Terms = lazy(() => import("./pages/Terms.js"));
 const Onboarding = lazy(() => import("./pages/Onboarding.js"));
+
+// Authenticated pages
 const Home = lazy(() => import("./pages/Home.js"));
 const Friends = lazy(() => import("./pages/Friends.js"));
-const Settings = lazy(() => import("./pages/Settings.js"));
+const Messages = lazy(() => import("./pages/Messages.js"));
+const DirectMessage = lazy(() => import("./pages/DirectMessage.js"));
+const ServerView = lazy(() => import("./pages/ServerView.js"));
 const ServerSettings = lazy(() => import("./pages/ServerSettings.js"));
-const Feedback = lazy(() => import("./pages/Feedback.js"));
+const Features = lazy(() => import("./pages/Feedback.js"));
+
+// Settings
+const SettingsLayout = lazy(() => import("./pages/SettingsLayout.js"));
+const SettingsRedirect = lazy(() => import("./pages/SettingsRedirect.js"));
+const ProfileSettings = lazy(() => import("./components/settings/profile-settings.js"));
+const AccountSettings = lazy(() => import("./components/settings/account-settings.js"));
+const AppearanceSettings = lazy(() => import("./components/settings/appearance-settings.js"));
+const TransferHistory = lazy(() => import("./components/settings/transfer-history.js"));
+const Upgrade = lazy(() => import("./pages/Upgrade.js"));
+const Billing = lazy(() => import("./pages/Billing.js"));
+const FallbackPage = lazy(() => import("./pages/FallbackPage.js"));
 
 const App = () => {
   return (
     <Router>
+      {/* Public */}
       <Route path="/" component={Landing} />
       <Route path="/login" component={Login} />
       <Route path="/register" component={Register} />
       <Route path="/forgot-password" component={ForgotPassword} />
       <Route path="/reset-password" component={ResetPassword} />
+      <Route path="/onboarding" component={Onboarding} />
       <Route path="/privacy" component={Privacy} />
       <Route path="/terms" component={Terms} />
-      <Route path="/onboarding" component={Onboarding} />
-      <Route path="/home" component={AppLayout}>
-        <Route path="/" component={Home} />
+
+      {/* Authenticated — all under AppLayout with AuthGuard */}
+      <Route path="/" component={AppLayout}>
+        <Route path="/home" component={Home} />
         <Route path="/friends" component={Friends} />
-        <Route path="/settings" component={Settings} />
-        <Route path="/server-settings" component={ServerSettings} />
-        <Route path="/feedback" component={Feedback} />
+        <Route path="/messages" component={Messages} />
+        <Route path="/messages/:userId" component={DirectMessage} />
+        <Route path="/servers/:serverId" component={ServerView} />
+        <Route path="/servers/:serverId/settings" component={ServerSettings} />
+        <Route path="/features" component={Features} />
+        <Route path="/settings" component={SettingsLayout}>
+          <Route path="/" component={SettingsRedirect} />
+          <Route path="/profile" component={ProfileSettings} />
+          <Route path="/account" component={AccountSettings} />
+          <Route path="/appearance" component={AppearanceSettings} />
+          <Route path="/transfers" component={TransferHistory} />
+          <Route path="/upgrade" component={Upgrade} />
+          <Route path="/billing" component={Billing} />
+          <Route path="/notifications" component={FallbackPage} />
+        </Route>
       </Route>
+
+      {/* Fallback */}
+      <Route path="/*" component={FallbackPage} />
     </Router>
   );
 };

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -7,16 +7,13 @@ import {
   type ParentComponent,
 } from "solid-js";
 import { useSession } from "../lib/auth.js";
-import { useLocation } from "@solidjs/router";
 import { connectGateway, disconnectGateway } from "../lib/gateway.js";
 import { gatewayStatus } from "../lib/gateway-store.js";
-import { selectedServerId, selectedDmChannelId } from "../stores/app-store.js";
 import { setupShortcuts, cleanupShortcuts } from "../stores/shortcut-store.js";
 import "../lib/gateway-errors.js";
 import "../stores/server-store.js";
 import AuthGuard from "./AuthGuard.js";
 import AppSidebar from "./AppSidebar.js";
-import ChatArea from "./ChatArea.js";
 import ShortcutsDialog from "./ShortcutsDialog.js";
 import { ToastContainer, showToast } from "./ui/toast.js";
 import { Empty } from "./ui/empty.js";
@@ -32,12 +29,8 @@ import {
 } from "../stores/share-session-store.js";
 import FileReceiveModal from "./modals/FileReceiveModal.js";
 
-const SETTINGS_PATHS = ["/home/server-settings", "/home/settings"];
-
 const AppLayout: ParentComponent = (props) => {
   const session = useSession();
-  const location = useLocation();
-  const isSettingsPage = () => SETTINGS_PATHS.some((p) => location.pathname.startsWith(p));
 
   createEffect(() => {
     const s = session();
@@ -64,7 +57,7 @@ const AppLayout: ParentComponent = (props) => {
         `${invite.senderDisplayName ?? invite.senderUsername} wants to share "${invite.fileName}" (${sizeKb})`,
         "info",
         {
-          durationMs: 60_000, // Long-lived — dismissed manually or on session close
+          durationMs: 60_000,
           subtitle: "Click to join",
           onClick: () => joinSession(invite.sessionId),
         },
@@ -92,7 +85,9 @@ const AppLayout: ParentComponent = (props) => {
           {/* Mobile header with sidebar trigger */}
           <div class="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2 md:hidden">
             <SidebarTrigger />
-            <span class="text-sm font-semibold text-foreground">UnCorded</span>
+            <span class="font-mono text-sm font-semibold tracking-wide text-foreground">
+              UNCORDED
+            </span>
           </div>
 
           <Show
@@ -131,12 +126,7 @@ const AppLayout: ParentComponent = (props) => {
               </div>
             }
           >
-            <Show
-              when={!isSettingsPage() && (selectedServerId() || selectedDmChannelId())}
-              fallback={<div class="flex-1 overflow-y-auto">{props.children}</div>}
-            >
-              <ChatArea />
-            </Show>
+            <div class="flex-1 overflow-y-auto">{props.children}</div>
           </Show>
         </SidebarInset>
       </SidebarProvider>

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -1,18 +1,16 @@
 import { createSignal, For, Show, onCleanup } from "solid-js";
-import { useNavigate } from "@solidjs/router";
+import { useNavigate, useLocation } from "@solidjs/router";
+import { Portal } from "solid-js/web";
 import { useSession, signOut } from "../lib/auth.js";
 import { readyData, channelCacheLoading } from "../lib/gateway-store.js";
 import {
   selectedServerId,
   selectedChannelId,
   setSelectedChannelId,
-  selectedDmChannelId,
-  selectDmChannel,
   selectHome,
   currentServer,
   currentChannels,
 } from "../stores/app-store.js";
-import { fetchMoreDms, loadingMoreDms } from "../stores/friend-store.js";
 import { getUnreadCount } from "../stores/notification-store.js";
 import {
   Sidebar,
@@ -33,30 +31,31 @@ import InviteModal from "./modals/InviteModal.js";
 import CheckoutModal from "./modals/CheckoutModal.js";
 import SubscriptionModal from "./modals/SubscriptionModal.js";
 import PricingModal from "./modals/PricingModal.js";
-import StatusDot, { type UserStatus } from "./StatusDot.js";
 import UnifiedReportDialog from "./modals/UnifiedReportDialog.js";
 import ShareFileModal from "./modals/ShareFileModal.js";
 import { showToast } from "./ui/toast.js";
-
-const iconBtnClass =
-  "rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
 
 const AppSidebar = () => {
   const { setOpenMobile } = useSidebar();
   const closeMobile = () => setOpenMobile(false);
   const session = useSession();
   const navigate = useNavigate();
-  const [modal, setModal] = createSignal<"create" | "join" | "invite" | "create-channel" | null>(
-    null,
-  );
+  const location = useLocation();
+
+  const [modal, setModal] = createSignal<
+    "create" | "join" | "invite" | "create-channel" | null
+  >(null);
   const [copiedUsername, setCopiedUsername] = createSignal(false);
   const [checkoutTier, setCheckoutTier] = createSignal<"supporter" | "server_owner" | null>(null);
   const [showPricingModal, setShowPricingModal] = createSignal(false);
   const [showSubscriptionModal, setShowSubscriptionModal] = createSignal(false);
   const [showReportDialog, setShowReportDialog] = createSignal(false);
   const [showShareModal, setShowShareModal] = createSignal(false);
+  const [userDropdownOpen, setUserDropdownOpen] = createSignal(false);
+  const [dropdownPos, setDropdownPos] = createSignal({ bottom: 0, left: 0 });
 
   let copiedUsernameTimer: ReturnType<typeof setTimeout> | undefined;
+  let footerRef!: HTMLDivElement;
   onCleanup(() => clearTimeout(copiedUsernameTimer));
 
   const copyUsername = async () => {
@@ -68,19 +67,19 @@ const AppSidebar = () => {
       setCopiedUsername(true);
       clearTimeout(copiedUsernameTimer);
       copiedUsernameTimer = setTimeout(() => setCopiedUsername(false), 1500);
-    } catch { /* clipboard unavailable */ }
+    } catch {
+      /* clipboard unavailable */
+    }
   };
 
   const resolvedUsername = () =>
     readyData.data?.user.username ?? session()?.data?.user?.name ?? "User";
-
-  const usernameSizeClass = () => {
-    if (resolvedUsername().length > 12) return "text-xs";
-    return "text-sm";
-  };
+  const resolvedDisplayName = () =>
+    readyData.data?.user.displayName ?? resolvedUsername();
 
   const isServerOwner = () =>
-    currentServer()?.ownerId != null && currentServer()?.ownerId === readyData.data?.user.id;
+    currentServer()?.ownerId != null &&
+    currentServer()?.ownerId === readyData.data?.user.id;
 
   const isPaidUser = () =>
     readyData.data?.user.subscriptionTier !== undefined &&
@@ -91,76 +90,53 @@ const AppSidebar = () => {
     window.location.href = "/login";
   };
 
-  // ── Group header actions ─────────────────────────────────────────────────
+  const openUserDropdown = () => {
+    const rect = footerRef.getBoundingClientRect();
+    setDropdownPos({ bottom: window.innerHeight - rect.top + 4, left: rect.left });
+    setUserDropdownOpen(true);
+  };
 
+  const closeUserDropdown = () => setUserDropdownOpen(false);
+
+  const isActive = (path: string) => location.pathname === path;
+
+  // ── Channel group header actions ────────────────────────────────
   const channelActions = () => (
     <>
       <button
-        class={iconBtnClass}
+        class="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         title="Invite People"
         aria-label="Invite People"
         onClick={() => setModal("invite")}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="2"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
-          />
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
         </svg>
       </button>
       <Show when={isServerOwner()}>
         <button
-          class={iconBtnClass}
+          class="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           title="Create Channel"
           aria-label="Create Channel"
           onClick={() => setModal("create-channel")}
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            stroke-width="2"
-            aria-hidden="true"
-          >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
           </svg>
         </button>
         <button
           type="button"
-          class={iconBtnClass}
+          class="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           title="Server Settings"
           aria-label="Server Settings"
-          onClick={() => navigate("/home/server-settings")}
+          onClick={() => {
+            const id = selectedServerId();
+            if (id) navigate(`/servers/${id}/settings`);
+          }}
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            stroke-width="2"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-            />
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-            />
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
         </button>
       </Show>
@@ -169,181 +145,127 @@ const AppSidebar = () => {
 
   return (
     <Sidebar variant="inset" collapsible="icon">
-      {/* ── Header: Brand Home + Server Switcher ────────────────────── */}
+      {/* ── Header: UNCORDED Logo ───────────────────────────────────── */}
       <SidebarHeader>
         <button
           onClick={() => {
             selectHome();
-            navigate("/home/friends");
+            navigate("/home");
             closeMobile();
           }}
-          class="flex w-full items-center gap-1.5 rounded-lg px-1 py-1 transition-colors hover:bg-accent"
+          class="flex w-full items-center gap-2 px-1 py-2 transition-colors hover:opacity-80"
         >
-          <div class="flex min-w-0 flex-1 items-center justify-center gap-2">
-            <img src="/icon-192.png" alt="UnCorded" class="h-12 w-12 rounded-lg" />
-            <span class="text-sm font-semibold tracking-tight text-foreground">UnCorded</span>
-            <span class="rounded-full bg-muted/50 px-1.5 py-0.5 text-[8px] font-medium uppercase tracking-[0.18em] text-muted-foreground/60">
-              Alpha
-            </span>
-          </div>
+          <img src="/icon-192.png" alt="UnCorded" class="h-8 w-8 rounded-md" />
+          <span class="font-mono text-sm font-bold uppercase tracking-[0.12em] text-foreground">
+            UNCORDED
+          </span>
+          <span class="rounded-sm bg-muted px-1.5 py-0.5 font-mono text-[8px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Alpha
+          </span>
         </button>
-        <button
-          onClick={() => setShowShareModal(true)}
-          class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-          title="Send File"
-          aria-label="Send File"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            stroke-width="2"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-            />
-          </svg>
-          Send File
-        </button>
-        <ServerSwitcher
-          onCreateServer={() => setModal("create")}
-          onJoinServer={() => setModal("join")}
-        />
       </SidebarHeader>
 
-      {/* ── Content: Channels or DMs ─────────────────────────────────── */}
+      {/* ── Content ─────────────────────────────────────────────────── */}
       <SidebarContent>
-        <Show
-          when={selectedServerId()}
-          fallback={
-            /* ── Home: Friends + DMs ─────────────────────────────────── */
-            <>
-              <SidebarMenu class="pt-1">
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    onClick={() => {
-                      navigate("/home/friends");
-                      closeMobile();
-                    }}
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="h-4 w-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-                      />
-                    </svg>
-                    Friends
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
-
-              <div class="mx-3 my-2 h-px bg-border" />
-
-              <Show
-                when={(readyData.data?.dmChannels ?? []).length > 0}
-                fallback={
-                  <p class="px-4 py-3 text-xs text-muted-foreground">No conversations yet</p>
-                }
+        {/* Social group */}
+        <SidebarGroup label="Social" collapsible defaultOpen>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                active={isActive("/friends")}
+                onClick={() => {
+                  selectHome();
+                  navigate("/friends");
+                  closeMobile();
+                }}
               >
-                <SidebarMenu>
-                  <For each={readyData.data?.dmChannels}>
-                    {(dm) => {
-                      const displayName = () =>
-                        dm.otherUser.displayName ?? dm.otherUser.username ?? "Unknown";
-                      const initial = () => displayName().charAt(0).toUpperCase();
-                      const isActive = () => selectedDmChannelId() === dm.id;
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                All Friends
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                active={isActive("/messages") || location.pathname.startsWith("/messages/")}
+                onClick={() => {
+                  selectHome();
+                  navigate("/messages");
+                  closeMobile();
+                }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                </svg>
+                Direct Messages
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
 
-                      return (
-                        <SidebarMenuItem>
-                          <SidebarMenuButton
-                            active={isActive()}
-                            onClick={() => {
-                              selectDmChannel(dm.id);
-                              closeMobile();
-                            }}
-                          >
-                            <div class="relative shrink-0">
-                              <Show
-                                when={dm.otherUser.avatarUrl}
-                                fallback={
-                                  <div class="flex h-6 w-6 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white">
-                                    {initial()}
-                                  </div>
-                                }
-                              >
-                                {(url) => (
-                                  <img src={url()} alt={displayName()} class="h-6 w-6 rounded-full object-cover" />
-                                )}
-                              </Show>
-                              <StatusDot
-                                status={dm.otherUser.status as UserStatus}
-                                size="sm"
-                                borderClass="border-sidebar"
-                              />
-                            </div>
-                            <span class="truncate">{displayName()}</span>
-                            <Show when={!isActive() && getUnreadCount(dm.id) > 0}>
-                              <span class="ml-auto flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
-                                {getUnreadCount(dm.id)}
-                              </span>
-                            </Show>
-                          </SidebarMenuButton>
-                        </SidebarMenuItem>
-                      );
-                    }}
-                  </For>
-                </SidebarMenu>
-                <Show when={readyData.data?.hasMoreDmChannels}>
-                  <button
-                    class="mx-3 mt-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
-                    disabled={loadingMoreDms()}
-                    onClick={() => fetchMoreDms()}
-                  >
-                    {loadingMoreDms() ? "Loading..." : "Load more"}
-                  </button>
-                </Show>
-              </Show>
-            </>
-          }
-        >
-          {/* ── Server: Channels ─────────────────────────────────────── */}
-          <SidebarGroup label="Channels" actions={channelActions()} collapsible defaultOpen>
+        {/* Servers group */}
+        <SidebarGroup label="Servers" collapsible defaultOpen>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton onClick={() => { setModal("join"); closeMobile(); }}>
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
+                </svg>
+                Join Server
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton onClick={() => { setModal("create"); closeMobile(); }}>
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                </svg>
+                Create Server
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+
+          {/* Server selector */}
+          <div class="px-2 pt-1">
+            <ServerSwitcher
+              onCreateServer={() => setModal("create")}
+              onJoinServer={() => setModal("join")}
+            />
+          </div>
+
+          {/* Channel list — shown when a server is selected */}
+          <Show when={selectedServerId()}>
             <Show
               when={channelCacheLoading() !== selectedServerId()}
-              fallback={<p class="px-4 py-3 text-xs text-muted-foreground">Loading channels...</p>}
+              fallback={
+                <p class="px-4 py-3 text-xs text-muted-foreground">Loading channels...</p>
+              }
             >
-              <SidebarMenu>
+              <SidebarMenu class="mt-1">
                 <For each={currentChannels()}>
                   {(channel) => {
-                    const isActive = () => selectedChannelId() === channel.id;
+                    const active = () => selectedChannelId() === channel.id;
                     return (
                       <SidebarMenuItem>
                         <SidebarMenuButton
-                          active={isActive()}
+                          active={active()}
                           onClick={() => {
                             setSelectedChannelId(channel.id);
+                            const sId = selectedServerId();
+                            if (sId) navigate(`/servers/${sId}`);
                             closeMobile();
                           }}
                         >
-                          <span class="text-muted-foreground">#</span>
+                          <span class="font-mono text-muted-foreground">#</span>
                           <span class="truncate">{channel.name}</span>
-                          <Show when={(!isActive() && getUnreadCount(channel.id) > 0) || channel.fileSharingEnabled}>
+                          <Show
+                            when={
+                              (!active() && getUnreadCount(channel.id) > 0) ||
+                              channel.fileSharingEnabled
+                            }
+                          >
                             <span class="ml-auto flex shrink-0 items-center gap-1.5">
-                              <Show when={!isActive() && getUnreadCount(channel.id) > 0}>
-                                <span class="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
+                              <Show when={!active() && getUnreadCount(channel.id) > 0}>
+                                <span class="flex h-4 min-w-4 items-center justify-center rounded-sm bg-primary px-1 font-mono text-[10px] font-bold text-primary-foreground">
                                   {getUnreadCount(channel.id)}
                                 </span>
                               </Show>
@@ -361,214 +283,219 @@ const AppSidebar = () => {
                   }}
                 </For>
               </SidebarMenu>
+              <Show when={isServerOwner()}>
+                <div class="flex items-center gap-1 px-3 pt-1">{channelActions()}</div>
+              </Show>
             </Show>
-          </SidebarGroup>
-        </Show>
-      </SidebarContent>
+          </Show>
+        </SidebarGroup>
 
-      {/* ── Footer: User Panel ───────────────────────────────────────── */}
-      <SidebarFooter class="flex-col">
-        {/* Report & Feature Requests buttons */}
-        <div class="flex gap-2 px-2 pb-2">
+        {/* Send File button */}
+        <div class="px-3 pt-2">
           <button
-            type="button"
-            class="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-muted/30 px-2 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-            aria-label="Report a problem"
-            onClick={() => setShowReportDialog(true)}
+            onClick={() => setShowShareModal(true)}
+            class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+            title="Send File"
+            aria-label="Send File"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-4 w-4 text-warning"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
-              />
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
             </svg>
-            Report
-          </button>
-          <button
-            type="button"
-            class="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-muted/30 px-2 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-            aria-label="Submit a feature request"
-            onClick={() => {
-              selectHome();
-              navigate("/home/feedback");
-              closeMobile();
-            }}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-              />
-            </svg>
-            Feature Requests
+            Send File
           </button>
         </div>
-        {/* PWA install button added in feat/pwa-admin-infra PR */}
-        <div class="relative flex min-w-0 flex-1 items-center gap-2">
-          <Show
-            when={readyData.data?.user.avatarUrl}
-            fallback={
-              <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-white">
-                {(readyData.data?.user.displayName ?? readyData.data?.user.username ?? session()?.data?.user?.name ?? "?").charAt(0).toUpperCase()}
-              </div>
-            }
-          >
-            {(url) => (
-              <img src={url()} alt={readyData.data?.user.displayName ?? readyData.data?.user.username ?? "User"} class="h-8 w-8 shrink-0 rounded-full object-cover" />
-            )}
-          </Show>
-          <div class="min-w-0 flex-1">
-            <Show
-              when={readyData.data?.user.displayName}
-              fallback={
-                <button
-                  type="button"
-                  class={`block max-w-full truncate ${usernameSizeClass()} font-medium text-foreground cursor-pointer`}
-                  title={resolvedUsername()}
-                  aria-label={`Copy username: ${resolvedUsername()}`}
-                  onClick={() => copyUsername()}
-                >
-                  {copiedUsername() ? "Copied!" : resolvedUsername()}
-                </button>
-              }
-            >
-              {(dn) => (
-                <>
-                  <div class="truncate text-sm font-medium text-foreground">{dn()}</div>
-                  <button
-                    type="button"
-                    class="block truncate text-xs text-muted-foreground cursor-pointer"
-                    title="Copy username"
-                    onClick={() => copyUsername()}
-                  >
-                    {copiedUsername()
-                      ? "Copied!"
-                      : (readyData.data?.user.username ?? session()?.data?.user?.name ?? "User")}
-                  </button>
-                </>
-              )}
-            </Show>
-          </div>
-          <Show
-            when={isPaidUser()}
-            fallback={
-              <button
-                onClick={() => setShowPricingModal(true)}
-                class="rounded p-1.5 text-primary transition-colors hover:bg-accent hover:text-primary"
-                title="Upgrade"
-                aria-label="Upgrade"
+
+        {/* Bottom nav — pushed to bottom */}
+        <div class="mt-auto px-3 pb-2">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                onClick={() => {
+                  setShowReportDialog(true);
+                  closeMobile();
+                }}
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M5 10l7-7m0 0l7 7m-7-7v18"
-                  />
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z" />
                 </svg>
-              </button>
-            }
-          >
-            <button
-              onClick={() => setShowSubscriptionModal(true)}
-              class="rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              title="Manage Subscription"
-              aria-label="Manage Subscription"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2"
+                Support
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                active={location.pathname.startsWith("/settings")}
+                onClick={() => {
+                  navigate("/settings");
+                  closeMobile();
+                }}
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
-                />
-              </svg>
-            </button>
-          </Show>
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                Settings
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </div>
+      </SidebarContent>
+
+      {/* ── Footer: User Card + Dropdown ────────────────────────────── */}
+      <SidebarFooter>
+        <div ref={footerRef}>
           <button
             type="button"
-            onClick={() => {
-              selectHome();
-              navigate("/home/settings");
-            }}
-            class="rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            title="Settings"
-            aria-label="Settings"
+            onClick={openUserDropdown}
+            class="flex w-full items-center gap-2 rounded-md px-2 py-2 transition-colors hover:bg-accent"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-              aria-hidden="true"
+            <Show
+              when={readyData.data?.user.avatarUrl}
+              fallback={
+                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary text-xs font-bold text-primary-foreground">
+                  {resolvedDisplayName().charAt(0).toUpperCase()}
+                </div>
+              }
             >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-              />
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-            </svg>
-          </button>
-          <button
-            onClick={handleLogout}
-            class="rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-destructive"
-            title="Log out"
-            aria-label="Log out"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-              />
+              {(url) => (
+                <img
+                  src={url()}
+                  alt={resolvedDisplayName()}
+                  class="h-8 w-8 shrink-0 rounded-md object-cover"
+                />
+              )}
+            </Show>
+            <div class="min-w-0 flex-1 text-left">
+              <div class="truncate text-sm font-medium text-foreground">
+                {resolvedDisplayName()}
+              </div>
+              <div class="truncate font-mono text-xs text-muted-foreground">
+                @{resolvedUsername()}
+              </div>
+            </div>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
             </svg>
           </button>
         </div>
       </SidebarFooter>
 
-      {/* ── Modals ───────────────────────────────────────────────────── */}
+      {/* ── User Dropdown Menu ──────────────────────────────────────── */}
+      <Show when={userDropdownOpen()}>
+        <Portal mount={document.body}>
+          <div class="fixed inset-0 z-[60]" onClick={closeUserDropdown} />
+          <div
+            class="fixed z-[60] w-56 rounded-md border border-border bg-popover p-1 shadow-md"
+            style={{
+              bottom: `${dropdownPos().bottom}px`,
+              left: `${dropdownPos().left}px`,
+            }}
+          >
+            {/* Profile header */}
+            <div class="flex items-center gap-2 px-2 py-2">
+              <Show
+                when={readyData.data?.user.avatarUrl}
+                fallback={
+                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary text-xs font-bold text-primary-foreground">
+                    {resolvedDisplayName().charAt(0).toUpperCase()}
+                  </div>
+                }
+              >
+                {(url) => (
+                  <img
+                    src={url()}
+                    alt={resolvedDisplayName()}
+                    class="h-8 w-8 shrink-0 rounded-md object-cover"
+                  />
+                )}
+              </Show>
+              <div class="min-w-0 flex-1">
+                <div class="truncate text-sm font-medium text-foreground">
+                  {resolvedDisplayName()}
+                </div>
+                <button
+                  type="button"
+                  class="truncate font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    copyUsername();
+                  }}
+                >
+                  {copiedUsername() ? "Copied!" : `@${resolvedUsername()}`}
+                </button>
+              </div>
+            </div>
+
+            <div class="mx-1 my-1 h-px bg-border" />
+
+            <Show when={!isPaidUser()}>
+              <button
+                class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-primary transition-colors hover:bg-accent"
+                onClick={() => {
+                  closeUserDropdown();
+                  navigate("/settings/upgrade");
+                }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                </svg>
+                Upgrade to Supporter
+              </button>
+              <div class="mx-1 my-1 h-px bg-border" />
+            </Show>
+
+            <button
+              class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
+              onClick={() => {
+                closeUserDropdown();
+                navigate("/settings/account");
+              }}
+            >
+              Account
+            </button>
+            <button
+              class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
+              onClick={() => {
+                closeUserDropdown();
+                navigate("/settings/billing");
+              }}
+            >
+              Billing
+            </button>
+            <button
+              class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
+              onClick={() => {
+                closeUserDropdown();
+                navigate("/settings/notifications");
+              }}
+            >
+              Notifications
+            </button>
+
+            <div class="mx-1 my-1 h-px bg-border" />
+
+            <button
+              class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
+              onClick={() => {
+                closeUserDropdown();
+                setShowReportDialog(true);
+              }}
+            >
+              Report Bug
+            </button>
+            <button
+              class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive transition-colors hover:bg-accent"
+              onClick={() => {
+                closeUserDropdown();
+                handleLogout();
+              }}
+            >
+              Log out
+            </button>
+          </div>
+        </Portal>
+      </Show>
+
+      {/* ── Modals ──────────────────────────────────────────────────── */}
       <Show when={modal() === "create"}>
         <CreateServerModal onClose={() => setModal(null)} />
       </Show>
@@ -579,7 +506,9 @@ const AppSidebar = () => {
         {(server) => <InviteModal serverId={server().id} onClose={() => setModal(null)} />}
       </Show>
       <Show when={modal() === "create-channel" && currentServer()}>
-        {(server) => <CreateChannelModal serverId={server().id} onClose={() => setModal(null)} />}
+        {(server) => (
+          <CreateChannelModal serverId={server().id} onClose={() => setModal(null)} />
+        )}
       </Show>
       <Show when={checkoutTier()}>
         {(tier) => <CheckoutModal tier={tier()} onClose={() => setCheckoutTier(null)} />}

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show, onCleanup } from "solid-js";
+import { createSignal, createEffect, For, Show, onCleanup } from "solid-js";
 import { useNavigate, useLocation } from "@solidjs/router";
 import { Portal } from "solid-js/web";
 import { useSession, signOut } from "../lib/auth.js";
@@ -56,6 +56,8 @@ const AppSidebar = () => {
 
   let copiedUsernameTimer: ReturnType<typeof setTimeout> | undefined;
   let footerRef!: HTMLDivElement;
+  let triggerRef!: HTMLButtonElement;
+  let menuRef!: HTMLDivElement;
   onCleanup(() => clearTimeout(copiedUsernameTimer));
 
   const copyUsername = async () => {
@@ -96,7 +98,47 @@ const AppSidebar = () => {
     setUserDropdownOpen(true);
   };
 
-  const closeUserDropdown = () => setUserDropdownOpen(false);
+  const closeUserDropdown = () => {
+    setUserDropdownOpen(false);
+    triggerRef?.focus();
+  };
+
+  // Focus first menu item when dropdown opens + wire Escape / focus trap
+  createEffect(() => {
+    if (!userDropdownOpen()) return;
+
+    // Focus first actionable item after render
+    requestAnimationFrame(() => {
+      const first = menuRef?.querySelector<HTMLElement>("button, a, [tabindex]");
+      first?.focus();
+    });
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeUserDropdown();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const focusable = [...(menuRef?.querySelectorAll<HTMLElement>("button, a, [tabindex]") ?? [])];
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first && last) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last && first) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
+  });
 
   const isActive = (path: string) => location.pathname === path;
 
@@ -344,8 +386,11 @@ const AppSidebar = () => {
       <SidebarFooter>
         <div ref={footerRef}>
           <button
+            ref={triggerRef}
             type="button"
             onClick={openUserDropdown}
+            aria-expanded={userDropdownOpen()}
+            aria-haspopup="menu"
             class="flex w-full items-center gap-2 rounded-md px-2 py-2 transition-colors hover:bg-accent"
           >
             <Show
@@ -384,6 +429,8 @@ const AppSidebar = () => {
         <Portal mount={document.body}>
           <div class="fixed inset-0 z-[60]" onClick={closeUserDropdown} />
           <div
+            ref={menuRef}
+            role="menu"
             class="fixed z-[60] w-56 rounded-md border border-border bg-popover p-1 shadow-md"
             style={{
               bottom: `${dropdownPos().bottom}px`,
@@ -429,6 +476,7 @@ const AppSidebar = () => {
 
             <Show when={!isPaidUser()}>
               <button
+                role="menuitem"
                 class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-primary transition-colors hover:bg-accent"
                 onClick={() => {
                   closeUserDropdown();
@@ -440,10 +488,11 @@ const AppSidebar = () => {
                 </svg>
                 Upgrade to Supporter
               </button>
-              <div class="mx-1 my-1 h-px bg-border" />
+              <div role="separator" class="mx-1 my-1 h-px bg-border" />
             </Show>
 
             <button
+              role="menuitem"
               class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
               onClick={() => {
                 closeUserDropdown();
@@ -453,6 +502,7 @@ const AppSidebar = () => {
               Account
             </button>
             <button
+              role="menuitem"
               class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
               onClick={() => {
                 closeUserDropdown();
@@ -462,6 +512,7 @@ const AppSidebar = () => {
               Billing
             </button>
             <button
+              role="menuitem"
               class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
               onClick={() => {
                 closeUserDropdown();
@@ -471,9 +522,10 @@ const AppSidebar = () => {
               Notifications
             </button>
 
-            <div class="mx-1 my-1 h-px bg-border" />
+            <div role="separator" class="mx-1 my-1 h-px bg-border" />
 
             <button
+              role="menuitem"
               class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
               onClick={() => {
                 closeUserDropdown();
@@ -483,6 +535,7 @@ const AppSidebar = () => {
               Report Bug
             </button>
             <button
+              role="menuitem"
               class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive transition-colors hover:bg-accent"
               onClick={() => {
                 closeUserDropdown();

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -69,8 +69,8 @@ const AppSidebar = () => {
       setCopiedUsername(true);
       clearTimeout(copiedUsernameTimer);
       copiedUsernameTimer = setTimeout(() => setCopiedUsername(false), 1500);
-    } catch {
-      /* clipboard unavailable */
+    } catch (err) {
+      if (import.meta.env.DEV) console.error("[AppSidebar] clipboard write failed:", err);
     }
   };
 

--- a/apps/web/src/components/ContentHeader.tsx
+++ b/apps/web/src/components/ContentHeader.tsx
@@ -1,0 +1,82 @@
+import { For, Show } from "solid-js";
+import { A } from "@solidjs/router";
+import { SidebarTrigger } from "./ui/sidebar.js";
+
+interface Breadcrumb {
+  label: string;
+  href?: string;
+}
+
+interface ContentHeaderProps {
+  title: string;
+  breadcrumbs?: Breadcrumb[];
+}
+
+const ContentHeader = (props: ContentHeaderProps) => {
+  return (
+    <header class="flex h-14 shrink-0 items-center gap-3 border-b border-border px-4">
+      {/* Sidebar toggle — visible on desktop too */}
+      <SidebarTrigger />
+      <div class="h-4 w-px bg-border" />
+
+      {/* Breadcrumbs */}
+      <nav class="flex min-w-0 items-center gap-1 text-sm" aria-label="Breadcrumb">
+        <Show when={props.breadcrumbs}>
+          {(crumbs) => (
+            <For each={crumbs()}>
+              {(crumb) => (
+                <>
+                  <Show
+                    when={crumb.href}
+                    fallback={
+                      <span class="hidden text-muted-foreground sm:inline">{crumb.label}</span>
+                    }
+                  >
+                    {(href) => (
+                      <A
+                        href={href()}
+                        class="hidden text-muted-foreground transition-colors hover:text-foreground sm:inline"
+                      >
+                        {crumb.label}
+                      </A>
+                    )}
+                  </Show>
+                  <span class="hidden text-muted-foreground sm:inline" aria-hidden="true">
+                    /
+                  </span>
+                </>
+              )}
+            </For>
+          )}
+        </Show>
+        <span class="truncate font-medium text-foreground">{props.title}</span>
+      </nav>
+
+      {/* Right side — Feature Requests link */}
+      <div class="ml-auto flex items-center">
+        <A
+          href="/features"
+          class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+            />
+          </svg>
+          <span class="hidden sm:inline">Feature Requests</span>
+        </A>
+      </div>
+    </header>
+  );
+};
+
+export default ContentHeader;

--- a/apps/web/src/components/ContentHeader.tsx
+++ b/apps/web/src/components/ContentHeader.tsx
@@ -56,6 +56,7 @@ const ContentHeader = (props: ContentHeaderProps) => {
       <div class="ml-auto flex items-center">
         <A
           href="/features"
+          aria-label="Feature Requests"
           class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
           <svg
@@ -65,6 +66,7 @@ const ContentHeader = (props: ContentHeaderProps) => {
             viewBox="0 0 24 24"
             stroke="currentColor"
             stroke-width="2"
+            aria-hidden="true"
           >
             <path
               stroke-linecap="round"

--- a/apps/web/src/components/MessageBubble.tsx
+++ b/apps/web/src/components/MessageBubble.tsx
@@ -414,7 +414,7 @@ const MessageBubble = (props: MessageBubbleProps) => {
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
                 <span class="text-sm font-semibold text-foreground">{displayName()}</span>
-                <span class="text-xs text-muted-foreground">
+                <span class="font-mono text-xs text-muted-foreground">
                   {formatTimestamp(props.message.createdAt)}
                 </span>
                 <Toolbar />

--- a/apps/web/src/components/settings/account-settings.tsx
+++ b/apps/web/src/components/settings/account-settings.tsx
@@ -125,7 +125,7 @@ const AccountSettings = () => {
   async function handleConnect(provider: "google" | "discord") {
     setConnecting(true);
     try {
-      await signIn.social({ provider, callbackURL: `${window.location.origin}/home/settings?linked=1` });
+      await signIn.social({ provider, callbackURL: `${window.location.origin}/settings/account?linked=1` });
     } catch {
       showToast("Failed to connect account", "error");
       setConnecting(false);

--- a/apps/web/src/components/settings/appearance-settings.tsx
+++ b/apps/web/src/components/settings/appearance-settings.tsx
@@ -41,7 +41,29 @@ const AppearanceSettings = () => {
         <h3 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           Message Density
         </h3>
-        <div class="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Message density">
+        <div
+          class="grid grid-cols-2 gap-3"
+          role="radiogroup"
+          aria-label="Message density"
+          onKeyDown={(e: KeyboardEvent) => {
+            const keys = ["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp"];
+            if (!keys.includes(e.key)) return;
+            e.preventDefault();
+            const currentIdx = densityOptions.findIndex((o) => o.id === messageDensity());
+            const forward = e.key === "ArrowRight" || e.key === "ArrowDown";
+            const nextIdx = forward
+              ? (currentIdx + 1) % densityOptions.length
+              : (currentIdx - 1 + densityOptions.length) % densityOptions.length;
+            const next = densityOptions[nextIdx];
+            if (next) {
+              setMessageDensity(next.id);
+              // Move focus to the newly selected radio
+              const container = e.currentTarget as HTMLElement;
+              const buttons = container.querySelectorAll<HTMLElement>("[role=radio]");
+              buttons[nextIdx]?.focus();
+            }
+          }}
+        >
           {densityOptions.map((opt) => (
             <button
               type="button"

--- a/apps/web/src/components/settings/appearance-settings.tsx
+++ b/apps/web/src/components/settings/appearance-settings.tsx
@@ -41,10 +41,13 @@ const AppearanceSettings = () => {
         <h3 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           Message Density
         </h3>
-        <div class="grid grid-cols-2 gap-3">
+        <div class="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Message density">
           {densityOptions.map((opt) => (
             <button
               type="button"
+              role="radio"
+              aria-checked={messageDensity() === opt.id}
+              tabIndex={messageDensity() === opt.id ? 0 : -1}
               class={`flex flex-col items-start gap-1 rounded-md border-2 p-4 text-left transition-colors ${
                 messageDensity() === opt.id
                   ? "border-primary bg-primary/5"

--- a/apps/web/src/components/settings/appearance-settings.tsx
+++ b/apps/web/src/components/settings/appearance-settings.tsx
@@ -1,18 +1,5 @@
-import { theme, setTheme, messageDensity, setMessageDensity } from "../../stores/theme-store.js";
-import type { Theme, MessageDensity } from "../../stores/theme-store.js";
-
-const themeOptions: { id: Theme; label: string; icon: string }[] = [
-  {
-    id: "dark",
-    label: "Dark",
-    icon: "M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z",
-  },
-  {
-    id: "light",
-    label: "Light",
-    icon: "M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z",
-  },
-];
+import { messageDensity, setMessageDensity } from "../../stores/theme-store.js";
+import type { MessageDensity } from "../../stores/theme-store.js";
 
 const densityOptions: { id: MessageDensity; label: string; description: string }[] = [
   { id: "cozy", label: "Cozy", description: "More spacing between messages" },
@@ -22,41 +9,30 @@ const densityOptions: { id: MessageDensity; label: string; description: string }
 const AppearanceSettings = () => {
   return (
     <div class="space-y-8">
-      {/* Theme */}
+      {/* Theme — dark only */}
       <div>
         <h3 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           Theme
         </h3>
-        <div class="grid grid-cols-2 gap-3">
-          {themeOptions.map((opt) => (
-            <button
-              type="button"
-              class={`flex flex-col items-center gap-3 rounded-lg border-2 p-4 transition-colors ${
-                theme() === opt.id
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-muted-foreground/30"
-              }`}
-              onClick={() => setTheme(opt.id)}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class={`h-8 w-8 ${theme() === opt.id ? "text-primary" : "text-muted-foreground"}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d={opt.icon} />
-              </svg>
-              <span
-                class={`text-sm font-medium ${
-                  theme() === opt.id ? "text-foreground" : "text-muted-foreground"
-                }`}
-              >
-                {opt.label}
-              </span>
-            </button>
-          ))}
+        <div class="flex items-center gap-3 rounded-md border border-border bg-card px-4 py-3">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 text-primary"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+            />
+          </svg>
+          <div>
+            <p class="text-sm font-medium text-foreground">Terminal Dark</p>
+            <p class="text-xs text-muted-foreground">The only theme. Dark mode always.</p>
+          </div>
         </div>
       </div>
 
@@ -69,7 +45,7 @@ const AppearanceSettings = () => {
           {densityOptions.map((opt) => (
             <button
               type="button"
-              class={`flex flex-col items-start gap-1 rounded-lg border-2 p-4 text-left transition-colors ${
+              class={`flex flex-col items-start gap-1 rounded-md border-2 p-4 text-left transition-colors ${
                 messageDensity() === opt.id
                   ? "border-primary bg-primary/5"
                   : "border-border hover:border-muted-foreground/30"

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { splitProps, type JSX } from "solid-js";
 import { cn } from "../../lib/cn.js";
 
 const buttonVariants = cva(
-  "relative inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium whitespace-nowrap transition-all duration-200 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50 disabled:pointer-events-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "relative inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all duration-150 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50 disabled:pointer-events-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = (props: DivProps) => {
     <div
       data-slot="card"
       class={cn(
-        "rounded-2xl border border-border bg-card text-card-foreground shadow-sm",
+        "rounded-md border border-border bg-card text-card-foreground shadow-sm",
         local.class,
       )}
       {...rest}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -119,7 +119,7 @@ const DialogContent = (props: DialogContentProps) => {
             aria-labelledby={titleId}
             aria-describedby={descriptionId}
             class={cn(
-              "relative mx-4 max-h-[85vh] w-full max-w-md overflow-y-auto rounded-xl border border-border bg-card p-6 shadow-md animate-scale-in sm:mx-0",
+              "relative mx-4 max-h-[85vh] w-full max-w-md overflow-y-auto rounded-md border border-border bg-card p-6 shadow-md animate-scale-in sm:mx-0",
               local.class,
             )}
             onClick={(e) => e.stopPropagation()}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = (props: InputProps) => {
     <input
       data-slot="input"
       class={cn(
-        "h-9 w-full rounded-lg border border-border bg-input px-3 text-sm text-foreground shadow-xs transition-shadow duration-200 placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:border-ring disabled:opacity-50 outline-none aria-[invalid=true]:border-destructive/50",
+        "h-9 w-full rounded-md border border-border bg-card px-3 text-sm text-foreground shadow-xs transition-shadow duration-150 placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:border-ring disabled:opacity-50 outline-none aria-[invalid=true]:border-destructive/50",
         local.class,
       )}
       {...rest}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = (props: InputProps) => {
     <input
       data-slot="input"
       class={cn(
-        "h-9 w-full rounded-md border border-border bg-card px-3 text-sm text-foreground shadow-xs transition-shadow duration-150 placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:border-ring disabled:opacity-50 outline-none aria-[invalid=true]:border-destructive/50",
+        "h-9 w-full rounded-md border border-border bg-input px-3 text-sm text-foreground shadow-xs transition-shadow duration-150 placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:border-ring disabled:opacity-50 outline-none aria-[invalid=true]:border-destructive/50",
         local.class,
       )}
       {...rest}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,6 +4,8 @@
 @theme inline {
   --font-sans:
     "DM Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono:
+    "Fira Code", "JetBrains Mono", "Courier New", monospace;
 
   /* Map semantic CSS vars → Tailwind color utilities */
   --color-background: var(--background);
@@ -34,26 +36,27 @@
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
 
-  /* Radius scale */
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  /* Radius scale — Terminal Dark: 4-6px max */
+  --radius-sm: 3px;
+  --radius-md: 4px;
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --radius-2xl: calc(var(--radius) + 8px);
+  --radius-xl: calc(var(--radius) + 2px);
+  --radius-2xl: calc(var(--radius) + 4px);
 
-  /* Shadow scale (brand-tinted hue 155) */
-  --shadow-xs: 0 1px 2px oklch(0.15 0.01 155 / 20%);
-  --shadow-sm: 0 1px 3px oklch(0.15 0.01 155 / 24%), 0 1px 2px oklch(0.15 0.01 155 / 16%);
-  --shadow-md: 0 4px 6px oklch(0.15 0.01 155 / 20%), 0 2px 4px oklch(0.15 0.01 155 / 12%);
-  --shadow-lg: 0 10px 15px oklch(0.15 0.01 155 / 20%), 0 4px 6px oklch(0.15 0.01 155 / 10%);
+  /* Shadow scale — minimal, no decorative shadows */
+  --shadow-xs: 0 1px 2px rgb(0 0 0 / 20%);
+  --shadow-sm: 0 1px 3px rgb(0 0 0 / 24%), 0 1px 2px rgb(0 0 0 / 16%);
+  --shadow-md: 0 4px 6px rgb(0 0 0 / 20%), 0 2px 4px rgb(0 0 0 / 12%);
+  --shadow-lg: 0 10px 15px rgb(0 0 0 / 20%), 0 4px 6px rgb(0 0 0 / 10%);
 
   /* Animation */
   --animate-skeleton: skeleton 2s -1s infinite linear;
   --animate-scale-in: scale-in 200ms ease-out;
   --animate-slide-in: slide-in 300ms ease-out;
-  --animate-fade-in: fade-in 200ms ease-out;
-  --animate-slide-in-left: slide-in-left 200ms ease-out;
-  --animate-slide-in-right: slide-in-right 200ms ease-out;
+  --animate-fade-in: fade-in 150ms ease-out;
+  --animate-slide-in-left: slide-in-left 150ms ease-out;
+  --animate-slide-in-right: slide-in-right 150ms ease-out;
+  --animate-cursor-blink: cursor-blink 1s step-end infinite;
 
   @keyframes slide-in-left {
     from {
@@ -104,6 +107,10 @@
       opacity: 1;
     }
   }
+  @keyframes cursor-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
 }
 
 @layer base {
@@ -115,110 +122,58 @@
   }
 }
 
+/* ── Terminal Dark palette ─────────────────────────────────────────── */
 :root {
-  --radius: 0.625rem;
+  --radius: 6px;
   color-scheme: dark;
 
-  /* Green-tinted dark palette (Railway-inspired, hue ~150°) */
-  --background: oklch(0.178 0.02 155);
-  --foreground: oklch(0.955 0.008 155);
+  --background: #0A0A0A;
+  --foreground: #E8E8E8;
 
-  --card: oklch(0.21 0.018 155);
-  --card-foreground: oklch(0.955 0.008 155);
+  --card: #111111;
+  --card-foreground: #E8E8E8;
 
-  --popover: oklch(0.21 0.018 155);
-  --popover-foreground: oklch(0.955 0.008 155);
+  --popover: #111111;
+  --popover-foreground: #E8E8E8;
 
-  --primary: oklch(0.66 0.17 155);
-  --primary-foreground: oklch(1 0 0);
+  --primary: #16A37F;
+  --primary-foreground: #0A0A0A;
 
-  --secondary: oklch(1 0 0 / 4%);
-  --secondary-foreground: oklch(0.91 0.008 155);
+  --secondary: #181818;
+  --secondary-foreground: #888888;
 
-  --muted: oklch(1 0 0 / 5%);
-  --muted-foreground: oklch(0.62 0.008 155);
+  --muted: #181818;
+  --muted-foreground: #3A3A3A;
 
-  --accent: oklch(1 0 0 / 4%);
-  --accent-foreground: oklch(0.955 0.008 155);
+  --accent: #181818;
+  --accent-foreground: #E8E8E8;
 
-  --destructive: oklch(0.55 0.2 25);
-  --destructive-foreground: oklch(0.78 0.12 25);
+  --destructive: #F87171;
+  --destructive-foreground: #0A0A0A;
 
-  --border: oklch(1 0 0 / 6%);
-  --input: oklch(1 0 0 / 8%);
-  --ring: oklch(0.66 0.17 155);
+  --border: #2A2A2A;
+  --input: #111111;
+  --ring: #16A37F;
 
-  --success: oklch(0.66 0.17 155);
-  --success-foreground: oklch(0.78 0.12 155);
+  --success: #16A37F;
+  --success-foreground: #0A0A0A;
 
-  --warning: oklch(0.75 0.16 75);
-  --warning-foreground: oklch(0.85 0.1 75);
+  --warning: #D97706;
+  --warning-foreground: #0A0A0A;
 
-  --info: oklch(0.65 0.16 255);
-  --info-foreground: oklch(0.78 0.1 255);
+  --info: #3B82F6;
+  --info-foreground: #0A0A0A;
 
-  --sidebar: oklch(0.16 0.022 155);
-  --sidebar-foreground: oklch(0.955 0.008 155);
+  --sidebar: #0A0A0A;
+  --sidebar-foreground: #E8E8E8;
 
-  /* Z-index scale (consumed directly as Tailwind utilities: z-40, z-50, z-60, z-70) */
   --z-noise: 9999;
 }
 
-.light {
-  color-scheme: light;
-
-  --background: oklch(0.97 0.008 155);
-  --foreground: oklch(0.18 0.02 155);
-
-  --card: oklch(0.99 0.004 155);
-  --card-foreground: oklch(0.18 0.02 155);
-
-  --popover: oklch(0.99 0.004 155);
-  --popover-foreground: oklch(0.18 0.02 155);
-
-  --primary: oklch(0.52 0.17 155);
-  --primary-foreground: oklch(1 0 0);
-
-  --secondary: oklch(0 0 0 / 4%);
-  --secondary-foreground: oklch(0.25 0.02 155);
-
-  --muted: oklch(0 0 0 / 5%);
-  --muted-foreground: oklch(0.45 0.015 155);
-
-  --accent: oklch(0 0 0 / 4%);
-  --accent-foreground: oklch(0.18 0.02 155);
-
-  --destructive: oklch(0.55 0.2 25);
-  --destructive-foreground: oklch(0.45 0.15 25);
-
-  --border: oklch(0 0 0 / 10%);
-  --input: oklch(0 0 0 / 8%);
-  --ring: oklch(0.52 0.17 155);
-
-  --success: oklch(0.52 0.17 155);
-  --success-foreground: oklch(0.4 0.12 155);
-
-  --warning: oklch(0.65 0.16 75);
-  --warning-foreground: oklch(0.5 0.12 75);
-
-  --info: oklch(0.55 0.16 255);
-  --info-foreground: oklch(0.4 0.12 255);
-
-  --sidebar: oklch(0.95 0.01 155);
-  --sidebar-foreground: oklch(0.18 0.02 155);
-}
-
-.light *,
-.light *::-webkit-scrollbar-thumb {
-  scrollbar-color: oklch(0 0 0 / 15%) transparent;
-}
-
-.light *::-webkit-scrollbar-thumb {
-  background: oklch(0 0 0 / 15%);
-}
-
-.light *::-webkit-scrollbar-thumb:hover {
-  background: oklch(0 0 0 / 25%);
+/* ── Selection ─────────────────────────────────────────────────────── */
+::selection {
+  background: #16A37F33;
+  color: #E8E8E8;
 }
 
 body::after {
@@ -226,34 +181,35 @@ body::after {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  opacity: 0.035;
+  opacity: 0.025;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
   background-repeat: repeat;
   background-size: 256px 256px;
   z-index: var(--z-noise);
 }
 
+/* ── Scrollbars — thin 3px ─────────────────────────────────────────── */
 * {
   scrollbar-width: thin;
-  scrollbar-color: oklch(1 0 0 / 12%) transparent;
+  scrollbar-color: #2A2A2A #0A0A0A;
 }
 
 *::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 3px;
+  height: 3px;
 }
 
 *::-webkit-scrollbar-track {
-  background: transparent;
+  background: #0A0A0A;
 }
 
 *::-webkit-scrollbar-thumb {
-  background: oklch(1 0 0 / 12%);
+  background: #2A2A2A;
   border-radius: 9999px;
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background: oklch(1 0 0 / 20%);
+  background: #3A3A3A;
 }
 
 .typing-dots {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -168,6 +168,10 @@
   --sidebar: #0A0A0A;
   --sidebar-foreground: #E8E8E8;
 
+  --scroll-track: #0A0A0A;
+  --scroll-thumb: #2A2A2A;
+  --scroll-thumb-hover: #3A3A3A;
+
   --z-noise: 9999;
 }
 
@@ -192,7 +196,7 @@ body::after {
 /* ── Scrollbars — thin 3px ─────────────────────────────────────────── */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #2A2A2A #0A0A0A;
+  scrollbar-color: var(--scroll-thumb) var(--scroll-track);
 }
 
 *::-webkit-scrollbar {
@@ -201,16 +205,16 @@ body::after {
 }
 
 *::-webkit-scrollbar-track {
-  background: #0A0A0A;
+  background: var(--scroll-track);
 }
 
 *::-webkit-scrollbar-thumb {
-  background: #2A2A2A;
+  background: var(--scroll-thumb);
   border-radius: 9999px;
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background: #3A3A3A;
+  background: var(--scroll-thumb-hover);
 }
 
 .typing-dots {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -124,8 +124,9 @@
 
 /* ── Terminal Dark palette ─────────────────────────────────────────── */
 :root {
-  --radius: 6px;
   color-scheme: dark;
+
+  --radius: 6px;
 
   --background: #0A0A0A;
   --foreground: #E8E8E8;
@@ -143,7 +144,7 @@
   --secondary-foreground: #888888;
 
   --muted: #181818;
-  --muted-foreground: #3A3A3A;
+  --muted-foreground: #6B6B6B;
 
   --accent: #181818;
   --accent-foreground: #E8E8E8;

--- a/apps/web/src/pages/Billing.tsx
+++ b/apps/web/src/pages/Billing.tsx
@@ -1,11 +1,12 @@
 import { createSignal, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
+import type { PaidTier } from "@uncorded/shared";
 import SubscriptionModal from "../components/modals/SubscriptionModal.js";
 import CheckoutModal from "../components/modals/CheckoutModal.js";
 
 const Billing = () => {
   const navigate = useNavigate();
-  const [checkoutTier, setCheckoutTier] = createSignal<"supporter" | "server_owner" | null>(null);
+  const [checkoutTier, setCheckoutTier] = createSignal<PaidTier | null>(null);
   const [showSub, setShowSub] = createSignal(true);
 
   return (

--- a/apps/web/src/pages/Billing.tsx
+++ b/apps/web/src/pages/Billing.tsx
@@ -1,0 +1,40 @@
+import { createSignal, Show } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import SubscriptionModal from "../components/modals/SubscriptionModal.js";
+import CheckoutModal from "../components/modals/CheckoutModal.js";
+
+const Billing = () => {
+  const navigate = useNavigate();
+  const [checkoutTier, setCheckoutTier] = createSignal<"supporter" | "server_owner" | null>(null);
+  const [showSub, setShowSub] = createSignal(true);
+
+  return (
+    <>
+      <Show when={showSub()}>
+        <SubscriptionModal
+          onClose={() => {
+            setShowSub(false);
+            navigate("/settings/profile");
+          }}
+          onCheckout={(tier) => {
+            setShowSub(false);
+            setCheckoutTier(tier);
+          }}
+        />
+      </Show>
+      <Show when={checkoutTier()}>
+        {(tier) => (
+          <CheckoutModal
+            tier={tier()}
+            onClose={() => {
+              setCheckoutTier(null);
+              navigate("/settings/profile");
+            }}
+          />
+        )}
+      </Show>
+    </>
+  );
+};
+
+export default Billing;

--- a/apps/web/src/pages/DirectMessage.tsx
+++ b/apps/web/src/pages/DirectMessage.tsx
@@ -1,8 +1,9 @@
 import { createEffect, Show } from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
-import type { DmChannelId } from "@uncorded/protocol";
+import type { UserId } from "@uncorded/protocol";
 import { readyData } from "../lib/gateway-store.js";
 import { selectDmChannel, selectedDmChannelId } from "../stores/app-store.js";
+import { fetchMoreDms, loadingMoreDms } from "../stores/friend-store.js";
 import ChatArea from "../components/ChatArea.js";
 import { Empty } from "../components/ui/empty.js";
 
@@ -10,37 +11,62 @@ const DirectMessage = () => {
   const params = useParams<{ userId: string }>();
   const navigate = useNavigate();
 
+  const userId = () => params.userId as UserId;
+
+  const findDm = () =>
+    readyData.data?.dmChannels.find((d) => d.otherUser.id === userId());
+
   // Auto-select the DM channel matching the URL userId
   createEffect(() => {
-    const userId = params.userId;
-    const dm = readyData.data?.dmChannels.find((d) => d.otherUser.id === userId);
+    const dm = findDm();
     if (dm && selectedDmChannelId() !== dm.id) {
-      selectDmChannel(dm.id as DmChannelId);
+      selectDmChannel(dm.id);
     }
   });
 
-  const hasDm = () =>
-    readyData.data?.dmChannels.some((d) => d.otherUser.id === params.userId) ?? false;
+  // If DM not in loaded slice but more pages exist, fetch them
+  createEffect(() => {
+    if (!findDm() && readyData.data?.hasMoreDmChannels && !loadingMoreDms()) {
+      fetchMoreDms();
+    }
+  });
+
+  const isLoading = () =>
+    !findDm() && (loadingMoreDms() || (readyData.data?.hasMoreDmChannels ?? false));
+
+  const hasDm = () => findDm() !== undefined;
 
   return (
     <Show
-      when={hasDm()}
+      when={!isLoading()}
       fallback={
-        <Empty
-          title="Conversation not found"
-          description="This DM doesn't exist or hasn't started yet."
-        >
-          <button
-            type="button"
-            onClick={() => navigate("/messages")}
-            class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-          >
-            &larr; Back to Messages
-          </button>
-        </Empty>
+        <div class="flex flex-1 items-center justify-center">
+          <div class="flex animate-fade-in flex-col items-center gap-3">
+            <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <p class="text-muted-foreground">Loading conversation...</p>
+          </div>
+        </div>
       }
     >
-      <ChatArea />
+      <Show
+        when={hasDm()}
+        fallback={
+          <Empty
+            title="Conversation not found"
+            description="This DM doesn't exist or hasn't started yet."
+          >
+            <button
+              type="button"
+              onClick={() => navigate("/messages")}
+              class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+            >
+              &larr; Back to Messages
+            </button>
+          </Empty>
+        }
+      >
+        <ChatArea />
+      </Show>
     </Show>
   );
 };

--- a/apps/web/src/pages/DirectMessage.tsx
+++ b/apps/web/src/pages/DirectMessage.tsx
@@ -1,4 +1,4 @@
-import { createEffect, Show } from "solid-js";
+import { createEffect, createSignal, Show } from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
 import type { UserId } from "@uncorded/protocol";
 import { readyData } from "../lib/gateway-store.js";
@@ -10,6 +10,7 @@ import { Empty } from "../components/ui/empty.js";
 const DirectMessage = () => {
   const params = useParams<{ userId: string }>();
   const navigate = useNavigate();
+  const [fetchFailed, setFetchFailed] = createSignal(false);
 
   const userId = () => params.userId as UserId;
 
@@ -24,15 +25,15 @@ const DirectMessage = () => {
     }
   });
 
-  // If DM not in loaded slice but more pages exist, fetch them
+  // If DM not in loaded slice but more pages exist, fetch them (once)
   createEffect(() => {
-    if (!findDm() && readyData.data?.hasMoreDmChannels && !loadingMoreDms()) {
-      fetchMoreDms();
+    if (!findDm() && readyData.data?.hasMoreDmChannels && !loadingMoreDms() && !fetchFailed()) {
+      fetchMoreDms().catch(() => setFetchFailed(true));
     }
   });
 
   const isLoading = () =>
-    !findDm() && (loadingMoreDms() || (readyData.data?.hasMoreDmChannels ?? false));
+    !findDm() && !fetchFailed() && (loadingMoreDms() || (readyData.data?.hasMoreDmChannels ?? false));
 
   const hasDm = () => findDm() !== undefined;
 

--- a/apps/web/src/pages/DirectMessage.tsx
+++ b/apps/web/src/pages/DirectMessage.tsx
@@ -1,0 +1,48 @@
+import { createEffect, Show } from "solid-js";
+import { useParams, useNavigate } from "@solidjs/router";
+import type { DmChannelId } from "@uncorded/protocol";
+import { readyData } from "../lib/gateway-store.js";
+import { selectDmChannel, selectedDmChannelId } from "../stores/app-store.js";
+import ChatArea from "../components/ChatArea.js";
+import { Empty } from "../components/ui/empty.js";
+
+const DirectMessage = () => {
+  const params = useParams<{ userId: string }>();
+  const navigate = useNavigate();
+
+  // Auto-select the DM channel matching the URL userId
+  createEffect(() => {
+    const userId = params.userId;
+    const dm = readyData.data?.dmChannels.find((d) => d.otherUser.id === userId);
+    if (dm && selectedDmChannelId() !== dm.id) {
+      selectDmChannel(dm.id as DmChannelId);
+    }
+  });
+
+  const hasDm = () =>
+    readyData.data?.dmChannels.some((d) => d.otherUser.id === params.userId) ?? false;
+
+  return (
+    <Show
+      when={hasDm()}
+      fallback={
+        <Empty
+          title="Conversation not found"
+          description="This DM doesn't exist or hasn't started yet."
+        >
+          <button
+            type="button"
+            onClick={() => navigate("/messages")}
+            class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            &larr; Back to Messages
+          </button>
+        </Empty>
+      }
+    >
+      <ChatArea />
+    </Show>
+  );
+};
+
+export default DirectMessage;

--- a/apps/web/src/pages/FallbackPage.tsx
+++ b/apps/web/src/pages/FallbackPage.tsx
@@ -29,7 +29,7 @@ const FallbackPage = (props: FallbackPageProps) => {
       <button
         type="button"
         onClick={handleCta}
-        class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+        class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
       >
         {ctaLabel()}
       </button>

--- a/apps/web/src/pages/FallbackPage.tsx
+++ b/apps/web/src/pages/FallbackPage.tsx
@@ -1,20 +1,37 @@
 import { useNavigate } from "@solidjs/router";
 
-const FallbackPage = () => {
+interface FallbackPageProps {
+  title?: string;
+  description?: string;
+  ctaLabel?: string;
+  ctaTarget?: string;
+}
+
+const FallbackPage = (props: FallbackPageProps) => {
   const navigate = useNavigate();
+
+  const title = () => props.title ?? "Coming Soon";
+  const description = () => props.description ?? "This feature is under development.";
+  const ctaLabel = () => props.ctaLabel ?? "\u2190 Back";
+
+  const handleCta = () => {
+    if (props.ctaTarget) {
+      navigate(props.ctaTarget);
+    } else {
+      navigate(-1);
+    }
+  };
 
   return (
     <div class="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
-      <h1 class="font-mono text-xl font-semibold text-foreground">Coming Soon</h1>
-      <p class="max-w-sm text-sm text-muted-foreground">
-        This feature is under development.
-      </p>
+      <h1 class="font-mono text-xl font-semibold text-foreground">{title()}</h1>
+      <p class="max-w-sm text-sm text-muted-foreground">{description()}</p>
       <button
         type="button"
-        onClick={() => navigate(-1)}
+        onClick={handleCta}
         class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
       >
-        &larr; Back
+        {ctaLabel()}
       </button>
     </div>
   );

--- a/apps/web/src/pages/FallbackPage.tsx
+++ b/apps/web/src/pages/FallbackPage.tsx
@@ -1,0 +1,23 @@
+import { useNavigate } from "@solidjs/router";
+
+const FallbackPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div class="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+      <h1 class="font-mono text-xl font-semibold text-foreground">Coming Soon</h1>
+      <p class="max-w-sm text-sm text-muted-foreground">
+        This feature is under development.
+      </p>
+      <button
+        type="button"
+        onClick={() => navigate(-1)}
+        class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+      >
+        &larr; Back
+      </button>
+    </div>
+  );
+};
+
+export default FallbackPage;

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import type { ActivePoll, ActivePollEntry } from "@uncorded/shared";
 import { readyData } from "../lib/gateway-store.js";
 import { api, ApiRequestError } from "../lib/api.js";
 import { showToast } from "../components/ui/toast.js";
+import ContentHeader from "../components/ContentHeader.js";
 import {
   Dialog,
   DialogContent,
@@ -94,7 +95,9 @@ const Home = () => {
   const hasVoted = () => poll()?.userVote !== null && poll()?.userVote !== undefined;
 
   return (
-    <div class="flex h-full flex-col items-center justify-start gap-4 overflow-y-auto px-6 pt-[15vh] text-center">
+    <div class="flex h-full flex-col">
+      <ContentHeader title="Home" />
+      <div class="flex flex-1 flex-col items-center justify-start gap-4 overflow-y-auto px-6 pt-[15vh] text-center">
       <h1 class="text-2xl font-bold text-foreground">
         Welcome back{username() ? `, ${username()}` : ""}
       </h1>
@@ -212,6 +215,7 @@ const Home = () => {
           </p>
         </DialogContent>
       </Dialog>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/pages/Messages.tsx
+++ b/apps/web/src/pages/Messages.tsx
@@ -1,7 +1,8 @@
 import { For, Show } from "solid-js";
-import { useNavigate } from "@solidjs/router";
+import { useNavigate, useParams } from "@solidjs/router";
+import type { DmChannelId } from "@uncorded/protocol";
 import { readyData } from "../lib/gateway-store.js";
-import { selectDmChannel, selectedDmChannelId } from "../stores/app-store.js";
+import { selectDmChannel } from "../stores/app-store.js";
 import { fetchMoreDms, loadingMoreDms } from "../stores/friend-store.js";
 import { getUnreadCount } from "../stores/notification-store.js";
 import StatusDot, { type UserStatus } from "../components/StatusDot.js";
@@ -9,11 +10,15 @@ import { Empty } from "../components/ui/empty.js";
 
 const Messages = () => {
   const navigate = useNavigate();
+  const params = useParams<{ userId?: string }>();
 
-  const handleSelect = (dmId: string, userId: string) => {
-    selectDmChannel(dmId as import("@uncorded/protocol").DmChannelId);
+  const handleSelect = (dmId: DmChannelId, userId: string) => {
+    selectDmChannel(dmId);
     navigate(`/messages/${userId}`);
   };
+
+  // Derive active state from route param, not global selection
+  const activeUserId = () => params.userId;
 
   return (
     <div class="flex h-full flex-col">
@@ -52,7 +57,7 @@ const Messages = () => {
                 const displayName = () =>
                   dm.otherUser.displayName ?? dm.otherUser.username ?? "Unknown";
                 const initial = () => displayName().charAt(0).toUpperCase();
-                const isActive = () => selectedDmChannelId() === dm.id;
+                const isActive = () => activeUserId() === dm.otherUser.id;
                 const unread = () => getUnreadCount(dm.id);
 
                 return (

--- a/apps/web/src/pages/Messages.tsx
+++ b/apps/web/src/pages/Messages.tsx
@@ -1,6 +1,6 @@
 import { For, Show } from "solid-js";
 import { useNavigate, useParams } from "@solidjs/router";
-import type { DmChannelId } from "@uncorded/protocol";
+import type { DmChannelId, UserId } from "@uncorded/protocol";
 import { readyData } from "../lib/gateway-store.js";
 import { selectDmChannel } from "../stores/app-store.js";
 import { fetchMoreDms, loadingMoreDms } from "../stores/friend-store.js";
@@ -12,7 +12,7 @@ const Messages = () => {
   const navigate = useNavigate();
   const params = useParams<{ userId?: string }>();
 
-  const handleSelect = (dmId: DmChannelId, userId: string) => {
+  const handleSelect = (dmId: DmChannelId, userId: UserId) => {
     selectDmChannel(dmId);
     navigate(`/messages/${userId}`);
   };

--- a/apps/web/src/pages/Messages.tsx
+++ b/apps/web/src/pages/Messages.tsx
@@ -1,0 +1,126 @@
+import { For, Show } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import { readyData } from "../lib/gateway-store.js";
+import { selectDmChannel, selectedDmChannelId } from "../stores/app-store.js";
+import { fetchMoreDms, loadingMoreDms } from "../stores/friend-store.js";
+import { getUnreadCount } from "../stores/notification-store.js";
+import StatusDot, { type UserStatus } from "../components/StatusDot.js";
+import { Empty } from "../components/ui/empty.js";
+
+const Messages = () => {
+  const navigate = useNavigate();
+
+  const handleSelect = (dmId: string, userId: string) => {
+    selectDmChannel(dmId as import("@uncorded/protocol").DmChannelId);
+    navigate(`/messages/${userId}`);
+  };
+
+  return (
+    <div class="flex h-full flex-col">
+      <div class="border-b border-border px-6 py-4">
+        <h1 class="text-lg font-semibold text-foreground">Direct Messages</h1>
+      </div>
+
+      <div class="flex-1 overflow-y-auto">
+        <Show
+          when={(readyData.data?.dmChannels ?? []).length > 0}
+          fallback={
+            <Empty
+              title="No conversations yet"
+              description="Start a DM from the Friends page"
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z"
+                  />
+                </svg>
+              }
+            />
+          }
+        >
+          <div class="flex flex-col">
+            <For each={readyData.data?.dmChannels}>
+              {(dm) => {
+                const displayName = () =>
+                  dm.otherUser.displayName ?? dm.otherUser.username ?? "Unknown";
+                const initial = () => displayName().charAt(0).toUpperCase();
+                const isActive = () => selectedDmChannelId() === dm.id;
+                const unread = () => getUnreadCount(dm.id);
+
+                return (
+                  <button
+                    type="button"
+                    class={`flex items-center gap-3 px-6 py-3 text-left transition-colors ${
+                      isActive()
+                        ? "bg-accent"
+                        : "hover:bg-accent/50"
+                    }`}
+                    onClick={() => handleSelect(dm.id, dm.otherUser.id)}
+                  >
+                    <div class="relative shrink-0">
+                      <Show
+                        when={dm.otherUser.avatarUrl}
+                        fallback={
+                          <div class="flex h-10 w-10 items-center justify-center rounded-md bg-primary text-sm font-bold text-primary-foreground">
+                            {initial()}
+                          </div>
+                        }
+                      >
+                        {(url) => (
+                          <img
+                            src={url()}
+                            alt={displayName()}
+                            class="h-10 w-10 rounded-md object-cover"
+                          />
+                        )}
+                      </Show>
+                      <StatusDot
+                        status={dm.otherUser.status as UserStatus}
+                        size="sm"
+                        borderClass="border-background"
+                      />
+                    </div>
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <span class="truncate text-sm font-medium text-foreground">
+                          {displayName()}
+                        </span>
+                        <Show when={!isActive() && unread() > 0}>
+                          <span class="flex h-4 min-w-4 shrink-0 items-center justify-center rounded-md bg-primary px-1 font-mono text-[10px] font-bold text-primary-foreground">
+                            {unread()}
+                          </span>
+                        </Show>
+                      </div>
+                      <p class="truncate font-mono text-xs text-muted-foreground">
+                        @{dm.otherUser.username ?? "unknown"}
+                      </p>
+                    </div>
+                  </button>
+                );
+              }}
+            </For>
+          </div>
+          <Show when={readyData.data?.hasMoreDmChannels}>
+            <button
+              class="mx-6 my-3 rounded-md px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+              disabled={loadingMoreDms()}
+              onClick={() => fetchMoreDms()}
+            >
+              {loadingMoreDms() ? "Loading..." : "Load more"}
+            </button>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default Messages;

--- a/apps/web/src/pages/ServerView.tsx
+++ b/apps/web/src/pages/ServerView.tsx
@@ -1,0 +1,61 @@
+import { createEffect, Show } from "solid-js";
+import { useParams, useNavigate } from "@solidjs/router";
+import type { ServerId } from "@uncorded/protocol";
+import { readyData } from "../lib/gateway-store.js";
+import {
+  selectedServerId,
+  setSelectedServerId,
+  selectedChannelId,
+} from "../stores/app-store.js";
+import ChatArea from "../components/ChatArea.js";
+import { Empty } from "../components/ui/empty.js";
+
+const ServerView = () => {
+  const params = useParams<{ serverId: string }>();
+  const navigate = useNavigate();
+
+  // Auto-select server from URL param
+  createEffect(() => {
+    const id = params.serverId as ServerId;
+    if (id && selectedServerId() !== id) {
+      setSelectedServerId(id);
+    }
+  });
+
+  const hasServer = () =>
+    readyData.data?.servers.some((s) => s.id === params.serverId) ?? false;
+
+  return (
+    <Show
+      when={hasServer() && selectedChannelId()}
+      fallback={
+        <Show
+          when={hasServer()}
+          fallback={
+            <Empty
+              title="Server not found"
+              description="You may not be a member of this server."
+            >
+              <button
+                type="button"
+                onClick={() => navigate("/home")}
+                class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+              >
+                &larr; Back to Home
+              </button>
+            </Empty>
+          }
+        >
+          <Empty
+            title="No channels"
+            description="This server has no channels yet."
+          />
+        </Show>
+      }
+    >
+      <ChatArea />
+    </Show>
+  );
+};
+
+export default ServerView;

--- a/apps/web/src/pages/ServerView.tsx
+++ b/apps/web/src/pages/ServerView.tsx
@@ -2,6 +2,7 @@ import { createEffect, Show } from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
 import type { ServerId } from "@uncorded/protocol";
 import { readyData } from "../lib/gateway-store.js";
+import { channelCacheLoading } from "../lib/gateway-store.js";
 import {
   selectedServerId,
   setSelectedServerId,
@@ -25,6 +26,9 @@ const ServerView = () => {
   const hasServer = () =>
     readyData.data?.servers.some((s) => s.id === params.serverId) ?? false;
 
+  const isLoadingChannels = () =>
+    channelCacheLoading() === (params.serverId as ServerId);
+
   return (
     <Show
       when={hasServer() && selectedChannelId()}
@@ -46,10 +50,22 @@ const ServerView = () => {
             </Empty>
           }
         >
-          <Empty
-            title="No channels"
-            description="This server has no channels yet."
-          />
+          <Show
+            when={!isLoadingChannels()}
+            fallback={
+              <div class="flex flex-1 items-center justify-center">
+                <div class="flex animate-fade-in flex-col items-center gap-3">
+                  <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                  <p class="text-muted-foreground">Loading channels...</p>
+                </div>
+              </div>
+            }
+          >
+            <Empty
+              title="No channels"
+              description="This server has no channels yet."
+            />
+          </Show>
         </Show>
       }
     >

--- a/apps/web/src/pages/SettingsLayout.tsx
+++ b/apps/web/src/pages/SettingsLayout.tsx
@@ -1,0 +1,92 @@
+import { For } from "solid-js";
+import { A, useLocation, type RouteSectionProps } from "@solidjs/router";
+
+const navItems = [
+  { label: "Profile", href: "/settings/profile" },
+  { label: "Account", href: "/settings/account" },
+  { label: "Appearance", href: "/settings/appearance" },
+  { label: "Transfers", href: "/settings/transfers" },
+  { divider: true as const },
+  { label: "Upgrade", href: "/settings/upgrade" },
+  { label: "Billing", href: "/settings/billing" },
+  { label: "Notifications", href: "/settings/notifications" },
+] as const;
+
+const SettingsLayout = (props: RouteSectionProps) => {
+  const location = useLocation();
+
+  const isActive = (href: string) => location.pathname === href;
+
+  return (
+    <div class="flex h-full">
+      {/* Settings sidebar nav — hidden on mobile, shows as list page instead */}
+      <nav class="hidden w-52 shrink-0 border-r border-border sm:block">
+        <div class="flex flex-col gap-0.5 p-3">
+          <For each={navItems}>
+            {(item) => {
+              if ("divider" in item) {
+                return <div class="my-1.5 h-px bg-border" />;
+              }
+              return (
+                <A
+                  href={item.href}
+                  class={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                    isActive(item.href)
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }`}
+                >
+                  {item.label}
+                </A>
+              );
+            }}
+          </For>
+        </div>
+      </nav>
+
+      {/* Mobile: show nav list when on /settings exactly */}
+      <div class="flex flex-1 flex-col overflow-y-auto sm:hidden">
+        {location.pathname === "/settings" || location.pathname === "/settings/" ? (
+          <div class="flex flex-col gap-0.5 p-3">
+            <For each={navItems}>
+              {(item) => {
+                if ("divider" in item) {
+                  return <div class="my-1.5 h-px bg-border" />;
+                }
+                return (
+                  <A
+                    href={item.href}
+                    class="flex items-center justify-between rounded-md px-3 py-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+                  >
+                    {item.label}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="h-4 w-4 text-muted-foreground"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </A>
+                );
+              }}
+            </For>
+          </div>
+        ) : (
+          <div class="flex-1 overflow-y-auto p-6">
+            <div class="mx-auto max-w-2xl">{props.children}</div>
+          </div>
+        )}
+      </div>
+
+      {/* Desktop content area */}
+      <div class="hidden flex-1 overflow-y-auto p-6 sm:block">
+        <div class="mx-auto max-w-2xl">{props.children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsLayout;

--- a/apps/web/src/pages/SettingsRedirect.tsx
+++ b/apps/web/src/pages/SettingsRedirect.tsx
@@ -1,0 +1,10 @@
+import { onMount } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+
+const SettingsRedirect = () => {
+  const navigate = useNavigate();
+  onMount(() => navigate("/settings/profile", { replace: true }));
+  return null;
+};
+
+export default SettingsRedirect;

--- a/apps/web/src/pages/Upgrade.tsx
+++ b/apps/web/src/pages/Upgrade.tsx
@@ -1,11 +1,12 @@
 import { createSignal, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
+import type { PaidTier } from "@uncorded/shared";
 import PricingModal from "../components/modals/PricingModal.js";
 import CheckoutModal from "../components/modals/CheckoutModal.js";
 
 const Upgrade = () => {
   const navigate = useNavigate();
-  const [checkoutTier, setCheckoutTier] = createSignal<"supporter" | "server_owner" | null>(null);
+  const [checkoutTier, setCheckoutTier] = createSignal<PaidTier | null>(null);
   const [showPricing, setShowPricing] = createSignal(true);
 
   return (

--- a/apps/web/src/pages/Upgrade.tsx
+++ b/apps/web/src/pages/Upgrade.tsx
@@ -1,0 +1,40 @@
+import { createSignal, Show } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import PricingModal from "../components/modals/PricingModal.js";
+import CheckoutModal from "../components/modals/CheckoutModal.js";
+
+const Upgrade = () => {
+  const navigate = useNavigate();
+  const [checkoutTier, setCheckoutTier] = createSignal<"supporter" | "server_owner" | null>(null);
+  const [showPricing, setShowPricing] = createSignal(true);
+
+  return (
+    <>
+      <Show when={showPricing()}>
+        <PricingModal
+          onClose={() => {
+            setShowPricing(false);
+            navigate("/settings/profile");
+          }}
+          onSelect={(tier) => {
+            setShowPricing(false);
+            setCheckoutTier(tier);
+          }}
+        />
+      </Show>
+      <Show when={checkoutTier()}>
+        {(tier) => (
+          <CheckoutModal
+            tier={tier()}
+            onClose={() => {
+              setCheckoutTier(null);
+              navigate("/settings/profile");
+            }}
+          />
+        )}
+      </Show>
+    </>
+  );
+};
+
+export default Upgrade;

--- a/apps/web/src/pages/settings/account-settings.tsx
+++ b/apps/web/src/pages/settings/account-settings.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../components/settings/account-settings.js";

--- a/apps/web/src/pages/settings/appearance-settings.tsx
+++ b/apps/web/src/pages/settings/appearance-settings.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../components/settings/appearance-settings.js";

--- a/apps/web/src/pages/settings/notification-settings.tsx
+++ b/apps/web/src/pages/settings/notification-settings.tsx
@@ -1,0 +1,10 @@
+import FallbackPage from "../FallbackPage.js";
+
+const NotificationSettings = () => (
+  <FallbackPage
+    title="Notifications"
+    description="Notification preferences are coming soon."
+  />
+);
+
+export default NotificationSettings;

--- a/apps/web/src/pages/settings/profile-settings.tsx
+++ b/apps/web/src/pages/settings/profile-settings.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../components/settings/profile-settings.js";

--- a/apps/web/src/pages/settings/transfer-history.tsx
+++ b/apps/web/src/pages/settings/transfer-history.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../components/settings/transfer-history.js";

--- a/apps/web/src/stores/theme-store.ts
+++ b/apps/web/src/stores/theme-store.ts
@@ -1,6 +1,5 @@
 import { createSignal } from "solid-js";
 
-export type Theme = "dark" | "light";
 export type MessageDensity = "cozy" | "compact";
 
 function readLocal<T extends string>(key: string, fallback: T, allowed: readonly T[]): T {
@@ -12,34 +11,11 @@ function readLocal<T extends string>(key: string, fallback: T, allowed: readonly
   }
 }
 
-const THEMES: readonly Theme[] = ["dark", "light"];
 const DENSITIES: readonly MessageDensity[] = ["cozy", "compact"];
 
-const [theme, setThemeSignal] = createSignal<Theme>(readLocal("uncorded-theme", "dark", THEMES));
 const [messageDensity, setDensitySignal] = createSignal<MessageDensity>(
   readLocal("uncorded-density", "cozy", DENSITIES),
 );
-
-function applyTheme(t: Theme) {
-  const html = document.documentElement;
-  html.classList.add("no-transitions");
-  html.classList.remove("dark", "light");
-  html.classList.add(t);
-  html.style.colorScheme = t;
-  // Force reflow then remove no-transitions
-  void html.offsetHeight;
-  html.classList.remove("no-transitions");
-}
-
-export function setTheme(t: Theme) {
-  setThemeSignal(t);
-  applyTheme(t);
-  try {
-    localStorage.setItem("uncorded-theme", t);
-  } catch {
-    // Quota exceeded or private browsing — signal + UI already updated
-  }
-}
 
 export function setMessageDensity(d: MessageDensity) {
   setDensitySignal(d);
@@ -50,7 +26,8 @@ export function setMessageDensity(d: MessageDensity) {
   }
 }
 
-// Initialize theme on module load
-applyTheme(theme());
+// Dark-only — no theme switching. Ensure dark class is present on init.
+document.documentElement.classList.add("dark");
+document.documentElement.style.colorScheme = "dark";
 
-export { theme, messageDensity };
+export { messageDensity };


### PR DESCRIPTION
## Summary

- **Terminal Dark theme**: Replaced OKLCH green-tinted palette with near-monochrome hex colors (#0A0A0A void, #111111 surface, #16A37F signal green, #F87171 danger). Reduced border-radius to 6px max, narrowed scrollbars to 3px, added ::selection styling, cursor blink keyframe, and monospace font variable. Removed light mode entirely.
- **Route restructure**: Rewrote App.tsx route tree — new URL-driven routes for `/friends`, `/messages/:userId`, `/servers/:serverId`, `/settings/*`, `/features`. Created 8 new pages (Messages, DirectMessage, ServerView, SettingsLayout, SettingsRedirect, FallbackPage, Upgrade, Billing). Settings now uses sidebar nav with child routes instead of tabs.
- **Sidebar redesign**: Major rewrite with collapsible "Social" and "Servers" groups, UNCORDED monospace logo, user card footer with dropdown menu (profile, upgrade, account, billing, notifications, report bug, logout), bottom nav items (Support, Settings), and channel list below server selector.
- **Component styling pass**: Updated button, card, input, dialog to `rounded-md`. Added monospace to timestamps. Removed light mode toggle from appearance settings. Created ContentHeader component with breadcrumbs.

### New files
- `ContentHeader.tsx` — breadcrumb header with sidebar trigger + Feature Requests link
- `Messages.tsx` — DM list page
- `DirectMessage.tsx` — DM conversation page (URL-routed by userId)
- `ServerView.tsx` — server view page (URL-routed by serverId)
- `SettingsLayout.tsx` — settings shell with sidebar nav + child routes
- `SettingsRedirect.tsx` — redirects /settings → /settings/profile
- `FallbackPage.tsx` — "Coming Soon" page for unimplemented features
- `Upgrade.tsx` / `Billing.tsx` — pricing and subscription pages

### Modified (21 files, +984 −573)
- `index.css` — full Terminal Dark palette, scrollbar, selection, radius, animations
- `App.tsx` — complete route tree rewrite
- `AppLayout.tsx` — simplified, delegates routing to child pages
- `AppSidebar.tsx` — major rewrite with new structure
- UI primitives: button, card, dialog, input — tighter radius, faster transitions

## Test plan
- [ ] Verify Terminal Dark theme renders correctly (deep blacks, green accent, 3px scrollbars)
- [ ] Navigate all new routes: /home, /friends, /messages, /servers/:id, /settings/*
- [ ] Test sidebar: collapsible groups, server selector, channel list, user dropdown
- [ ] Verify settings sidebar nav works on desktop and mobile
- [ ] Check auth flow still works (login → /home redirect)
- [ ] Verify DM and server chat still function via new URL-routed pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messaging (DM list + conversation), server views, Billing & Upgrade flows, catch‑all "Coming Soon" page, and a Settings layout with Profile/Account/Appearance/Transfers/Upgrade/Billing/Notifications; added a Features route and content header.

* **Style**
  * Terminal Dark look with monospace typography, reduced border radii, shorter animations, slimmer scrollbars, and updated header branding; minor UI spacing and timestamp typography tweaks.

* **Refactor**
  * Redesigned sidebar/navigation and replaced footer user panel with a user dropdown; simplified app layout rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->