### PR TITLE
feat: sidebar quick actions — bigger logo, Add Friend, command palette

### DIFF
--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -44,13 +44,28 @@ const AppLayout: ParentComponent = (props) => {
     setupShortcuts();
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-        e.preventDefault();
-        setCommandPaletteOpen((prev) => !prev);
-      }
       if (e.key === "Escape" && commandPaletteOpen()) {
         e.preventDefault();
         setCommandPaletteOpen(false);
+        return;
+      }
+
+      // Skip Ctrl+K when focus is inside editable elements
+      const target = e.target as HTMLElement;
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target.isContentEditable ||
+        target.closest("[contenteditable]")
+      ) {
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setCommandPaletteOpen((prev) => !prev);
       }
     };
     window.addEventListener("keydown", handleKeyDown);

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -22,6 +22,7 @@ import P2PNoticeDialog from "./P2PNoticeDialog.js";
 import GiftNotification from "./modals/GiftNotification.js";
 import DeletionCountdown from "./modals/DeletionCountdown.js";
 import { getP2pDialogOpen, confirmP2pDialog, cancelP2pDialog } from "../stores/file-store.js";
+import { commandPaletteOpen, setCommandPaletteOpen } from "../stores/command-palette-store.js";
 import {
   pendingInvite,
   joinSession,
@@ -39,7 +40,23 @@ const AppLayout: ParentComponent = (props) => {
     }
   });
 
