### PR TITLE
fix: sidebar collapsed mode and layout issues

### DIFF
--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -191,22 +191,27 @@ const AppSidebar = () => {
     <Sidebar variant="inset" collapsible="icon">
       {/* ── Header: UNCORDED Logo ───────────────────────────────────── */}
       <SidebarHeader>
-        <button
-          onClick={() => {
-            selectHome();
-            navigate("/home");
-            closeMobile();
-          }}
-          class="flex w-full items-center gap-2 px-1 py-2 transition-colors hover:opacity-80"
-        >
-          <img src="/icon-192.png" alt="UnCorded" class="h-8 w-8 rounded-md" />
-          <span class="font-mono text-sm font-bold uppercase tracking-[0.12em] text-foreground">
-            UNCORDED
-          </span>
-          <span class="rounded-sm bg-muted px-1.5 py-0.5 font-mono text-[8px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Alpha
-          </span>
-        </button>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              size="lg"
+              tooltip="UnCorded"
+              onClick={() => {
+                selectHome();
+                navigate("/home");
+                closeMobile();
+              }}
+            >
+              <img src="/icon-192.png" alt="UnCorded" class="h-8 w-8 shrink-0 rounded-md" />
+              <span class="truncate font-mono text-sm font-bold uppercase tracking-[0.12em] text-foreground">
+                UNCORDED
+              </span>
+              <span class="ml-auto rounded-md bg-muted px-2 py-0.5 font-mono text-[11px] font-medium uppercase text-muted-foreground">
+                Alpha
+              </span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
       </SidebarHeader>
 
       {/* ── Content ─────────────────────────────────────────────────── */}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -13,7 +13,6 @@ import {
   type ParentProps,
 } from "solid-js";
 import { cn } from "../../lib/cn.js";
-import { ScrollArea } from "./scroll-area.js";
 import { Sheet, SheetContent } from "./sheet.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -325,13 +324,16 @@ type SidebarContentProps = ParentProps<JSX.HTMLAttributes<HTMLDivElement>>;
 const SidebarContent = (props: SidebarContentProps) => {
   const [local, rest] = splitProps(props, ["class", "children"]);
   return (
-    <ScrollArea
+    <div
       data-slot="sidebar-content"
-      class={cn("flex-1 overflow-hidden group-data-[collapsible=icon]:overflow-hidden", local.class)}
+      class={cn(
+        "flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        local.class,
+      )}
       {...rest}
     >
       {local.children}
-    </ScrollArea>
+    </div>
   );
 };
 
@@ -344,7 +346,7 @@ const SidebarFooter = (props: SidebarFooterProps) => {
   return (
     <div
       data-slot="sidebar-footer"
-      class={cn("flex shrink-0 items-center border-t border-border p-2", local.class)}
+      class={cn("flex shrink-0 flex-col gap-2 p-2", local.class)}
       {...rest}
     >
       {local.children}
@@ -373,12 +375,12 @@ const SidebarGroup = (props: SidebarGroupProps) => {
   const [open, setOpen] = createSignal(local.defaultOpen ?? true);
 
   return (
-    <div data-slot="sidebar-group" class={cn("py-1", local.class)} {...rest}>
+    <div data-slot="sidebar-group" class={cn("relative flex w-full min-w-0 flex-col p-2", local.class)} {...rest}>
       <Show when={local.label}>
-        <div class="flex items-center gap-1 px-4 py-1.5">
+        <div class="flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-semibold uppercase text-muted-foreground transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0">
           <button
             type="button"
-            class="flex flex-1 items-center gap-1 text-xs font-semibold uppercase text-muted-foreground"
+            class="flex flex-1 items-center gap-1"
             classList={{ "cursor-pointer hover:text-foreground": !!local.collapsible }}
             onClick={() => local.collapsible && setOpen((o) => !o)}
           >
@@ -446,11 +448,11 @@ const SidebarMenuButton = (props: SidebarMenuButtonProps) => {
   const sizeClass = () => {
     switch (local.size) {
       case "sm":
-        return "px-2 py-1 text-xs";
+        return "h-7 px-2 py-1 text-xs";
       case "lg":
-        return "px-2.5 py-2.5 text-sm";
+        return "h-12 px-2.5 py-2.5 text-sm group-data-[collapsible=icon]:!p-0";
       default:
-        return "px-2.5 py-1.5 text-sm";
+        return "h-8 px-2.5 py-1.5 text-sm";
     }
   };
   return (

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -327,7 +327,7 @@ const SidebarContent = (props: SidebarContentProps) => {
     <div
       data-slot="sidebar-content"
       class={cn(
-        "flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-x-hidden",
         local.class,
       )}
       {...rest}
@@ -373,11 +373,13 @@ const SidebarGroup = (props: SidebarGroupProps) => {
     "defaultOpen",
   ]);
   const [open, setOpen] = createSignal(local.defaultOpen ?? true);
+  const { state } = useSidebar();
+  const sidebarExpanded = () => state() === "expanded";
 
   return (
     <div data-slot="sidebar-group" class={cn("relative flex w-full min-w-0 flex-col p-2", local.class)} {...rest}>
-      <Show when={local.label}>
-        <div class="flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-semibold uppercase text-muted-foreground transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0">
+      <Show when={local.label && sidebarExpanded()}>
+        <div class="flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-semibold uppercase text-muted-foreground">
           <button
             type="button"
             class="flex flex-1 items-center gap-1"
@@ -448,11 +450,11 @@ const SidebarMenuButton = (props: SidebarMenuButtonProps) => {
   const sizeClass = () => {
     switch (local.size) {
       case "sm":
-        return "h-7 px-2 py-1 text-xs";
+        return "h-7 px-2 py-1 text-xs group-data-[collapsible=icon]:!p-2";
       case "lg":
         return "h-12 px-2.5 py-2.5 text-sm group-data-[collapsible=icon]:!p-0";
       default:
-        return "h-8 px-2.5 py-1.5 text-sm";
+        return "h-8 px-2.5 py-1.5 text-sm group-data-[collapsible=icon]:!p-2";
     }
   };
   return (
@@ -462,7 +464,7 @@ const SidebarMenuButton = (props: SidebarMenuButtonProps) => {
       class={cn(
         "flex w-full items-center gap-2 rounded-lg transition-colors",
         sizeClass(),
-        "group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 group-data-[collapsible=icon]:justify-center",
+        "group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:justify-center",
         "[&>span]:group-data-[collapsible=icon]:hidden",
         "[&>div]:group-data-[collapsible=icon]:hidden",
         "[&>svg:last-child]:group-data-[collapsible=icon]:hidden",


### PR DESCRIPTION
## Summary
- **Collapsed mode fixed**: Group labels now hide with smooth opacity/margin transition, menu buttons collapse to icon-only, header text/badge auto-hides — all via `group-data-[collapsible=icon]` selectors matching the shadcn/ui reference
- **Footer user card full width**: Replaced `items-center` with `flex-col gap-2` on `SidebarFooter` so the user card button stretches properly
- **Support/Settings anchored to bottom**: Replaced `ScrollArea` wrapper with a flex column div in `SidebarContent` so `mt-auto` on the bottom group actually works
- **Header logo**: Wrapped in `SidebarMenu > SidebarMenuItem > SidebarMenuButton size="lg"` so "UNCORDED" text and "Alpha" badge hide automatically when collapsed

## Test plan
- [ ] Expanded sidebar: all items visible, labels show, user card full width
- [ ] Collapsed sidebar: only icons visible, no truncated text, labels hidden, logo icon centered
- [ ] Support & Settings pinned to bottom of content area
- [ ] User footer card stretches full sidebar width
- [ ] Header shows logo + text expanded, logo only collapsed
- [ ] Mobile sheet sidebar unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked sidebar internals for clearer structure and reliance on native overflow for scrolling.
  * Sidebar groups now conditionally show labels based on expansion state.

* **Style**
  * Updated header logo layout and badge sizing/alignment.
  * Footer changed to a stacked layout without a top border.
  * Standardized menu button heights and padding for consistent sizing across states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->