### PR TITLE
feat: bot account system — API tokens, management UI, WS auth

### DIFF
--- a/apps/server/drizzle/0014_add_bots.sql
+++ b/apps/server/drizzle/0014_add_bots.sql
@@ -15,4 +15,5 @@ CREATE TABLE "bots" (
   CONSTRAINT "bots_user_id_unique" UNIQUE("user_id")
 );--> statement-breakpoint
 
-CREATE INDEX "bots_owner_id_idx" ON "bots" ("owner_id");
+CREATE INDEX "bots_owner_id_idx" ON "bots" ("owner_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "bots_token_hash_unique" ON "bots" ("token_hash");

--- a/apps/server/drizzle/0014_add_bots.sql
+++ b/apps/server/drizzle/0014_add_bots.sql
@@ -1,0 +1,18 @@
+-- Add is_bot flag to user table
+ALTER TABLE "user" ADD COLUMN "is_bot" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+
+-- Create bots table
+CREATE TABLE "bots" (
+  "id" text PRIMARY KEY NOT NULL,
+  "owner_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "name" text NOT NULL,
+  "description" text,
+  "token_hash" text NOT NULL,
+  "token_prefix" text NOT NULL,
+  "last_used_at" timestamp,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "bots_user_id_unique" UNIQUE("user_id")
+);--> statement-breakpoint
+
+CREATE INDEX "bots_owner_id_idx" ON "bots" ("owner_id");

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1742515200000,
       "tag": "0013_file_session_receipts",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1743091200000,
+      "tag": "0014_add_bots",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -116,7 +116,10 @@ export const bots = pgTable(
     lastUsedAt: timestamp("last_used_at", { mode: "date" }),
     createdAt: createdAt(),
   },
-  (t) => [index("bots_owner_id_idx").on(t.ownerId)],
+  (t) => [
+    index("bots_owner_id_idx").on(t.ownerId),
+    unique("bots_token_hash_unique").on(t.tokenHash),
+  ],
 );
 
 export const session = pgTable(

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -95,7 +95,29 @@ export const user = pgTable("user", {
   status: userStatusEnum("status").default("offline").notNull(),
   subscriptionTier: subscriptionTierEnum("subscription_tier").default("free").notNull(),
   banned: boolean("banned").default(false).notNull(),
+  isBot: boolean("is_bot").default(false).notNull(),
 });
+
+export const bots = pgTable(
+  "bots",
+  {
+    id: id(),
+    ownerId: text("owner_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" })
+      .unique(),
+    name: text("name").notNull(),
+    description: text("description"),
+    tokenHash: text("token_hash").notNull(),
+    tokenPrefix: text("token_prefix").notNull(),
+    lastUsedAt: timestamp("last_used_at", { mode: "date" }),
+    createdAt: createdAt(),
+  },
+  (t) => [index("bots_owner_id_idx").on(t.ownerId)],
+);
 
 export const session = pgTable(
   "session",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,7 @@ import { webhookRoutes } from "./routes/webhook.js";
 import { stripeRoutes } from "./routes/stripe.js";
 import { turnRoutes } from "./routes/turn.js";
 import { fileReceiptRoutes } from "./routes/file-receipts.js";
+import { botRoutes } from "./routes/bots.js";
 import { gatewayTicketRoutes } from "./routes/gateway.js";
 import { gateway } from "./ws/gateway.js";
 import { subscribeCacheInvalidation, PubSubChannel } from "./lib/redis-pubsub.js";
@@ -79,6 +80,7 @@ const app = new Elysia()
   .use(pollRoutes)
   .use(safetyRoutes)
   .use(fileReceiptRoutes)
+  .use(botRoutes)
   .use(gatewayTicketRoutes)
   .use(gateway)
   .get("/health", () => ({ status: "ok" }))

--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -19,6 +19,9 @@ export function authResolve() {
       // Try bot token auth as fallback
       const botSession = await getBotSession(request.headers);
       if (botSession) {
+        if ((botSession.user as Record<string, unknown>).banned === true) {
+          throw new ForbiddenError("Account banned");
+        }
         return { user: botSession.user, session: null };
       }
       throw new UnauthorizedError();

--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { UnauthorizedError, ForbiddenError } from "@uncorded/shared";
 import { auth } from "../auth/index.js";
+import { getBotSession } from "./bot-auth.js";
 
 export const betterAuthPlugin = new Elysia({ name: "better-auth" }).mount(auth.handler);
 
@@ -11,8 +12,15 @@ export async function getSession(headers: Headers) {
 /** Reusable `.resolve()` callback that gates routes behind authentication. */
 export function authResolve() {
   return async ({ request }: { request: Request }) => {
+    // Try session auth first (existing flow)
     const session = await getSession(request.headers);
+
     if (!session) {
+      // Try bot token auth as fallback
+      const botSession = await getBotSession(request.headers);
+      if (botSession) {
+        return { user: botSession.user, session: null };
+      }
       throw new UnauthorizedError();
     }
 

--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -9,20 +9,28 @@ export async function getSession(headers: Headers) {
   return auth.api.getSession({ headers });
 }
 
-/** Reusable `.resolve()` callback that gates routes behind authentication. */
-export function authResolve() {
+/**
+ * Reusable `.resolve()` callback that gates routes behind authentication.
+ * Bot token auth is disabled by default — pass `{ allowBots: true }` for
+ * routes that bots should be able to access (e.g. messaging, members).
+ */
+export function authResolve(opts?: { allowBots?: boolean }) {
+  const allowBots = opts?.allowBots ?? false;
+
   return async ({ request }: { request: Request }) => {
     // Try session auth first (existing flow)
     const session = await getSession(request.headers);
 
     if (!session) {
-      // Try bot token auth as fallback
-      const botSession = await getBotSession(request.headers);
-      if (botSession) {
-        if ((botSession.user as Record<string, unknown>).banned === true) {
-          throw new ForbiddenError("Account banned");
+      // Try bot token auth as fallback — only if route allows bots
+      if (allowBots) {
+        const botSession = await getBotSession(request.headers);
+        if (botSession) {
+          if ((botSession.user as Record<string, unknown>).banned === true) {
+            throw new ForbiddenError("Account banned");
+          }
+          return { user: botSession.user, session: null };
         }
-        return { user: botSession.user, session: null };
       }
       throw new UnauthorizedError();
     }

--- a/apps/server/src/middleware/bot-auth.ts
+++ b/apps/server/src/middleware/bot-auth.ts
@@ -1,0 +1,32 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { bots, user } from "../db/schema.js";
+
+export async function getBotSession(headers: Headers) {
+  const auth = headers.get("Authorization");
+  if (!auth?.startsWith("Bearer uncrd_")) return null;
+
+  const token = auth.slice(7); // remove "Bearer "
+  const hash = new Bun.CryptoHasher("sha256").update(token).digest("hex");
+
+  const rows = await db
+    .select()
+    .from(bots)
+    .innerJoin(user, eq(bots.userId, user.id))
+    .where(eq(bots.tokenHash, hash))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return null;
+
+  // Update lastUsedAt (fire and forget)
+  db.update(bots)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(bots.id, row.bots.id))
+    .catch(() => {});
+
+  return {
+    user: row.user,
+    bot: row.bots,
+  };
+}

--- a/apps/server/src/middleware/bot-auth.ts
+++ b/apps/server/src/middleware/bot-auth.ts
@@ -19,11 +19,15 @@ export async function getBotSession(headers: Headers) {
   const row = rows[0];
   if (!row) return null;
 
-  // Update lastUsedAt (fire and forget)
-  db.update(bots)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(bots.id, row.bots.id))
-    .catch(() => {});
+  // Update lastUsedAt at most once every 5 minutes to reduce write amplification
+  const STALE_MS = 5 * 60_000;
+  const lastUsed = row.bots.lastUsedAt?.getTime() ?? 0;
+  if (Date.now() - lastUsed > STALE_MS) {
+    db.update(bots)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(bots.id, row.bots.id))
+      .catch(() => {});
+  }
 
   return {
     user: row.user,

--- a/apps/server/src/routes/bots.ts
+++ b/apps/server/src/routes/bots.ts
@@ -95,17 +95,6 @@ export const botRoutes = new Elysia({ prefix: "/api/bots" })
     const tierKey = String(sessionUser.subscriptionTier);
     const limit = BOT_LIMITS[tierKey] ?? 1;
 
-    const [countRow] = await db
-      .select({ value: count() })
-      .from(bots)
-      .where(eq(bots.ownerId, sessionUser.id));
-
-    if ((countRow?.value ?? 0) >= limit) {
-      throw new ValidationError(
-        `Bot limit reached (${limit} for ${sessionUser.subscriptionTier} tier)`,
-      );
-    }
-
     const token = generateToken();
     const tokenH = hashToken(token);
     const tokenPfx = token.slice(0, 14); // "uncrd_" + 8 chars
@@ -116,6 +105,18 @@ export const botRoutes = new Elysia({ prefix: "/api/bots" })
     const username = `bot_${sanitizeUsername(parsed.data.name)}_${shortId}`;
 
     const result = await db.transaction(async (tx) => {
+      // Check bot limit inside transaction to prevent races
+      const [countRow] = await tx
+        .select({ value: count() })
+        .from(bots)
+        .where(eq(bots.ownerId, sessionUser.id));
+
+      if ((countRow?.value ?? 0) >= limit) {
+        throw new ValidationError(
+          `Bot limit reached (${limit} for ${sessionUser.subscriptionTier} tier)`,
+        );
+      }
+
       // Create user record for the bot
       const [botUser] = await tx
         .insert(user)

--- a/apps/server/src/routes/bots.ts
+++ b/apps/server/src/routes/bots.ts
@@ -9,10 +9,11 @@ import {
   createId,
 } from "@uncorded/shared";
 import { db } from "../db/index.js";
-import { bots, user } from "../db/schema.js";
+import { bots, user, members } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
-import { disconnectUser } from "../ws/connections.js";
-import { CloseCode } from "@uncorded/protocol";
+import { disconnectUser, broadcastToServer } from "../ws/connections.js";
+import { removeServerMember } from "../ws/server-members.js";
+import { CloseCode, Opcode, serverId, userId } from "@uncorded/protocol";
 
 // ── Schemas ──────────────────────────────────────────────────────────────────
 
@@ -188,12 +189,27 @@ export const botRoutes = new Elysia({ prefix: "/api/bots" })
 
     if (!bot) throw new NotFoundError("Bot");
 
+    // Clean up server memberships so clients get MEMBER_REMOVE broadcasts
+    const botMemberships = await db
+      .select({ serverId: members.serverId })
+      .from(members)
+      .where(eq(members.userId, bot.userId));
+
+    for (const m of botMemberships) {
+      removeServerMember(m.serverId, bot.userId);
+      broadcastToServer(m.serverId, {
+        op: Opcode.MEMBER_REMOVE,
+        d: { serverId: serverId(m.serverId), userId: userId(bot.userId) },
+      });
+    }
+
     // Disconnect the bot from WebSocket if connected
     disconnectUser(bot.userId, CloseCode.INVALID_SESSION, "Bot deleted");
 
-    // Delete bot record first, then the bot's user record
+    // Delete bot record, memberships, then the bot's user record
     await db.transaction(async (tx) => {
       await tx.delete(bots).where(eq(bots.id, bot.id));
+      await tx.delete(members).where(eq(members.userId, bot.userId));
       await tx.delete(user).where(eq(user.id, bot.userId));
     });
 
@@ -206,25 +222,21 @@ export const botRoutes = new Elysia({ prefix: "/api/bots" })
       throw new ForbiddenError("Bots cannot regenerate tokens");
     }
 
-    const [bot] = await db
-      .select()
-      .from(bots)
-      .where(and(eq(bots.id, params.id), eq(bots.ownerId, sessionUser.id)))
-      .limit(1);
-
-    if (!bot) throw new NotFoundError("Bot");
-
     const token = generateToken();
     const tokenH = hashToken(token);
     const tokenPfx = token.slice(0, 14);
 
-    await db
+    // Atomic update — no separate read needed
+    const [updated] = await db
       .update(bots)
       .set({ tokenHash: tokenH, tokenPrefix: tokenPfx })
-      .where(eq(bots.id, bot.id));
+      .where(and(eq(bots.id, params.id), eq(bots.ownerId, sessionUser.id)))
+      .returning({ userId: bots.userId });
+
+    if (!updated) throw new NotFoundError("Bot");
 
     // Disconnect bot — old token is now invalid
-    disconnectUser(bot.userId, CloseCode.INVALID_SESSION, "Token regenerated");
+    disconnectUser(updated.userId, CloseCode.INVALID_SESSION, "Token regenerated");
 
     return { token, tokenPrefix: tokenPfx };
   });

--- a/apps/server/src/routes/bots.ts
+++ b/apps/server/src/routes/bots.ts
@@ -1,0 +1,223 @@
+import { Elysia } from "elysia";
+import { eq, and, count } from "drizzle-orm";
+import { z } from "zod";
+import {
+  ValidationError,
+  NotFoundError,
+  ForbiddenError,
+  InternalError,
+  createId,
+} from "@uncorded/shared";
+import { db } from "../db/index.js";
+import { bots, user } from "../db/schema.js";
+import { authResolve } from "../middleware/auth.js";
+import { disconnectUser } from "../ws/connections.js";
+import { CloseCode } from "@uncorded/protocol";
+
+// ── Schemas ──────────────────────────────────────────────────────────────────
+
+const createBotSchema = z.object({
+  name: z.string().trim().min(2).max(32),
+  description: z.string().trim().max(200).optional(),
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const BOT_LIMITS: Record<string, number> = {
+  free: 1,
+  supporter: 3,
+  server_owner: 5,
+};
+
+function generateToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(24));
+  const chars = Array.from(bytes, (b) => b.toString(36).padStart(2, "0")).join("").slice(0, 32);
+  return `uncrd_${chars}`;
+}
+
+function hashToken(token: string): string {
+  return new Bun.CryptoHasher("sha256").update(token).digest("hex");
+}
+
+function sanitizeUsername(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "")
+    .slice(0, 20);
+}
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+
+export const botRoutes = new Elysia({ prefix: "/api/bots" })
+  .resolve(authResolve())
+
+  // ── GET /api/bots — list user's bots ─────────────────────────────────
+  .get("/", async ({ user: sessionUser }) => {
+    if ((sessionUser as Record<string, unknown>).isBot) {
+      throw new ForbiddenError("Bots cannot manage bots");
+    }
+
+    const rows = await db
+      .select({
+        id: bots.id,
+        name: bots.name,
+        description: bots.description,
+        userId: bots.userId,
+        tokenPrefix: bots.tokenPrefix,
+        lastUsedAt: bots.lastUsedAt,
+        createdAt: bots.createdAt,
+        username: user.username,
+      })
+      .from(bots)
+      .innerJoin(user, eq(bots.userId, user.id))
+      .where(eq(bots.ownerId, sessionUser.id));
+
+    return { bots: rows };
+  })
+
+  // ── POST /api/bots — create a new bot ────────────────────────────────
+  .post("/", async ({ user: sessionUser, body, set }) => {
+    if ((sessionUser as Record<string, unknown>).isBot) {
+      throw new ForbiddenError("Bots cannot create bots");
+    }
+
+    if (!sessionUser.emailVerified) {
+      throw new ForbiddenError("Verify your email to create bots");
+    }
+
+    const parsed = createBotSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
+    }
+
+    const tierKey = String(sessionUser.subscriptionTier);
+    const limit = BOT_LIMITS[tierKey] ?? 1;
+
+    const [countRow] = await db
+      .select({ value: count() })
+      .from(bots)
+      .where(eq(bots.ownerId, sessionUser.id));
+
+    if ((countRow?.value ?? 0) >= limit) {
+      throw new ValidationError(
+        `Bot limit reached (${limit} for ${sessionUser.subscriptionTier} tier)`,
+      );
+    }
+
+    const token = generateToken();
+    const tokenH = hashToken(token);
+    const tokenPfx = token.slice(0, 14); // "uncrd_" + 8 chars
+
+    const botId = createId();
+    const botUserId = createId();
+    const shortId = botId.slice(0, 4);
+    const username = `bot_${sanitizeUsername(parsed.data.name)}_${shortId}`;
+
+    const result = await db.transaction(async (tx) => {
+      // Create user record for the bot
+      const [botUser] = await tx
+        .insert(user)
+        .values({
+          id: botUserId,
+          name: parsed.data.name,
+          username,
+          displayUsername: username,
+          email: `bot-${botId}@bots.uncorded.internal`,
+          emailVerified: true,
+          isBot: true,
+          status: "offline",
+        })
+        .returning();
+
+      if (!botUser) throw new InternalError("Failed to create bot user");
+
+      // Create bot record
+      const [bot] = await tx
+        .insert(bots)
+        .values({
+          id: botId,
+          ownerId: sessionUser.id,
+          userId: botUserId,
+          name: parsed.data.name,
+          description: parsed.data.description ?? null,
+          tokenHash: tokenH,
+          tokenPrefix: tokenPfx,
+        })
+        .returning();
+
+      if (!bot) throw new InternalError("Failed to create bot");
+
+      return { bot, botUser };
+    });
+
+    set.status = 201;
+    return {
+      bot: {
+        id: result.bot.id,
+        name: result.bot.name,
+        description: result.bot.description,
+        userId: result.bot.userId,
+        username: result.botUser.username,
+        tokenPrefix: result.bot.tokenPrefix,
+        createdAt: result.bot.createdAt,
+      },
+      token,
+    };
+  })
+
+  // ── DELETE /api/bots/:id — delete a bot ──────────────────────────────
+  .delete("/:id", async ({ user: sessionUser, params }) => {
+    if ((sessionUser as Record<string, unknown>).isBot) {
+      throw new ForbiddenError("Bots cannot delete bots");
+    }
+
+    const [bot] = await db
+      .select()
+      .from(bots)
+      .where(and(eq(bots.id, params.id), eq(bots.ownerId, sessionUser.id)))
+      .limit(1);
+
+    if (!bot) throw new NotFoundError("Bot");
+
+    // Disconnect the bot from WebSocket if connected
+    disconnectUser(bot.userId, CloseCode.INVALID_SESSION, "Bot deleted");
+
+    // Delete bot record first, then the bot's user record
+    await db.transaction(async (tx) => {
+      await tx.delete(bots).where(eq(bots.id, bot.id));
+      await tx.delete(user).where(eq(user.id, bot.userId));
+    });
+
+    return { success: true };
+  })
+
+  // ── POST /api/bots/:id/regenerate-token — regenerate token ───────────
+  .post("/:id/regenerate-token", async ({ user: sessionUser, params }) => {
+    if ((sessionUser as Record<string, unknown>).isBot) {
+      throw new ForbiddenError("Bots cannot regenerate tokens");
+    }
+
+    const [bot] = await db
+      .select()
+      .from(bots)
+      .where(and(eq(bots.id, params.id), eq(bots.ownerId, sessionUser.id)))
+      .limit(1);
+
+    if (!bot) throw new NotFoundError("Bot");
+
+    const token = generateToken();
+    const tokenH = hashToken(token);
+    const tokenPfx = token.slice(0, 14);
+
+    await db
+      .update(bots)
+      .set({ tokenHash: tokenH, tokenPrefix: tokenPfx })
+      .where(eq(bots.id, bot.id));
+
+    // Disconnect bot — old token is now invalid
+    disconnectUser(bot.userId, CloseCode.INVALID_SESSION, "Token regenerated");
+
+    return { token, tokenPrefix: tokenPfx };
+  });

--- a/apps/server/src/routes/bots.ts
+++ b/apps/server/src/routes/bots.ts
@@ -105,7 +105,13 @@ export const botRoutes = new Elysia({ prefix: "/api/bots" })
     const username = `bot_${sanitizeUsername(parsed.data.name)}_${shortId}`;
 
     const result = await db.transaction(async (tx) => {
-      // Check bot limit inside transaction to prevent races
+      // Lock owner row to serialize concurrent bot creates per-owner
+      await tx
+        .select({ id: user.id })
+        .from(user)
+        .where(eq(user.id, sessionUser.id))
+        .for("update");
+
       const [countRow] = await tx
         .select({ value: count() })
         .from(bots)

--- a/apps/server/src/routes/friend.ts
+++ b/apps/server/src/routes/friend.ts
@@ -107,6 +107,10 @@ export const friendRoutes = new Elysia({ prefix: "/api/friends" })
 
   // POST /request — Send friend request
   .post("/request", async ({ user: sessionUser, body, set }) => {
+    if ((sessionUser as Record<string, unknown>).isBot) {
+      throw new ForbiddenError("Bots cannot send friend requests");
+    }
+
     await checkUserRateLimit(
       sessionUser.id,
       "friends:request",

--- a/apps/server/src/routes/gateway.ts
+++ b/apps/server/src/routes/gateway.ts
@@ -42,7 +42,7 @@ export async function consumeTicket(ticket: string): Promise<string | null> {
 // ── Route ───────────────────────────────────────────────────────────────────
 
 export const gatewayTicketRoutes = new Elysia({ prefix: "/api/gateway" })
-  .resolve(authResolve())
+  .resolve(authResolve({ allowBots: true }))
   .post("/ticket", async ({ user: sessionUser }) => {
     const ticket = crypto.randomUUID();
     const redisKey = `ws:ticket:${ticket}`;

--- a/apps/server/src/routes/invite.ts
+++ b/apps/server/src/routes/invite.ts
@@ -192,6 +192,7 @@ export const inviteCodeRoutes = new Elysia({ prefix: "/api/invites/:code" })
           username: user.username,
           displayName: user.displayName,
           avatarUrl: user.avatarUrl,
+          isBot: user.isBot,
         })
         .from(user)
         .where(eq(user.id, sessionUser.id))

--- a/apps/server/src/routes/invite.ts
+++ b/apps/server/src/routes/invite.ts
@@ -139,7 +139,7 @@ export const inviteCodeRoutes = new Elysia({ prefix: "/api/invites/:code" })
       memberCount: memberCount?.count ?? 0,
     };
   })
-  .resolve(authResolve())
+  .resolve(authResolve({ allowBots: true }))
   .post("/accept", async ({ user: sessionUser, params }) => {
     const { invite, server, joinerProfile, serverChannels } = await db.transaction(async (tx) => {
       const [inv] = await tx

--- a/apps/server/src/routes/member.ts
+++ b/apps/server/src/routes/member.ts
@@ -26,6 +26,7 @@ export const memberRoutes = new Elysia({ prefix: "/api/servers/:serverId/members
         displayName: user.displayName,
         avatarUrl: user.avatarUrl,
         status: user.status,
+        isBot: user.isBot,
       })
       .from(members)
       .innerJoin(user, eq(user.id, members.userId))

--- a/apps/server/src/routes/member.ts
+++ b/apps/server/src/routes/member.ts
@@ -11,7 +11,7 @@ import { broadcastToServer, sendToUser, clients } from "../ws/connections.js";
 import { paginationQuerySchema } from "../helpers/pagination.js";
 
 export const memberRoutes = new Elysia({ prefix: "/api/servers/:serverId/members" })
-  .resolve(authResolve())
+  .resolve(authResolve({ allowBots: true }))
   .get("/", async ({ user: sessionUser, params, query }) => {
     await requireMember(sessionUser.id, params.serverId);
 

--- a/apps/server/src/routes/message.ts
+++ b/apps/server/src/routes/message.ts
@@ -45,6 +45,7 @@ const DELETED_AUTHOR = {
   username: "[deleted user]",
   displayName: null as string | null,
   avatarUrl: null as string | null,
+  isBot: false,
 };
 
 /** Fetch a single message with author info. Uses leftJoin to include messages from deleted users. */
@@ -61,6 +62,7 @@ async function fetchMessageWithAuthor(msgId: string) {
         username: user.username,
         displayName: user.displayName,
         avatarUrl: user.avatarUrl,
+        isBot: user.isBot,
       },
     })
     .from(messages)
@@ -185,6 +187,7 @@ export const messageRoutes = new Elysia({ prefix: "/api/channels/:channelId/mess
           username: user.username,
           displayName: user.displayName,
           avatarUrl: user.avatarUrl,
+          isBot: user.isBot,
         },
         fileReceipt: {
           id: fileReceipts.id,

--- a/apps/server/src/routes/message.ts
+++ b/apps/server/src/routes/message.ts
@@ -81,7 +81,7 @@ async function fetchMessageWithAuthor(msgId: string) {
 }
 
 export const messageRoutes = new Elysia({ prefix: "/api/channels/:channelId/messages" })
-  .resolve(authResolve())
+  .resolve(authResolve({ allowBots: true }))
 
   // POST / — Create message
   .post("/", async ({ user: sessionUser, params, body, set }) => {

--- a/apps/server/src/routes/server.ts
+++ b/apps/server/src/routes/server.ts
@@ -6,6 +6,7 @@ import {
   transferOwnershipSchema,
   ValidationError,
   NotFoundError,
+  ForbiddenError,
   InternalError,
   createId,
   MAX_SERVERS_PER_USER,
@@ -22,6 +23,10 @@ import { Opcode } from "@uncorded/protocol";
 export const serverRoutes = new Elysia({ prefix: "/api/servers" })
   .resolve(authResolve())
   .post("/", async ({ user: sessionUser, body, set }) => {
+    if ((sessionUser as Record<string, unknown>).isBot) {
+      throw new ForbiddenError("Bots cannot create servers");
+    }
+
     const parsed = createServerSchema.safeParse(body);
     if (!parsed.success) {
       throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");

--- a/apps/server/src/ws/gateway.ts
+++ b/apps/server/src/ws/gateway.ts
@@ -320,6 +320,7 @@ export const gateway = new Elysia().ws("/gateway", {
               username: user.username,
               displayName: user.displayName,
               avatarUrl: user.avatarUrl,
+              isBot: user.isBot,
             })
             .from(user)
             .where(eq(user.id, ctx.userId))
@@ -335,8 +336,8 @@ export const gateway = new Elysia().ws("/gateway", {
               editedAt: null,
               createdAt: insertedMsg!.createdAt.toISOString(),
               author: author
-                ? { id: author.id, username: author.username, displayName: author.displayName, avatarUrl: author.avatarUrl }
-                : { id: ctx.userId, username: null, displayName: null, avatarUrl: null },
+                ? { id: author.id, username: author.username, displayName: author.displayName, avatarUrl: author.avatarUrl, isBot: author.isBot }
+                : { id: ctx.userId, username: null, displayName: null, avatarUrl: null, isBot: false },
               fileReceipt: {
                 id: receiptId,
                 fileName: d.fileName,

--- a/apps/server/src/ws/handlers.ts
+++ b/apps/server/src/ws/handlers.ts
@@ -16,6 +16,7 @@ import { registerUserServers } from "./server-members.js";
 import { seedChannelCache } from "./channel-cache.js";
 import { consumeTicket } from "../routes/gateway.js";
 import { resetIdleTimer, broadcastPresence } from "./presence.js";
+import { getBotSession } from "../middleware/bot-auth.js";
 
 type IdentifyResult =
   | { success: true; userId: string; username: string | null; subscriptionTier: string }
@@ -30,23 +31,38 @@ export async function handleIdentify(
     return {
       success: false,
       closeCode: CloseCode.MISSING_TOKEN,
-      closeReason: "Missing ticket in IDENTIFY",
+      closeReason: "Missing ticket or token in IDENTIFY",
     };
   }
-  const ticket = parsed.data.ticket;
 
   try {
-    // Validate one-time ticket
-    const ticketUserId = await consumeTicket(ticket);
-    if (!ticketUserId) {
-      return {
-        success: false,
-        closeCode: CloseCode.INVALID_SESSION,
-        closeReason: "Invalid or expired ticket",
-      };
-    }
+    let identifiedUserId: string;
 
-    const identifiedUserId = ticketUserId;
+    if (parsed.data.token) {
+      // Bot token flow
+      const botSession = await getBotSession(
+        new Headers({ Authorization: `Bearer ${parsed.data.token}` }),
+      );
+      if (!botSession) {
+        return {
+          success: false,
+          closeCode: CloseCode.INVALID_SESSION,
+          closeReason: "Invalid bot token",
+        };
+      }
+      identifiedUserId = botSession.user.id;
+    } else {
+      // Existing ticket flow
+      const ticketUserId = await consumeTicket(parsed.data.ticket!);
+      if (!ticketUserId) {
+        return {
+          success: false,
+          closeCode: CloseCode.INVALID_SESSION,
+          closeReason: "Invalid or expired ticket",
+        };
+      }
+      identifiedUserId = ticketUserId;
+    }
 
     // Register connection
     addConnection(identifiedUserId, ws);
@@ -60,6 +76,7 @@ export async function handleIdentify(
         avatarUrl: user.avatarUrl,
         status: user.status,
         subscriptionTier: user.subscriptionTier,
+        isBot: user.isBot,
       })
       .from(user)
       .where(eq(user.id, identifiedUserId))

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,6 +30,7 @@ const ProfileSettings = lazy(() => import("./pages/settings/profile-settings.js"
 const AccountSettings = lazy(() => import("./pages/settings/account-settings.js"));
 const AppearanceSettings = lazy(() => import("./pages/settings/appearance-settings.js"));
 const TransferHistory = lazy(() => import("./pages/settings/transfer-history.js"));
+const BotsSettings = lazy(() => import("./pages/settings/bots-settings.js"));
 const NotificationSettings = lazy(() => import("./pages/settings/notification-settings.js"));
 const Upgrade = lazy(() => import("./pages/Upgrade.js"));
 const Billing = lazy(() => import("./pages/Billing.js"));
@@ -77,6 +78,7 @@ const App = () => {
           <Route path="/account" component={AccountSettings} />
           <Route path="/appearance" component={AppearanceSettings} />
           <Route path="/transfers" component={TransferHistory} />
+          <Route path="/bots" component={BotsSettings} />
           <Route path="/upgrade" component={Upgrade} />
           <Route path="/billing" component={Billing} />
           <Route path="/notifications" component={NotificationSettings} />

--- a/apps/web/src/components/MessageBubble.tsx
+++ b/apps/web/src/components/MessageBubble.tsx
@@ -414,6 +414,11 @@ const MessageBubble = (props: MessageBubbleProps) => {
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
                 <span class="text-sm font-semibold text-foreground">{displayName()}</span>
+                <Show when={props.message.author.isBot}>
+                  <span class="rounded bg-primary/20 px-1 py-0.5 text-[9px] font-bold uppercase text-primary">
+                    Bot
+                  </span>
+                </Show>
                 <span class="font-mono text-xs text-muted-foreground">
                   {formatTimestamp(props.message.createdAt)}
                 </span>

--- a/apps/web/src/components/settings/bots-settings.tsx
+++ b/apps/web/src/components/settings/bots-settings.tsx
@@ -1,0 +1,357 @@
+import { createSignal, createResource, For, Show } from "solid-js";
+import { api, ApiRequestError } from "../../lib/api.js";
+import { readyData } from "../../lib/gateway-store.js";
+import { showToast } from "../ui/toast.js";
+import { Button } from "../ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "../ui/dialog.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Bot {
+  id: string;
+  name: string;
+  description: string | null;
+  userId: string;
+  username: string | null;
+  tokenPrefix: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+const BOT_LIMITS: Record<string, number> = {
+  free: 1,
+  supporter: 3,
+  server_owner: 5,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatRelativeTime(iso: string | null): string {
+  if (!iso) return "Never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "Just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+const BotsSettings = () => {
+  const tier = () => readyData.data?.user.subscriptionTier ?? "free";
+  const limit = () => BOT_LIMITS[tier()] ?? 1;
+
+  // Bot list resource
+  const [botList, { refetch }] = createResource(async () => {
+    const res = await api<{ bots: Bot[] }>("/api/bots");
+    return res.bots;
+  });
+
+  // Create dialog state
+  const [showCreate, setShowCreate] = createSignal(false);
+  const [createName, setCreateName] = createSignal("");
+  const [createDesc, setCreateDesc] = createSignal("");
+  const [creating, setCreating] = createSignal(false);
+
+  // Token reveal state (shown once after create/regenerate)
+  const [revealedToken, setRevealedToken] = createSignal<string | null>(null);
+
+  // Delete dialog state
+  const [deleteTarget, setDeleteTarget] = createSignal<Bot | null>(null);
+  const [deleting, setDeleting] = createSignal(false);
+
+  // Regenerate dialog state
+  const [regenTarget, setRegenTarget] = createSignal<Bot | null>(null);
+  const [regenerating, setRegenerating] = createSignal(false);
+
+  // ── Actions ──────────────────────────────────────────────────────────────
+
+  async function handleCreate() {
+    const name = createName().trim();
+    if (!name || name.length < 2 || creating()) return;
+
+    setCreating(true);
+    try {
+      const res = await api<{ bot: Bot; token: string }>("/api/bots", {
+        method: "POST",
+        body: JSON.stringify({
+          name,
+          description: createDesc().trim() || undefined,
+        }),
+      });
+      setShowCreate(false);
+      setCreateName("");
+      setCreateDesc("");
+      setRevealedToken(res.token);
+      refetch();
+    } catch (err) {
+      const msg = err instanceof ApiRequestError ? err.body.message : "Failed to create bot";
+      showToast(msg, "error");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete() {
+    const target = deleteTarget();
+    if (!target || deleting()) return;
+
+    setDeleting(true);
+    try {
+      await api(`/api/bots/${target.id}`, { method: "DELETE" });
+      setDeleteTarget(null);
+      showToast("Bot deleted", "info");
+      refetch();
+    } catch (err) {
+      const msg = err instanceof ApiRequestError ? err.body.message : "Failed to delete bot";
+      showToast(msg, "error");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function handleRegenerate() {
+    const target = regenTarget();
+    if (!target || regenerating()) return;
+
+    setRegenerating(true);
+    try {
+      const res = await api<{ token: string; tokenPrefix: string }>(
+        `/api/bots/${target.id}/regenerate-token`,
+        { method: "POST" },
+      );
+      setRegenTarget(null);
+      setRevealedToken(res.token);
+      refetch();
+    } catch (err) {
+      const msg = err instanceof ApiRequestError ? err.body.message : "Failed to regenerate token";
+      showToast(msg, "error");
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  async function copyToken() {
+    const token = revealedToken();
+    if (!token) return;
+    try {
+      await navigator.clipboard.writeText(token);
+      showToast("Token copied to clipboard", "info");
+    } catch {
+      showToast("Failed to copy", "error");
+    }
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div class="space-y-6">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">Bots</h2>
+        <p class="text-sm text-muted-foreground">
+          Create and manage bot accounts. Bots can connect to UnCorded via API.
+        </p>
+      </div>
+
+      {/* Create button */}
+      <Button
+        onClick={() => setShowCreate(true)}
+        disabled={(botList()?.length ?? 0) >= limit()}
+      >
+        + Create Bot
+      </Button>
+
+      {/* Bot list */}
+      <Show when={!botList.loading} fallback={<p class="text-sm text-muted-foreground">Loading...</p>}>
+        <Show
+          when={(botList()?.length ?? 0) > 0}
+          fallback={
+            <div class="rounded-lg border border-border p-6 text-center">
+              <p class="text-sm text-muted-foreground">
+                No bots yet. Create one to get started with the UnCorded API.
+              </p>
+            </div>
+          }
+        >
+          <div class="space-y-3">
+            <For each={botList()}>
+              {(bot) => (
+                <div class="rounded-lg border border-border p-4">
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <span class="font-semibold text-foreground">{bot.name}</span>
+                        <span class="rounded bg-primary/20 px-1 py-0.5 text-[9px] font-bold uppercase text-primary">
+                          Bot
+                        </span>
+                      </div>
+                      <p class="text-sm text-muted-foreground">@{bot.username}</p>
+                      <Show when={bot.description}>
+                        <p class="mt-1 text-sm text-muted-foreground">{bot.description}</p>
+                      </Show>
+                      <div class="mt-2 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                        <span>Token: {bot.tokenPrefix}...</span>
+                        <span>Last used: {formatRelativeTime(bot.lastUsedAt)}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="mt-3 flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setRegenTarget(bot)}
+                    >
+                      Regenerate Token
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setDeleteTarget(bot)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Show>
+
+      {/* Limit indicator */}
+      <p class="text-xs text-muted-foreground">
+        {botList()?.length ?? 0}/{limit()} bots ({tier()} tier: max {limit()})
+      </p>
+
+      {/* ── Create Dialog ─────────────────────────────────────────────────── */}
+      <Dialog open={showCreate()} onOpenChange={setShowCreate}>
+        <DialogContent onClose={() => setShowCreate(false)}>
+          <DialogHeader>
+            <DialogTitle>Create Bot</DialogTitle>
+            <DialogDescription>
+              Give your bot a name. You'll receive an API token after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div class="space-y-4 py-2">
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Name</label>
+              <input
+                type="text"
+                value={createName()}
+                onInput={(e) => setCreateName(e.currentTarget.value)}
+                placeholder="My Bot"
+                maxLength={32}
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+              <p class="mt-1 text-xs text-muted-foreground">2-32 characters</p>
+            </div>
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">
+                Description <span class="text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                value={createDesc()}
+                onInput={(e) => setCreateDesc(e.currentTarget.value)}
+                placeholder="What does this bot do?"
+                maxLength={200}
+                rows={2}
+                class="w-full resize-none rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowCreate(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={creating() || createName().trim().length < 2}
+            >
+              {creating() ? "Creating..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Token Reveal Dialog ───────────────────────────────────────────── */}
+      <Dialog open={!!revealedToken()} onOpenChange={(open) => { if (!open) setRevealedToken(null); }}>
+        <DialogContent onClose={() => setRevealedToken(null)}>
+          <DialogHeader>
+            <DialogTitle>Bot Token</DialogTitle>
+            <DialogDescription>
+              This token will only be shown once. Copy it now and store it securely.
+            </DialogDescription>
+          </DialogHeader>
+          <div class="py-2">
+            <div class="flex items-center gap-2 rounded-lg bg-input p-3">
+              <code class="min-w-0 flex-1 break-all text-sm text-foreground">
+                {revealedToken()}
+              </code>
+              <Button size="sm" variant="outline" onClick={copyToken}>
+                Copy
+              </Button>
+            </div>
+            <p class="mt-2 text-xs font-medium text-destructive">
+              Warning: You won't be able to see this token again.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => setRevealedToken(null)}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Delete Dialog ─────────────────────────────────────────────────── */}
+      <Dialog open={!!deleteTarget()} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+        <DialogContent onClose={() => setDeleteTarget(null)}>
+          <DialogHeader>
+            <DialogTitle>Delete Bot</DialogTitle>
+            <DialogDescription>
+              This will permanently delete <strong>{deleteTarget()?.name}</strong> and revoke its token. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting()}>
+              {deleting() ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Regenerate Dialog ─────────────────────────────────────────────── */}
+      <Dialog open={!!regenTarget()} onOpenChange={(open) => { if (!open) setRegenTarget(null); }}>
+        <DialogContent onClose={() => setRegenTarget(null)}>
+          <DialogHeader>
+            <DialogTitle>Regenerate Token</DialogTitle>
+            <DialogDescription>
+              This will invalidate the current token for <strong>{regenTarget()?.name}</strong> and disconnect it from any active sessions.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRegenTarget(null)}>
+              Cancel
+            </Button>
+            <Button onClick={handleRegenerate} disabled={regenerating()}>
+              {regenerating() ? "Regenerating..." : "Regenerate"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default BotsSettings;

--- a/apps/web/src/components/settings/bots-settings.tsx
+++ b/apps/web/src/components/settings/bots-settings.tsx
@@ -173,6 +173,14 @@ const BotsSettings = () => {
 
       {/* Bot list */}
       <Show when={!botList.loading} fallback={<p class="text-sm text-muted-foreground">Loading...</p>}>
+        <Show when={!botList.error} fallback={
+          <div class="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
+            <p class="text-sm text-destructive">Failed to load bots.</p>
+            <Button variant="outline" size="sm" class="mt-2" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </div>
+        }>
         <Show
           when={(botList()?.length ?? 0) > 0}
           fallback={
@@ -225,6 +233,7 @@ const BotsSettings = () => {
               )}
             </For>
           </div>
+        </Show>
         </Show>
       </Show>
 

--- a/apps/web/src/lib/gateway-store.ts
+++ b/apps/web/src/lib/gateway-store.ts
@@ -11,6 +11,7 @@ export interface ReadyUser {
   avatarUrl: string | null;
   status: string;
   subscriptionTier: string;
+  isBot?: boolean;
 }
 
 export interface ReadyChannel {

--- a/apps/web/src/pages/SettingsLayout.tsx
+++ b/apps/web/src/pages/SettingsLayout.tsx
@@ -7,6 +7,7 @@ const navItems = [
   { label: "Account", href: "/settings/account" },
   { label: "Appearance", href: "/settings/appearance" },
   { label: "Transfers", href: "/settings/transfers" },
+  { label: "Bots", href: "/settings/bots" },
   { divider: true as const },
   { label: "Upgrade", href: "/settings/upgrade" },
   { label: "Billing", href: "/settings/billing" },

--- a/apps/web/src/pages/settings/bots-settings.tsx
+++ b/apps/web/src/pages/settings/bots-settings.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../components/settings/bots-settings.js";

--- a/apps/web/src/stores/member-store.ts
+++ b/apps/web/src/stores/member-store.ts
@@ -21,6 +21,7 @@ export interface Member {
   avatarUrl: string | null;
   status: string;
   online: boolean;
+  isBot?: boolean;
 }
 
 interface MemberStoreState {
@@ -105,6 +106,7 @@ export function setupMemberStore(): void {
           avatarUrl: d.user.avatarUrl,
           status: "online",
           online: true,
+          isBot: d.user.isBot,
         });
       }),
     );

--- a/apps/web/src/stores/message-store.ts
+++ b/apps/web/src/stores/message-store.ts
@@ -35,6 +35,7 @@ export interface Message {
     username: string | null;
     displayName: string | null;
     avatarUrl: string | null;
+    isBot?: boolean;
   };
   fileReceipt?: MessageFileReceipt | null | undefined;
 }

--- a/apps/web/src/stores/message-store.ts
+++ b/apps/web/src/stores/message-store.ts
@@ -232,6 +232,7 @@ export function setupMessageStore(): void {
         username: d.author.username,
         displayName: d.author.displayName,
         avatarUrl: d.author.avatarUrl,
+        isBot: d.author.isBot,
       },
       fileReceipt: d.fileReceipt ?? null,
     };

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -19,6 +19,7 @@ export const authorSchema = z.object({
   username: z.string().nullable(),
   displayName: z.string().nullable(),
   avatarUrl: z.string().nullable(),
+  isBot: z.boolean().default(false),
 });
 
 const userProfileSchema = z.object({
@@ -41,7 +42,12 @@ export const channelSchema = z.object({
 
 // ── Client → Server (request schemas) ────────────────────────────────────────
 
-export const identifyRequestSchema = z.object({ ticket: z.string() });
+export const identifyRequestSchema = z
+  .object({
+    ticket: z.string().optional(),
+    token: z.string().optional(),
+  })
+  .refine((d) => d.ticket || d.token, "Must provide ticket or token");
 
 export const typingStartRequestSchema = z.object({ channelId: z.string().min(1) });
 
@@ -81,6 +87,7 @@ export const readyEventSchema = z.object({
     avatarUrl: z.string().nullable(),
     status: z.string(),
     subscriptionTier: z.string(),
+    isBot: z.boolean().default(false),
   }),
   servers: z.array(
     z.object({

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -18,6 +18,7 @@ export const userSchema = z.object({
   avatarUrl: z.string().url().nullable(),
   status: userStatusSchema,
   subscriptionTier: z.enum(["free", "supporter", "server_owner"]),
+  isBot: z.boolean().default(false),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });


### PR DESCRIPTION
## Summary

- **Database:** New `bots` table + `is_bot` flag on `user` table with Drizzle migration
- **Auth:** Bot token middleware (`Bearer uncrd_...`) with SHA-256 hash lookup, integrated as fallback in `authResolve()` when no session exists
- **API:** CRUD endpoints at `/api/bots` — create (with email verification + tier-based limits), list, delete, regenerate token. Tokens shown once on creation, only prefix stored.
- **WebSocket:** `IDENTIFY` now accepts `token` alongside `ticket` for bot connections
- **Protocol:** `isBot` field propagated through `authorSchema`, `readyEventSchema`, `MESSAGE_CREATE`, member list, and invite join payloads
- **Restrictions:** Bots cannot create servers, send friend requests, or access admin endpoints
- **Frontend:** New `/settings/bots` page with create/delete/regenerate dialogs, one-time token reveal with copy-to-clipboard, tier limit display
- **UI:** `[BOT]` badge rendered next to author names in chat messages

## Test plan

- [ ] Create a bot via Settings > Bots, verify token is shown once
- [ ] Copy token and use it to authenticate REST requests (`Authorization: Bearer uncrd_...`)
- [ ] Connect a bot via WebSocket using `token` in IDENTIFY payload
- [ ] Verify bot messages show [BOT] badge in chat
- [ ] Verify bot cannot create servers (403)
- [ ] Verify bot cannot send friend requests (403)
- [ ] Regenerate token — verify old token stops working and bot is disconnected
- [ ] Delete bot — verify it's removed and disconnected
- [ ] Verify tier limits: free=1, supporter=3, server_owner=5
- [ ] Verify unverified email users cannot create bots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, list, delete, and regenerate API bots from Settings; plaintext token shown once on create/regenerate.

* **Enhancements**
  * Bots represented on messages/members/ready payloads with an isBot flag and a “Bot” badge.
  * Bot tokens tracked (hashed + prefix) and last-used timestamps; websocket identify and API gateway support token auth.

* **Restrictions**
  * Bots cannot create servers, send friend requests, or manage bots via bot sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->