-  onMount(() => setupShortcuts());
+  onMount(() => {
+    setupShortcuts();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setCommandPaletteOpen((prev) => !prev);
+      }
+      if (e.key === "Escape" && commandPaletteOpen()) {
+        e.preventDefault();
+        setCommandPaletteOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    onCleanup(() => window.removeEventListener("keydown", handleKeyDown));
+  });
+
   onCleanup(() => {
     disconnectGateway();
     cleanupShortcuts();

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -249,7 +249,7 @@ const AppSidebar = () => {
                 fallback={
                   <SidebarMenuButton
                     tooltip="Search (Ctrl+K)"
-                    onClick={() => setCommandPaletteOpen(true)}
+                    onClick={() => { closeMobile(); setCommandPaletteOpen(true); }}
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -260,7 +260,7 @@ const AppSidebar = () => {
               >
                 <button
                   type="button"
-                  onClick={() => setCommandPaletteOpen(true)}
+                  onClick={() => { closeMobile(); setCommandPaletteOpen(true); }}
                   class="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -33,11 +33,14 @@ import SubscriptionModal from "./modals/SubscriptionModal.js";
 import PricingModal from "./modals/PricingModal.js";
 import UnifiedReportDialog from "./modals/UnifiedReportDialog.js";
 import ShareFileModal from "./modals/ShareFileModal.js";
+import AddFriendModal from "./modals/AddFriendModal.js";
+import CommandPalette from "./CommandPalette.js";
+import { commandPaletteOpen, setCommandPaletteOpen } from "../stores/command-palette-store.js";
 import SupportSheet from "./SupportSheet.js";
 import { showToast } from "./ui/toast.js";
 
 const AppSidebar = () => {
-  const { setOpenMobile } = useSidebar();
+  const { setOpenMobile, state: sidebarState } = useSidebar();
   const closeMobile = () => setOpenMobile(false);
   const session = useSession();
   const navigate = useNavigate();
@@ -52,6 +55,7 @@ const AppSidebar = () => {
   const [showSubscriptionModal, setShowSubscriptionModal] = createSignal(false);
   const [showReportDialog, setShowReportDialog] = createSignal(false);
   const [showShareModal, setShowShareModal] = createSignal(false);
+  const [showAddFriendModal, setShowAddFriendModal] = createSignal(false);
   const [showSupportSheet, setShowSupportSheet] = createSignal(false);
   const [userDropdownOpen, setUserDropdownOpen] = createSignal(false);
   const [dropdownPos, setDropdownPos] = createSignal({ bottom: 0, left: 0 });
@@ -142,6 +146,26 @@ const AppSidebar = () => {
     onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
   });
 
+  const handleCommandAction = (action: string) => {
+    switch (action) {
+      case "send-file":
+        setShowShareModal(true);
+        break;
+      case "add-friend":
+        setShowAddFriendModal(true);
+        break;
+      case "settings":
+        navigate("/settings");
+        break;
+      case "feature-requests":
+        navigate("/settings/feature-requests");
+        break;
+      case "support":
+        setShowSupportSheet(true);
+        break;
+    }
+  };
+
   const isActive = (path: string) => location.pathname === path;
 
   // ── Channel group header actions ────────────────────────────────
@@ -202,7 +226,7 @@ const AppSidebar = () => {
                 closeMobile();
               }}
             >
-              <img src="/icon-192.png" alt="UnCorded" class="h-8 w-8 shrink-0 rounded-md" />
+              <img src="/icon-192.png" alt="UnCorded" class="h-10 w-10 shrink-0 rounded-md" />
               <span class="truncate font-mono text-sm font-bold uppercase tracking-[0.12em] text-foreground">
                 UNCORDED
               </span>
@@ -216,7 +240,41 @@ const AppSidebar = () => {
 
       {/* ── Content ─────────────────────────────────────────────────── */}
       <SidebarContent>
-        {/* Send File — above Social */}
+        {/* Search — opens command palette */}
+        <SidebarGroup>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <Show
+                when={sidebarState() === "expanded"}
+                fallback={
+                  <SidebarMenuButton
+                    tooltip="Search (Ctrl+K)"
+                    onClick={() => setCommandPaletteOpen(true)}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                    </svg>
+                    <span>Search</span>
+                  </SidebarMenuButton>
+                }
+              >
+                <button
+                  type="button"
+                  onClick={() => setCommandPaletteOpen(true)}
+                  class="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  </svg>
+                  <span>Search...</span>
+                  <kbd class="ml-auto text-[10px] text-muted-foreground">Ctrl+K</kbd>
+                </button>
+              </Show>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+
+        {/* Quick actions — Send File + Add Friend */}
         <SidebarGroup>
           <SidebarMenu>
             <SidebarMenuItem>
@@ -228,6 +286,17 @@ const AppSidebar = () => {
                   <path stroke-linecap="round" stroke-linejoin="round" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
                 </svg>
                 <span>Send File</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                tooltip="Add Friend"
+                onClick={() => { setShowAddFriendModal(true); closeMobile(); }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                </svg>
+                <span>Add Friend</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
@@ -609,6 +678,14 @@ const AppSidebar = () => {
       <Show when={showShareModal()}>
         <ShareFileModal onClose={() => setShowShareModal(false)} />
       </Show>
+      <Show when={showAddFriendModal()}>
+        <AddFriendModal onClose={() => setShowAddFriendModal(false)} />
+      </Show>
+      <CommandPalette
+        open={commandPaletteOpen()}
+        onClose={() => setCommandPaletteOpen(false)}
+        onAction={handleCommandAction}
+      />
       <SupportSheet
         open={showSupportSheet()}
         onClose={() => setShowSupportSheet(false)}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,8 +1,9 @@
-import { createSignal, createMemo, onMount, onCleanup, For, Show } from "solid-js";
+import { createSignal, createMemo, createEffect, on, For, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { useNavigate } from "@solidjs/router";
 import { readyData, channelCache } from "../lib/gateway-store.js";
-import type { ReadyFriend, ReadyServer, ReadyChannel } from "../lib/gateway-store.js";
+import { setSelectedChannelId } from "../stores/app-store.js";
+import type { ReadyFriend, ReadyChannel } from "../lib/gateway-store.js";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -13,7 +14,7 @@ interface CommandPaletteProps {
 interface ResultItem {
   id: string;
   label: string;
-  sublabel?: string;
+  sublabel?: string | undefined;
   category: "Friends" | "Servers" | "Channels" | "Actions";
   onSelect: () => void;
 }
@@ -25,12 +26,18 @@ const CommandPalette = (props: CommandPaletteProps) => {
   let inputRef!: HTMLInputElement;
   let listRef!: HTMLDivElement;
 
-  // Reset state when opening
-  onMount(() => {
-    setQuery("");
-    setSelectedIndex(0);
-    requestAnimationFrame(() => inputRef?.focus());
-  });
+  // Reset state and focus input whenever the palette opens
+  createEffect(
+    on(
+      () => props.open,
+      (open) => {
+        if (!open) return;
+        setQuery("");
+        setSelectedIndex(0);
+        requestAnimationFrame(() => inputRef?.focus());
+      },
+    ),
+  );
 
   const allResults = createMemo<ResultItem[]>(() => {
     const q = query().trim().toLowerCase();
@@ -91,6 +98,7 @@ const CommandPalette = (props: CommandPaletteProps) => {
         sublabel: ch.serverName,
         category: "Channels",
         onSelect: () => {
+          setSelectedChannelId(ch.id);
           navigate(`/servers/${ch.serverId}`);
           props.onClose();
         },

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -154,11 +154,8 @@ const CommandPalette = (props: CommandPaletteProps) => {
     return groups;
   });
 
-  // Flatten for index-based keyboard nav
-  const flatResults = createMemo(() => allResults());
-
   const handleKeyDown = (e: KeyboardEvent) => {
-    const total = flatResults().length;
+    const total = allResults().length;
     if (total === 0) return;
 
     if (e.key === "ArrowDown") {
@@ -171,7 +168,7 @@ const CommandPalette = (props: CommandPaletteProps) => {
       scrollToSelected();
     } else if (e.key === "Enter") {
       e.preventDefault();
-      const item = flatResults()[selectedIndex()];
+      const item = allResults()[selectedIndex()];
       item?.onSelect();
     }
   };
@@ -262,7 +259,7 @@ const CommandPalette = (props: CommandPaletteProps) => {
             {/* Results */}
             <div ref={listRef} class="max-h-80 overflow-y-auto p-2">
               <Show
-                when={flatResults().length > 0}
+                when={allResults().length > 0}
                 fallback={
                   <p class="px-2 py-6 text-center text-sm text-muted-foreground">
                     {query().trim() ? "No results found." : "Start typing to search..."}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -43,10 +43,9 @@ const CommandPalette = (props: CommandPaletteProps) => {
     const q = query().trim().toLowerCase();
     const results: ResultItem[] = [];
     const data = readyData.data;
-    if (!data) return results;
 
-    // Friends — only accepted friends
-    const friends = data.friends.filter((f) => f.friendshipStatus === "accepted");
+    // Friends — only accepted friends (skip if gateway not ready)
+    const friends = data ? data.friends.filter((f) => f.friendshipStatus === "accepted") : [];
     const matchedFriends = q
       ? friends.filter((f) => matchUser(f, q))
       : friends;
@@ -64,9 +63,10 @@ const CommandPalette = (props: CommandPaletteProps) => {
     }
 
     // Servers
+    const servers = data?.servers ?? [];
     const matchedServers = q
-      ? data.servers.filter((s) => s.name.toLowerCase().includes(q))
-      : data.servers;
+      ? servers.filter((s) => s.name.toLowerCase().includes(q))
+      : servers;
     for (const s of matchedServers.slice(0, 8)) {
       results.push({
         id: `server-${s.id}`,
@@ -81,7 +81,7 @@ const CommandPalette = (props: CommandPaletteProps) => {
 
     // Channels — iterate cached channels for all servers
     const channels: (ReadyChannel & { serverName: string })[] = [];
-    for (const server of data.servers) {
+    for (const server of servers) {
       const serverChannels = channelCache[server.id];
       if (!serverChannels) continue;
       for (const ch of serverChannels) {
@@ -233,6 +233,9 @@ const CommandPalette = (props: CommandPaletteProps) => {
 
           {/* Palette */}
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Command palette"
             class="relative mx-4 flex w-full max-w-lg flex-col overflow-hidden rounded-xl border border-border bg-card shadow-lg animate-scale-in"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={handleKeyDown}
@@ -246,6 +249,7 @@ const CommandPalette = (props: CommandPaletteProps) => {
                 ref={inputRef}
                 type="text"
                 placeholder="Search friends, servers, channels..."
+                aria-label="Search friends, servers, channels"
                 value={query()}
                 onInput={(e) => handleInput(e.currentTarget.value)}
                 class="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,0 +1,306 @@
+import { createSignal, createMemo, onMount, onCleanup, For, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { useNavigate } from "@solidjs/router";
+import { readyData, channelCache } from "../lib/gateway-store.js";
+import type { ReadyFriend, ReadyServer, ReadyChannel } from "../lib/gateway-store.js";
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  onAction: (action: string) => void;
+}
+
+interface ResultItem {
+  id: string;
+  label: string;
+  sublabel?: string;
+  category: "Friends" | "Servers" | "Channels" | "Actions";
+  onSelect: () => void;
+}
+
+const CommandPalette = (props: CommandPaletteProps) => {
+  const navigate = useNavigate();
+  const [query, setQuery] = createSignal("");
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  let inputRef!: HTMLInputElement;
+  let listRef!: HTMLDivElement;
+
+  // Reset state when opening
+  onMount(() => {
+    setQuery("");
+    setSelectedIndex(0);
+    requestAnimationFrame(() => inputRef?.focus());
+  });
+
+  const allResults = createMemo<ResultItem[]>(() => {
+    const q = query().trim().toLowerCase();
+    const results: ResultItem[] = [];
+    const data = readyData.data;
+    if (!data) return results;
+
+    // Friends — only accepted friends
+    const friends = data.friends.filter((f) => f.friendshipStatus === "accepted");
+    const matchedFriends = q
+      ? friends.filter((f) => matchUser(f, q))
+      : friends;
+    for (const f of matchedFriends.slice(0, 8)) {
+      results.push({
+        id: `friend-${f.userId}`,
+        label: f.displayName ?? f.username ?? "Unknown",
+        sublabel: f.username ? `@${f.username}` : undefined,
+        category: "Friends",
+        onSelect: () => {
+          navigate(`/messages/${f.userId}`);
+          props.onClose();
+        },
+      });
+    }
+
+    // Servers
+    const matchedServers = q
+      ? data.servers.filter((s) => s.name.toLowerCase().includes(q))
+      : data.servers;
+    for (const s of matchedServers.slice(0, 8)) {
+      results.push({
+        id: `server-${s.id}`,
+        label: s.name,
+        category: "Servers",
+        onSelect: () => {
+          navigate(`/servers/${s.id}`);
+          props.onClose();
+        },
+      });
+    }
+
+    // Channels — iterate cached channels for all servers
+    const channels: (ReadyChannel & { serverName: string })[] = [];
+    for (const server of data.servers) {
+      const serverChannels = channelCache[server.id];
+      if (!serverChannels) continue;
+      for (const ch of serverChannels) {
+        channels.push({ ...ch, serverName: server.name });
+      }
+    }
+    const matchedChannels = q
+      ? channels.filter((ch) => ch.name.toLowerCase().includes(q))
+      : channels;
+    for (const ch of matchedChannels.slice(0, 8)) {
+      results.push({
+        id: `channel-${ch.id}`,
+        label: `# ${ch.name}`,
+        sublabel: ch.serverName,
+        category: "Channels",
+        onSelect: () => {
+          navigate(`/servers/${ch.serverId}`);
+          props.onClose();
+        },
+      });
+    }
+
+    // Actions — static list, always shown when matching or when query is empty
+    const actions: { id: string; label: string; action: string }[] = [
+      { id: "action-send-file", label: "Send File", action: "send-file" },
+      { id: "action-add-friend", label: "Add Friend", action: "add-friend" },
+      { id: "action-settings", label: "Settings", action: "settings" },
+      { id: "action-feature-requests", label: "Feature Requests", action: "feature-requests" },
+      { id: "action-support", label: "Support", action: "support" },
+    ];
+    const matchedActions = q
+      ? actions.filter((a) => a.label.toLowerCase().includes(q))
+      : actions;
+    for (const a of matchedActions) {
+      results.push({
+        id: a.id,
+        label: a.label,
+        category: "Actions",
+        onSelect: () => {
+          props.onAction(a.action);
+          props.onClose();
+        },
+      });
+    }
+
+    return results;
+  });
+
+  // Group results by category for rendering
+  const groupedResults = createMemo(() => {
+    const groups: { category: string; items: ResultItem[] }[] = [];
+    const categoryOrder: ResultItem["category"][] = ["Friends", "Servers", "Channels", "Actions"];
+
+    for (const cat of categoryOrder) {
+      const items = allResults().filter((r) => r.category === cat);
+      if (items.length > 0) {
+        groups.push({ category: cat, items });
+      }
+    }
+    return groups;
+  });
+
+  // Flatten for index-based keyboard nav
+  const flatResults = createMemo(() => allResults());
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const total = flatResults().length;
+    if (total === 0) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => (i + 1) % total);
+      scrollToSelected();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => (i - 1 + total) % total);
+      scrollToSelected();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const item = flatResults()[selectedIndex()];
+      item?.onSelect();
+    }
+  };
+
+  const scrollToSelected = () => {
+    requestAnimationFrame(() => {
+      const el = listRef?.querySelector<HTMLElement>(`[data-index="${selectedIndex()}"]`);
+      el?.scrollIntoView({ block: "nearest" });
+    });
+  };
+
+  // Reset index when query changes
+  const handleInput = (value: string) => {
+    setQuery(value);
+    setSelectedIndex(0);
+  };
+
+  // Category icon
+  const categoryIcon = (cat: string) => {
+    switch (cat) {
+      case "Friends":
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        );
+      case "Servers":
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
+          </svg>
+        );
+      case "Channels":
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+          </svg>
+        );
+      case "Actions":
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+        );
+      default:
+        return null;
+    }
+  };
+
+  // Track flat index across grouped rendering
+  let flatIdx = 0;
+
+  return (
+    <Show when={props.open}>
+      <Portal mount={document.body}>
+        <div
+          class="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+          onClick={props.onClose}
+        >
+          {/* Backdrop */}
+          <div class="fixed inset-0 bg-black/50 backdrop-blur-sm" />
+
+          {/* Palette */}
+          <div
+            class="relative mx-4 flex w-full max-w-lg flex-col overflow-hidden rounded-xl border border-border bg-card shadow-lg animate-scale-in"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={handleKeyDown}
+          >
+            {/* Search input */}
+            <div class="flex items-center gap-2 border-b border-border px-4 py-3">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                ref={inputRef}
+                type="text"
+                placeholder="Search friends, servers, channels..."
+                value={query()}
+                onInput={(e) => handleInput(e.currentTarget.value)}
+                class="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+              />
+              <kbd class="hidden rounded border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline-block">
+                ESC
+              </kbd>
+            </div>
+
+            {/* Results */}
+            <div ref={listRef} class="max-h-80 overflow-y-auto p-2">
+              <Show
+                when={flatResults().length > 0}
+                fallback={
+                  <p class="px-2 py-6 text-center text-sm text-muted-foreground">
+                    {query().trim() ? "No results found." : "Start typing to search..."}
+                  </p>
+                }
+              >
+                {(() => {
+                  flatIdx = 0;
+                  return null;
+                })()}
+                <For each={groupedResults()}>
+                  {(group) => (
+                    <div class="mb-2 last:mb-0">
+                      <div class="flex items-center gap-1.5 px-2 pb-1 pt-2 text-[11px] font-semibold uppercase text-muted-foreground">
+                        {categoryIcon(group.category)}
+                        {group.category}
+                      </div>
+                      <For each={group.items}>
+                        {(item) => {
+                          const idx = flatIdx++;
+                          return (
+                            <button
+                              type="button"
+                              data-index={idx}
+                              class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+                              classList={{
+                                "bg-accent text-foreground": selectedIndex() === idx,
+                                "text-secondary-foreground hover:bg-accent hover:text-foreground": selectedIndex() !== idx,
+                              }}
+                              onMouseEnter={() => setSelectedIndex(idx)}
+                              onClick={() => item.onSelect()}
+                            >
+                              <span class="flex-1 truncate">{item.label}</span>
+                              <Show when={item.sublabel}>
+                                <span class="shrink-0 text-xs text-muted-foreground">{item.sublabel}</span>
+                              </Show>
+                            </button>
+                          );
+                        }}
+                      </For>
+                    </div>
+                  )}
+                </For>
+              </Show>
+            </div>
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+};
+
+function matchUser(f: ReadyFriend, q: string): boolean {
+  const name = (f.displayName ?? "").toLowerCase();
+  const uname = (f.username ?? "").toLowerCase();
+  return name.includes(q) || uname.includes(q);
+}
+
+export default CommandPalette;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -131,13 +131,22 @@ const CommandPalette = (props: CommandPaletteProps) => {
     return results;
   });
 
-  // Group results by category for rendering
+  // Group results by category with precomputed flat indices for keyboard nav
+  interface IndexedItem extends ResultItem {
+    flatIndex: number;
+  }
   const groupedResults = createMemo(() => {
-    const groups: { category: string; items: ResultItem[] }[] = [];
+    const groups: { category: string; items: IndexedItem[] }[] = [];
     const categoryOrder: ResultItem["category"][] = ["Friends", "Servers", "Channels", "Actions"];
+    let idx = 0;
 
     for (const cat of categoryOrder) {
-      const items = allResults().filter((r) => r.category === cat);
+      const items: IndexedItem[] = [];
+      for (const r of allResults()) {
+        if (r.category === cat) {
+          items.push({ ...r, flatIndex: idx++ });
+        }
+      }
       if (items.length > 0) {
         groups.push({ category: cat, items });
       }
@@ -212,9 +221,6 @@ const CommandPalette = (props: CommandPaletteProps) => {
     }
   };
 
-  // Track flat index across grouped rendering
-  let flatIdx = 0;
-
   return (
     <Show when={props.open}>
       <Portal mount={document.body}>
@@ -259,10 +265,6 @@ const CommandPalette = (props: CommandPaletteProps) => {
                   </p>
                 }
               >
-                {(() => {
-                  flatIdx = 0;
-                  return null;
-                })()}
                 <For each={groupedResults()}>
                   {(group) => (
                     <div class="mb-2 last:mb-0">
@@ -271,27 +273,24 @@ const CommandPalette = (props: CommandPaletteProps) => {
                         {group.category}
                       </div>
                       <For each={group.items}>
-                        {(item) => {
-                          const idx = flatIdx++;
-                          return (
-                            <button
-                              type="button"
-                              data-index={idx}
-                              class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
-                              classList={{
-                                "bg-accent text-foreground": selectedIndex() === idx,
-                                "text-secondary-foreground hover:bg-accent hover:text-foreground": selectedIndex() !== idx,
-                              }}
-                              onMouseEnter={() => setSelectedIndex(idx)}
-                              onClick={() => item.onSelect()}
-                            >
-                              <span class="flex-1 truncate">{item.label}</span>
-                              <Show when={item.sublabel}>
-                                <span class="shrink-0 text-xs text-muted-foreground">{item.sublabel}</span>
-                              </Show>
-                            </button>
-                          );
-                        }}
+                        {(item) => (
+                          <button
+                            type="button"
+                            data-index={item.flatIndex}
+                            class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+                            classList={{
+                              "bg-accent text-foreground": selectedIndex() === item.flatIndex,
+                              "text-secondary-foreground hover:bg-accent hover:text-foreground": selectedIndex() !== item.flatIndex,
+                            }}
+                            onMouseEnter={() => setSelectedIndex(item.flatIndex)}
+                            onClick={() => item.onSelect()}
+                          >
+                            <span class="flex-1 truncate">{item.label}</span>
+                            <Show when={item.sublabel}>
+                              <span class="shrink-0 text-xs text-muted-foreground">{item.sublabel}</span>
+                            </Show>
+                          </button>
+                        )}
                       </For>
                     </div>
                   )}

--- a/apps/web/src/components/modals/AddFriendModal.tsx
+++ b/apps/web/src/components/modals/AddFriendModal.tsx
@@ -1,13 +1,13 @@
 import { createSignal, createEffect, onCleanup, For, Show } from "solid-js";
+import type { UserId } from "@uncorded/protocol";
 import { sendFriendRequest } from "../../stores/friend-store.js";
 import { api } from "../../lib/api.js";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog.js";
 import { Input } from "../ui/input.js";
 import { Button } from "../ui/button.js";
-import { showToast } from "../ui/toast.js";
 
 interface SearchUser {
-  id: string;
+  id: UserId;
   username: string | null;
   displayName: string | null;
   avatarUrl: string | null;
@@ -27,6 +27,7 @@ const AddFriendModal = (props: Props) => {
   let searchTimer: ReturnType<typeof setTimeout> | undefined;
   let searchAbort: AbortController | undefined;
   let suppressNextSearch = false;
+  let sendInFlight = false;
 
   createEffect(() => {
     const q = username().trim();
@@ -71,16 +72,17 @@ const AddFriendModal = (props: Props) => {
 
   const handleSend = async () => {
     const name = username().trim();
-    if (!name) return;
+    if (!name || sendInFlight) return;
     setError(null);
     setSending(true);
+    sendInFlight = true;
     try {
       await sendFriendRequest(name);
-      showToast(`Friend request sent to ${name}`, "success");
       props.onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to send request");
     } finally {
+      sendInFlight = false;
       setSending(false);
     }
   };

--- a/apps/web/src/components/modals/AddFriendModal.tsx
+++ b/apps/web/src/components/modals/AddFriendModal.tsx
@@ -1,0 +1,210 @@
+import { createSignal, createEffect, onCleanup, For, Show } from "solid-js";
+import { sendFriendRequest } from "../../stores/friend-store.js";
+import { api } from "../../lib/api.js";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog.js";
+import { Input } from "../ui/input.js";
+import { Button } from "../ui/button.js";
+import { showToast } from "../ui/toast.js";
+
+interface SearchUser {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+interface Props {
+  onClose: () => void;
+}
+
+const AddFriendModal = (props: Props) => {
+  const [username, setUsername] = createSignal("");
+  const [sending, setSending] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [suggestions, setSuggestions] = createSignal<SearchUser[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = createSignal(-1);
+
+  let searchTimer: ReturnType<typeof setTimeout> | undefined;
+  let searchAbort: AbortController | undefined;
+  let suppressNextSearch = false;
+
+  createEffect(() => {
+    const q = username().trim();
+
+    if (suppressNextSearch) {
+      suppressNextSearch = false;
+      return;
+    }
+
+    if (q.length < 1) {
+      clearTimeout(searchTimer);
+      if (searchAbort) searchAbort.abort();
+      setSuggestions([]);
+      return;
+    }
+
+    if (searchAbort) searchAbort.abort();
+    clearTimeout(searchTimer);
+
+    searchTimer = setTimeout(() => {
+      const controller = new AbortController();
+      searchAbort = controller;
+
+      api<{ users: SearchUser[] }>(
+        `/api/users/search?q=${encodeURIComponent(q)}`,
+        { signal: controller.signal },
+      )
+        .then((res) => {
+          if (!controller.signal.aborted) setSuggestions(res.users);
+        })
+        .catch((err) => {
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          if (!controller.signal.aborted) setSuggestions([]);
+        });
+    }, 300);
+  });
+
+  onCleanup(() => {
+    clearTimeout(searchTimer);
+    if (searchAbort) searchAbort.abort();
+  });
+
+  const handleSend = async () => {
+    const name = username().trim();
+    if (!name) return;
+    setError(null);
+    setSending(true);
+    try {
+      await sendFriendRequest(name);
+      showToast(`Friend request sent to ${name}`, "success");
+      props.onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send request");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const selectSuggestion = (user: SearchUser) => {
+    suppressNextSearch = true;
+    setUsername(user.username ?? "");
+    setSuggestions([]);
+    setHighlightedIndex(-1);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const list = suggestions();
+    if (list.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setHighlightedIndex((i) => (i + 1) % list.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setHighlightedIndex((i) => (i - 1 + list.length) % list.length);
+        return;
+      }
+      if (e.key === "Enter" && highlightedIndex() >= 0) {
+        e.preventDefault();
+        const selected = list[highlightedIndex()];
+        if (selected) selectSuggestion(selected);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setSuggestions([]);
+        setHighlightedIndex(-1);
+        return;
+      }
+    }
+    if (e.key === "Enter") handleSend();
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) props.onClose(); }}>
+      <DialogContent onClose={props.onClose}>
+        <DialogHeader>
+          <DialogTitle>Add Friend</DialogTitle>
+        </DialogHeader>
+
+        <p class="mb-3 text-sm text-muted-foreground">
+          Enter a username to send a friend request.
+        </p>
+
+        <div class="relative">
+          <Input
+            type="text"
+            placeholder="Enter a username"
+            value={username()}
+            onInput={(e) => {
+              setUsername(e.currentTarget.value);
+              setHighlightedIndex(-1);
+              setError(null);
+            }}
+            onKeyDown={handleKeyDown}
+            autofocus
+          />
+
+          <Show when={suggestions().length > 0}>
+            <div class="absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+              <For each={suggestions()}>
+                {(user, index) => (
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-accent"
+                    classList={{ "bg-accent": highlightedIndex() === index() }}
+                    onMouseEnter={() => setHighlightedIndex(index())}
+                    onClick={() => selectSuggestion(user)}
+                  >
+                    <Show
+                      when={user.avatarUrl}
+                      fallback={
+                        <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                          {(user.displayName ?? user.username ?? "?").charAt(0).toUpperCase()}
+                        </div>
+                      }
+                    >
+                      {(url) => (
+                        <img
+                          src={url()}
+                          alt={user.displayName ?? user.username ?? "User"}
+                          class="h-8 w-8 shrink-0 rounded-full object-cover"
+                        />
+                      )}
+                    </Show>
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm font-medium text-foreground">
+                        {user.displayName ?? user.username ?? "Unknown"}
+                      </p>
+                      <Show when={user.username}>
+                        {(uname) => (
+                          <p class="truncate text-xs text-muted-foreground">@{uname()}</p>
+                        )}
+                      </Show>
+                    </div>
+                  </button>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+
+        <Show when={error()}>
+          <p class="mt-2 text-xs text-destructive">{error()}</p>
+        </Show>
+
+        <div class="mt-4 flex justify-end gap-2">
+          <Button variant="secondary" onClick={props.onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSend} disabled={sending() || !username().trim()}>
+            {sending() ? "Sending..." : "Send Request"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddFriendModal;

--- a/apps/web/src/stores/command-palette-store.ts
+++ b/apps/web/src/stores/command-palette-store.ts
@@ -1,0 +1,5 @@
+import { createSignal } from "solid-js";
+
+const [commandPaletteOpen, setCommandPaletteOpen] = createSignal(false);
+
+export { commandPaletteOpen, setCommandPaletteOpen };


### PR DESCRIPTION
## Summary
- **Bigger logo**: Sidebar logo increased from `h-8 w-8` to `h-10 w-10` for stronger brand identity
- **Add Friend button**: Persistent quick-action button in sidebar (next to Send File) with full modal — username search with autocomplete via `/api/users/search`, send request, toast feedback
- **Command palette**: `Ctrl+K` / `Cmd+K` overlay that searches friends, servers, channels, and app actions. Keyboard-navigable (arrows, Enter, Escape). Search trigger styled as input bar (expanded) or icon (collapsed)

## New files
- `apps/web/src/components/CommandPalette.tsx` — command palette overlay
- `apps/web/src/components/modals/AddFriendModal.tsx` — Add Friend dialog
- `apps/web/src/stores/command-palette-store.ts` — shared open/close signal

## Modified files
- `apps/web/src/components/AppSidebar.tsx` — logo size, search trigger, Add Friend button, command palette rendering
- `apps/web/src/components/AppLayout.tsx` — global Ctrl+K keyboard shortcut

## Test plan
- [ ] Verify logo is visibly larger in both expanded and collapsed sidebar
- [ ] Click "Add Friend" in sidebar → modal opens, search autocomplete works, sending request shows toast
- [ ] Click search bar in expanded sidebar → command palette opens
- [ ] Press Ctrl+K from anywhere → command palette toggles
- [ ] Type in command palette → results filter across friends/servers/channels/actions
- [ ] Keyboard nav (arrows, Enter, Escape) works in command palette
- [ ] Collapsed sidebar shows search icon and Add Friend icon correctly
- [ ] Selecting a friend navigates to DM, selecting server navigates to server page
- [ ] Actions (Send File, Settings, Support) trigger correctly from command palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable command palette (Ctrl/Cmd+K) with grouped results (friends, servers, channels, actions), keyboard navigation, Enter to activate, and Escape to close.
  * Add Friend modal with live username suggestions, keyboard/mouse selection, debounced search, error display, and send-request flow.
  * Sidebar quick actions: Search and Add Friend.

* **Improvements**
  * Palette shortcuts ignore editable fields and close mobile sidebar when actions run.
  * Header icon size adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->