### PR TITLE
refactor: shared backend for dev preview — remove server-dev container

### DIFF
--- a/apps/server/src/auth/index.ts
+++ b/apps/server/src/auth/index.ts
@@ -20,7 +20,7 @@ export const auth = betterAuth({
   secret: env.BETTER_AUTH_SECRET,
   baseURL: env.BETTER_AUTH_URL,
   // APP_URL always has a value (see env.ts default), so this array is never empty
-  trustedOrigins: [env.APP_URL, env.CORS_ORIGIN, env.DEV_ORIGIN, `https://admin.${new URL(env.APP_URL).host}`].filter(Boolean) as string[],
+  trustedOrigins: [env.APP_URL, env.CORS_ORIGIN, env.DEV_ORIGIN, `https://admin.${new URL(env.APP_URL).host}`].filter((v): v is string => Boolean(v)),
   emailVerification: {
     sendOnSignUp: true,
     autoSignInAfterVerification: true,

--- a/apps/server/src/auth/index.ts
+++ b/apps/server/src/auth/index.ts
@@ -20,7 +20,7 @@ export const auth = betterAuth({
   secret: env.BETTER_AUTH_SECRET,
   baseURL: env.BETTER_AUTH_URL,
   // APP_URL always has a value (see env.ts default), so this array is never empty
-  trustedOrigins: [env.APP_URL, env.CORS_ORIGIN, `https://admin.${new URL(env.APP_URL).host}`].filter(Boolean) as string[],
+  trustedOrigins: [env.APP_URL, env.CORS_ORIGIN, env.DEV_ORIGIN, `https://admin.${new URL(env.APP_URL).host}`].filter(Boolean) as string[],
   emailVerification: {
     sendOnSignUp: true,
     autoSignInAfterVerification: true,

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -21,6 +21,7 @@ const envSchema = z.object({
     .transform((s) => (s === "" ? "http://localhost:3000" : s))
     .pipe(z.string().url()),
   CORS_ORIGIN: optionalUrl,
+  DEV_ORIGIN: optionalUrl,
 
   // Optional with defaults
   PORT: z.coerce.number().default(3000),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -33,7 +33,7 @@ import { applyChannelEvent, applyDmMemberEvent } from "./ws/channel-cache.js";
 const app = new Elysia()
   .use(
     cors({
-      origin: [env.CORS_ORIGIN ?? env.APP_URL, `https://admin.${new URL(env.APP_URL).host}`].filter(Boolean),
+      origin: [env.CORS_ORIGIN ?? env.APP_URL, env.DEV_ORIGIN, `https://admin.${new URL(env.APP_URL).host}`].filter((o): o is string => Boolean(o)),
       credentials: true,
     }),
   )


### PR DESCRIPTION
## Summary
- Add optional `DEV_ORIGIN` env var so the main server accepts CORS and auth requests from `dev.uncorded.app`
- Dev preview now shares the production backend — no more separate `server-dev` container
- Infrastructure changes (docker-compose.yml, nginx dev.conf, switch-dev.sh) applied directly on host

## Deploy checklist
- [ ] Add `DEV_ORIGIN=https://dev.uncorded.app` to production `.env`
- [ ] Apply docker-compose.yml / nginx / script changes on host (already done in `C:\Projects\UnCorded-Dev\`)
- [ ] `docker compose up -d server dev` to pick up changes

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (0 errors)
- [ ] `docker compose config` validates
- [ ] After deploy: dev.uncorded.app serves frontend, API calls hit main backend, login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development origin configuration so development/staging hosts can authenticate and communicate with the server.

* **Improvements**
  * Expanded allowed origins for CORS and authentication to include the new development origin.
  * Strengthened origin validation and type safety for more reliable and secure cross-environment operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->