### PR TITLE
feat: wire up email verification on signup

### DIFF
--- a/apps/server/src/auth/index.ts
+++ b/apps/server/src/auth/index.ts
@@ -21,6 +21,47 @@ export const auth = betterAuth({
   baseURL: env.BETTER_AUTH_URL,
   // APP_URL always has a value (see env.ts default), so this array is never empty
   trustedOrigins: [env.APP_URL, env.CORS_ORIGIN, `https://admin.${new URL(env.APP_URL).host}`].filter(Boolean) as string[],
+  emailVerification: {
+    sendOnSignUp: true,
+    autoSignInAfterVerification: true,
+    sendVerificationEmail: async ({ user, url }) => {
+      try {
+        await sendEmail({
+          to: user.email,
+          subject: "Verify your UnCorded email",
+          html: `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background-color:#111114;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#111114;padding:40px 20px;">
+    <tr><td align="center">
+      <table width="480" cellpadding="0" cellspacing="0" style="background-color:#1a1a1f;border-radius:12px;border:1px solid #2a2a30;padding:40px;">
+        <tr><td style="text-align:center;padding-bottom:24px;">
+          <h1 style="margin:0;font-size:20px;font-weight:700;color:#22c55e;">UnCorded</h1>
+        </td></tr>
+        <tr><td style="color:#e4e4e7;font-size:15px;line-height:1.6;">
+          <p style="margin:0 0 16px;">Hi ${escapeHtml(user.name ?? "there")},</p>
+          <p style="margin:0 0 24px;">Please verify your email address to complete your UnCorded account setup.</p>
+        </td></tr>
+        <tr><td align="center" style="padding-bottom:24px;">
+          <a href="${escapeHtml(url)}" style="display:inline-block;background-color:#22c55e;color:#000;font-weight:600;font-size:15px;padding:12px 32px;border-radius:8px;text-decoration:none;">Verify Email</a>
+        </td></tr>
+        <tr><td style="color:#a1a1aa;font-size:13px;line-height:1.5;">
+          <p style="margin:0 0 8px;">This link expires in 24 hours.</p>
+          <p style="margin:0;">If you didn't create an account, you can ignore this email.</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`.trim(),
+        });
+      } catch (err) {
+        console.error("[email] Failed to send verification email:", err);
+      }
+    },
+  },
   emailAndPassword: {
     enabled: true,
     sendResetPassword: async ({ user, url }) => {

--- a/apps/server/src/auth/index.ts
+++ b/apps/server/src/auth/index.ts
@@ -24,6 +24,7 @@ export const auth = betterAuth({
   emailVerification: {
     sendOnSignUp: true,
     autoSignInAfterVerification: true,
+    expiresIn: 86_400,
     sendVerificationEmail: async ({ user, url }) => {
       try {
         await sendEmail({
@@ -59,6 +60,7 @@ export const auth = betterAuth({
         });
       } catch (err) {
         console.error("[email] Failed to send verification email:", err);
+        throw err;
       }
     },
   },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ const ForgotPassword = lazy(() => import("./pages/ForgotPassword.js"));
 const ResetPassword = lazy(() => import("./pages/ResetPassword.js"));
 const Privacy = lazy(() => import("./pages/Privacy.js"));
 const Terms = lazy(() => import("./pages/Terms.js"));
+const VerifyEmail = lazy(() => import("./pages/VerifyEmail.js"));
 const Onboarding = lazy(() => import("./pages/Onboarding.js"));
 
 // Authenticated pages
@@ -59,6 +60,7 @@ const App = () => {
       <Route path="/onboarding" component={Onboarding} />
       <Route path="/privacy" component={Privacy} />
       <Route path="/terms" component={Terms} />
+      <Route path="/verify-email" component={VerifyEmail} />
 
       {/* Authenticated — all under AppLayout with AuthGuard */}
       <Route path="/" component={AppLayout}>

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -21,6 +21,7 @@ import { SidebarProvider, SidebarInset } from "./ui/sidebar.js";
 import P2PNoticeDialog from "./P2PNoticeDialog.js";
 import GiftNotification from "./modals/GiftNotification.js";
 import DeletionCountdown from "./modals/DeletionCountdown.js";
+import VerificationBanner from "./VerificationBanner.js";
 import { getP2pDialogOpen, confirmP2pDialog, cancelP2pDialog } from "../stores/file-store.js";
 import {
   pendingInvite,
@@ -82,6 +83,7 @@ const AppLayout: ParentComponent = (props) => {
       <SidebarProvider class="h-screen !min-h-0">
         <AppSidebar />
         <SidebarInset>
+          <VerificationBanner />
           <Show
             when={gatewayStatus() === "connected"}
             fallback={

--- a/apps/web/src/components/VerificationBanner.tsx
+++ b/apps/web/src/components/VerificationBanner.tsx
@@ -1,0 +1,68 @@
+import { createSignal, Show } from "solid-js";
+import { sendVerificationEmail, useSession } from "../lib/auth.js";
+
+const DISMISSED_KEY = "verification-banner-dismissed";
+
+const VerificationBanner = () => {
+  const session = useSession();
+  const [dismissed, setDismissed] = createSignal(sessionStorage.getItem(DISMISSED_KEY) === "1");
+  const [resending, setResending] = createSignal(false);
+  const [resent, setResent] = createSignal(false);
+
+  const user = () => session()?.data?.user;
+  const shouldShow = () => {
+    const u = user();
+    if (!u || dismissed()) return false;
+    return u.emailVerified === false;
+  };
+
+  const handleResend = async (e: MouseEvent) => {
+    e.preventDefault();
+    const email = user()?.email;
+    if (!email) return;
+    setResending(true);
+    setResent(false);
+    try {
+      await sendVerificationEmail({ email, callbackURL: "/home" });
+      setResent(true);
+    } finally {
+      setResending(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(DISMISSED_KEY, "1");
+    setDismissed(true);
+  };
+
+  return (
+    <Show when={shouldShow()}>
+      <div class="flex items-center justify-between gap-2 bg-warning/15 px-4 py-2 text-sm text-warning">
+        <span>
+          Your email isn't verified. Check your inbox or{" "}
+          <button
+            type="button"
+            class="font-medium underline hover:no-underline"
+            disabled={resending()}
+            onClick={handleResend}
+          >
+            {resending() ? "sending..." : resent() ? "sent!" : "resend"}
+          </button>
+          .
+        </span>
+        <button
+          type="button"
+          class="shrink-0 text-warning/60 hover:text-warning"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+            <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+          </svg>
+        </button>
+      </div>
+    </Show>
+  );
+};
+
+export default VerificationBanner;

--- a/apps/web/src/components/VerificationBanner.tsx
+++ b/apps/web/src/components/VerificationBanner.tsx
@@ -1,5 +1,6 @@
 import { createSignal, Show } from "solid-js";
 import { sendVerificationEmail, useSession } from "../lib/auth.js";
+import { showToast } from "./ui/toast.js";
 
 const DISMISSED_KEY = "verification-banner-dismissed";
 
@@ -25,6 +26,8 @@ const VerificationBanner = () => {
     try {
       await sendVerificationEmail({ email, callbackURL: "/home" });
       setResent(true);
+    } catch {
+      showToast("Failed to resend verification email. Please try again.", "error");
     } finally {
       setResending(false);
     }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -7,4 +7,4 @@ export const authClient = createAuthClient({
   plugins: [usernameClient()],
 });
 
-export const { signIn, signUp, signOut, useSession } = authClient;
+export const { signIn, signUp, signOut, useSession, sendVerificationEmail } = authClient;

--- a/apps/web/src/pages/Register.tsx
+++ b/apps/web/src/pages/Register.tsx
@@ -75,7 +75,7 @@ const Register = () => {
       if (result.error) {
         setError(result.error.message ?? "Registration failed");
       } else {
-        navigate("/home", { replace: true });
+        navigate("/verify-email", { replace: true });
       }
     } catch {
       setError("Something went wrong");

--- a/apps/web/src/pages/VerifyEmail.tsx
+++ b/apps/web/src/pages/VerifyEmail.tsx
@@ -1,0 +1,76 @@
+import { createSignal } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import { sendVerificationEmail, useSession } from "../lib/auth.js";
+import AuthLayout from "../components/AuthLayout.js";
+import { Button } from "../components/ui/button.js";
+
+const VerifyEmail = () => {
+  const navigate = useNavigate();
+  const session = useSession();
+  const [resending, setResending] = createSignal(false);
+  const [resent, setResent] = createSignal(false);
+
+  const email = () => session()?.data?.user?.email ?? "";
+
+  const handleResend = async () => {
+    const addr = email();
+    if (!addr) return;
+    setResending(true);
+    setResent(false);
+    try {
+      await sendVerificationEmail({ email: addr, callbackURL: "/home" });
+      setResent(true);
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <div class="flex flex-col items-center text-center">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="mb-4 h-12 w-12 text-primary"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"
+          />
+        </svg>
+
+        <h1 class="mb-2 text-2xl font-bold text-foreground">Check your email</h1>
+
+        <p class="mb-6 text-sm text-secondary-foreground">
+          We sent a verification link to{" "}
+          <span class="font-medium text-foreground">{email() || "your email"}</span>.
+          Click it to verify your account.
+        </p>
+
+        <div class="flex w-full gap-3">
+          <Button
+            variant="outline"
+            class="flex-1"
+            disabled={resending()}
+            onClick={handleResend}
+          >
+            {resending() ? "Sending..." : resent() ? "Sent!" : "Resend Email"}
+          </Button>
+          <Button class="flex-1" onClick={() => navigate("/home", { replace: true })}>
+            Continue Anyway
+          </Button>
+        </div>
+
+        <p class="mt-4 text-xs text-muted-foreground">
+          Didn't receive it? Check your spam folder.
+        </p>
+      </div>
+    </AuthLayout>
+  );
+};
+
+export default VerifyEmail;

--- a/apps/web/src/pages/VerifyEmail.tsx
+++ b/apps/web/src/pages/VerifyEmail.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { sendVerificationEmail, useSession } from "../lib/auth.js";
 import AuthLayout from "../components/AuthLayout.js";
@@ -9,6 +9,7 @@ const VerifyEmail = () => {
   const session = useSession();
   const [resending, setResending] = createSignal(false);
   const [resent, setResent] = createSignal(false);
+  const [error, setError] = createSignal("");
 
   const email = () => session()?.data?.user?.email ?? "";
 
@@ -17,9 +18,12 @@ const VerifyEmail = () => {
     if (!addr) return;
     setResending(true);
     setResent(false);
+    setError("");
     try {
       await sendVerificationEmail({ email: addr, callbackURL: "/home" });
       setResent(true);
+    } catch {
+      setError("Failed to send verification email. Please try again.");
     } finally {
       setResending(false);
     }
@@ -58,12 +62,16 @@ const VerifyEmail = () => {
             disabled={resending()}
             onClick={handleResend}
           >
-            {resending() ? "Sending..." : resent() ? "Sent!" : "Resend Email"}
+            {resending() ? "Sending..." : resent() ? "Sent!" : error() ? "Retry" : "Resend Email"}
           </Button>
           <Button class="flex-1" onClick={() => navigate("/home", { replace: true })}>
             Continue Anyway
           </Button>
         </div>
+
+        <Show when={error()}>
+          <p class="mt-3 text-sm text-destructive">{error()}</p>
+        </Show>
 
         <p class="mt-4 text-xs text-muted-foreground">
           Didn't receive it? Check your spam folder.


### PR DESCRIPTION
## Summary

- Enable Better Auth's `emailVerification` config with `sendOnSignUp` and `autoSignInAfterVerification`
- Send branded verification email matching the existing password reset email style
- Add `/verify-email` page with resend and "Continue Anyway" buttons
- Redirect register flow to `/verify-email` instead of `/home`
- Add dismissible verification banner in `AppLayout` for unverified users (sessionStorage-backed dismiss)

## Test plan

- [ ] Register a new account with email/password — should redirect to `/verify-email` page
- [ ] Check inbox for verification email — should match dark theme branding
- [ ] Click "Verify Email" button in email — should verify and auto sign-in
- [ ] Click "Resend Email" on verify page — should send another verification email
- [ ] Click "Continue Anyway" — should navigate to `/home`
- [ ] Unverified user sees yellow banner in app with resend link
- [ ] Dismissing banner persists for the session, reappears on next session
- [ ] OAuth signup (Google/Discord) should have `emailVerified = true` — no banner shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email verification is now required on sign-up. After registration, users are directed to a verification page and automatically signed in upon successful verification.
  * A verification banner appears in the app for unverified users with an option to resend verification emails.
  * Users can resend verification emails from both the banner and dedicated verification page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->