### PR TITLE
feat: plugin UI integration — sidebar tabs, iframe content, postMessage bridge

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -172,6 +172,8 @@ function setupSidecarIpc(): void {
 // These handlers forward requests to the sidecar HTTP API
 // and broadcast state changes to all renderer windows.
 
+// Canonical definition: apps/web/src/stores/plugin-store.ts (PluginInfo)
+// Duplicated here because main process and renderer have separate build targets.
 interface PluginInfo {
   id: string;
   name: string;
@@ -215,7 +217,11 @@ function setupPluginIpc(): void {
   ipcMain.handle("plugins:start", async (_event, pluginId: string) => {
     const port = sidecar.getPort();
     if (!port) throw new Error("Sidecar not running");
-    await fetch(`http://localhost:${port}/plugins/${pluginId}/start`, { method: "POST" });
+    const res = await fetch(`http://localhost:${port}/plugins/${pluginId}/start`, { method: "POST" });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Plugin start failed (${res.status}): ${body}`);
+    }
     cachedPlugins = await fetchPluginsFromSidecar();
     broadcastPluginState();
   });
@@ -223,7 +229,11 @@ function setupPluginIpc(): void {
   ipcMain.handle("plugins:stop", async (_event, pluginId: string) => {
     const port = sidecar.getPort();
     if (!port) throw new Error("Sidecar not running");
-    await fetch(`http://localhost:${port}/plugins/${pluginId}/stop`, { method: "POST" });
+    const res = await fetch(`http://localhost:${port}/plugins/${pluginId}/stop`, { method: "POST" });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Plugin stop failed (${res.status}): ${body}`);
+    }
     cachedPlugins = await fetchPluginsFromSidecar();
     broadcastPluginState();
   });
@@ -231,7 +241,11 @@ function setupPluginIpc(): void {
   ipcMain.handle("plugins:restart", async (_event, pluginId: string) => {
     const port = sidecar.getPort();
     if (!port) throw new Error("Sidecar not running");
-    await fetch(`http://localhost:${port}/plugins/${pluginId}/restart`, { method: "POST" });
+    const res = await fetch(`http://localhost:${port}/plugins/${pluginId}/restart`, { method: "POST" });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Plugin restart failed (${res.status}): ${body}`);
+    }
     cachedPlugins = await fetchPluginsFromSidecar();
     broadcastPluginState();
   });
@@ -255,6 +269,12 @@ let pluginPollTimer: ReturnType<typeof setInterval> | null = null;
 function startPluginPolling(): void {
   if (pluginPollTimer) return;
   pluginPollTimer = setInterval(async () => {
+    if (isQuitting) {
+      stopPluginPolling();
+      return;
+    }
+    // JSON.stringify comparison is intentional — simple change detection
+    // until the sidecar supports a push/event mechanism for state updates.
     const prev = JSON.stringify(cachedPlugins);
     cachedPlugins = await fetchPluginsFromSidecar();
     if (JSON.stringify(cachedPlugins) !== prev) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -167,6 +167,109 @@ function setupSidecarIpc(): void {
   });
 }
 
+// --- IPC: Plugins ---
+// Plugin state is managed by the sidecar's Bridge Server.
+// These handlers forward requests to the sidecar HTTP API
+// and broadcast state changes to all renderer windows.
+
+interface PluginInfo {
+  id: string;
+  name: string;
+  icon: string | null;
+  uiSlot: "content" | "panel";
+  header: boolean;
+  rightPanel: boolean;
+  status: "running" | "stopped" | "crashed" | "starting";
+  port: number;
+  permissions: string[];
+}
+
+let cachedPlugins: PluginInfo[] = [];
+
+function broadcastPluginState(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send("plugins:state-change", cachedPlugins);
+    }
+  }
+}
+
+async function fetchPluginsFromSidecar(): Promise<PluginInfo[]> {
+  const port = sidecar.getPort();
+  if (!port) return [];
+  try {
+    const res = await fetch(`http://localhost:${port}/plugins`);
+    if (!res.ok) return [];
+    return (await res.json()) as PluginInfo[];
+  } catch {
+    return [];
+  }
+}
+
+function setupPluginIpc(): void {
+  ipcMain.handle("plugins:get-all", async () => {
+    cachedPlugins = await fetchPluginsFromSidecar();
+    return cachedPlugins;
+  });
+
+  ipcMain.handle("plugins:start", async (_event, pluginId: string) => {
+    const port = sidecar.getPort();
+    if (!port) throw new Error("Sidecar not running");
+    await fetch(`http://localhost:${port}/plugins/${pluginId}/start`, { method: "POST" });
+    cachedPlugins = await fetchPluginsFromSidecar();
+    broadcastPluginState();
+  });
+
+  ipcMain.handle("plugins:stop", async (_event, pluginId: string) => {
+    const port = sidecar.getPort();
+    if (!port) throw new Error("Sidecar not running");
+    await fetch(`http://localhost:${port}/plugins/${pluginId}/stop`, { method: "POST" });
+    cachedPlugins = await fetchPluginsFromSidecar();
+    broadcastPluginState();
+  });
+
+  ipcMain.handle("plugins:restart", async (_event, pluginId: string) => {
+    const port = sidecar.getPort();
+    if (!port) throw new Error("Sidecar not running");
+    await fetch(`http://localhost:${port}/plugins/${pluginId}/restart`, { method: "POST" });
+    cachedPlugins = await fetchPluginsFromSidecar();
+    broadcastPluginState();
+  });
+
+  ipcMain.handle("plugins:get-permissions", async (_event, pluginId: string) => {
+    const port = sidecar.getPort();
+    if (!port) return [];
+    try {
+      const res = await fetch(`http://localhost:${port}/plugins/${pluginId}/permissions`);
+      if (!res.ok) return [];
+      return (await res.json()) as string[];
+    } catch {
+      return [];
+    }
+  });
+}
+
+// Poll sidecar for plugin state changes (until we have a push mechanism)
+let pluginPollTimer: ReturnType<typeof setInterval> | null = null;
+
+function startPluginPolling(): void {
+  if (pluginPollTimer) return;
+  pluginPollTimer = setInterval(async () => {
+    const prev = JSON.stringify(cachedPlugins);
+    cachedPlugins = await fetchPluginsFromSidecar();
+    if (JSON.stringify(cachedPlugins) !== prev) {
+      broadcastPluginState();
+    }
+  }, 3000);
+}
+
+function stopPluginPolling(): void {
+  if (pluginPollTimer) {
+    clearInterval(pluginPollTimer);
+    pluginPollTimer = null;
+  }
+}
+
 // --- App lifecycle ---
 
 app.on("ready", async () => {
@@ -175,11 +278,13 @@ app.on("ready", async () => {
   tray = createTray();
 
   setupSidecarIpc();
+  setupPluginIpc();
   setupAutoUpdater();
   setupAutoUpdateIpc(() => sidecar.stop());
 
   // Spawn sidecar
   await sidecar.start();
+  startPluginPolling();
 });
 
 app.on("second-instance", () => {
@@ -211,6 +316,7 @@ app.on("before-quit", (e) => {
   e.preventDefault();
   isQuitting = true;
   setIsQuitting(true);
+  stopPluginPolling();
   tray?.destroy();
   tray = null;
   sidecar.stop().finally(() => {

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -18,6 +18,8 @@ interface SidecarStatus {
   port: number | null;
 }
 
+// Canonical definition: apps/web/src/stores/plugin-store.ts (PluginInfo)
+// Duplicated here because preload runs in a separate build context.
 interface PluginInfo {
   id: string;
   name: string;

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -18,6 +18,18 @@ interface SidecarStatus {
   port: number | null;
 }
 
+interface PluginInfo {
+  id: string;
+  name: string;
+  icon: string | null;
+  uiSlot: "content" | "panel";
+  header: boolean;
+  rightPanel: boolean;
+  status: "running" | "stopped" | "crashed" | "starting";
+  port: number;
+  permissions: string[];
+}
+
 interface UpdateResult {
   accepted: boolean;
   completed: boolean;
@@ -35,9 +47,29 @@ const desktopBridge = {
   getDockerStatus: (): Promise<{ available: boolean; bridgePort?: number }> =>
     ipcRenderer.invoke("docker:status"),
 
-  // --- Plugins (forwarded to sidecar via bridge) ---
-  // These will call the sidecar's Bridge Server once it's running
-  // For now they're stubs — real implementation comes when Bridge Server is wired
+  // --- Plugins ---
+  plugins: {
+    getAll: (): Promise<PluginInfo[]> =>
+      ipcRenderer.invoke("plugins:get-all"),
+
+    onStateChange: (listener: (plugins: PluginInfo[]) => void): (() => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, list: PluginInfo[]) => listener(list);
+      ipcRenderer.on("plugins:state-change", handler);
+      return () => ipcRenderer.removeListener("plugins:state-change", handler);
+    },
+
+    start: (pluginId: string): Promise<void> =>
+      ipcRenderer.invoke("plugins:start", pluginId),
+
+    stop: (pluginId: string): Promise<void> =>
+      ipcRenderer.invoke("plugins:stop", pluginId),
+
+    restart: (pluginId: string): Promise<void> =>
+      ipcRenderer.invoke("plugins:restart", pluginId),
+
+    getPermissions: (pluginId: string): Promise<string[]> =>
+      ipcRenderer.invoke("plugins:get-permissions", pluginId),
+  },
 
   // --- Auto-update ---
   getUpdateState: (): Promise<UpdateState> =>

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -29,6 +29,12 @@ import {
   joinSession,
   activeReceiverSessionId,
 } from "../stores/share-session-store.js";
+import { isDesktop, plugins } from "../stores/plugin-store.js";
+import {
+  setupPluginBridge,
+  teardownPluginBridge,
+  updateAllowedOrigins,
+} from "../lib/plugin-bridge.js";
 import FileReceiveModal from "./modals/FileReceiveModal.js";
 
 const AppLayout: ParentComponent = (props) => {
@@ -38,6 +44,20 @@ const AppLayout: ParentComponent = (props) => {
     const s = session();
     if (s.data?.session && gatewayStatus() === "disconnected") {
       connectGateway();
+    }
+  });
+
+  // Plugin bridge — only active in desktop app
+  onMount(() => {
+    if (isDesktop()) {
+      setupPluginBridge();
+    }
+  });
+
+  // Keep origin allowlist in sync with running plugins
+  createEffect(() => {
+    if (isDesktop()) {
+      updateAllowedOrigins(plugins());
     }
   });
 
@@ -76,6 +96,7 @@ const AppLayout: ParentComponent = (props) => {
   onCleanup(() => {
     disconnectGateway();
     cleanupShortcuts();
+    teardownPluginBridge();
   });
 
   // Show persistent toast for incoming file share invites

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -36,6 +36,13 @@ import ShareFileModal from "./modals/ShareFileModal.js";
 import AddFriendModal from "./modals/AddFriendModal.js";
 import CommandPalette from "./CommandPalette.js";
 import { commandPaletteOpen, setCommandPaletteOpen } from "../stores/command-palette-store.js";
+import {
+  isDesktop,
+  visiblePlugins,
+  activePluginId,
+  setActivePluginId,
+  clearActivePlugin,
+} from "../stores/plugin-store.js";
 import SupportSheet from "./SupportSheet.js";
 import { showToast } from "./ui/toast.js";
 
@@ -383,6 +390,7 @@ const AppSidebar = () => {
                           tooltip={`# ${channel.name}`}
                           active={active()}
                           onClick={() => {
+                            clearActivePlugin();
                             setSelectedChannelId(channel.id);
                             const sId = selectedServerId();
                             if (sId) navigate(`/servers/${sId}`);
@@ -425,6 +433,59 @@ const AppSidebar = () => {
             </Show>
           </Show>
         </SidebarGroup>
+
+        {/* Plugins — desktop only */}
+        <Show when={isDesktop() && visiblePlugins().length > 0}>
+          <SidebarGroup label="Plugins" collapsible defaultOpen>
+            <SidebarMenu classList={{ hidden: sidebarState() === "collapsed" }}>
+              <For each={visiblePlugins()}>
+                {(plugin) => {
+                  const isPluginActive = () => activePluginId() === plugin.id;
+                  const statusColor = (): string => {
+                    switch (plugin.status) {
+                      case "running": return "bg-success";
+                      case "starting": return "bg-warning";
+                      case "crashed": return "bg-destructive";
+                      default: return "bg-muted-foreground";
+                    }
+                  };
+                  return (
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        tooltip={plugin.name}
+                        active={isPluginActive()}
+                        onClick={() => {
+                          setActivePluginId(plugin.id);
+                          const sId = selectedServerId();
+                          if (sId) navigate(`/servers/${sId}`);
+                          closeMobile();
+                        }}
+                      >
+                        <span class="relative flex h-4 w-4 shrink-0 items-center justify-center">
+                          <Show
+                            when={plugin.icon}
+                            fallback={
+                              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5" />
+                              </svg>
+                            }
+                          >
+                            <span class="text-sm">{plugin.icon}</span>
+                          </Show>
+                          <span
+                            class={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ${statusColor()}`}
+                            title={plugin.status}
+                          />
+                        </span>
+                        <span class="truncate">{plugin.name}</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                }}
+              </For>
+            </SidebarMenu>
+          </SidebarGroup>
+        </Show>
 
         {/* Bottom nav — pushed to bottom */}
         <SidebarGroup class="mt-auto">

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -474,8 +474,10 @@ const AppSidebar = () => {
                           </Show>
                           <span
                             class={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ${statusColor()}`}
+                            aria-hidden="true"
                             title={plugin.status}
                           />
+                          <span class="sr-only">Status: {plugin.status}</span>
                         </span>
                         <span class="truncate">{plugin.name}</span>
                       </SidebarMenuButton>

--- a/apps/web/src/components/PluginFrame.tsx
+++ b/apps/web/src/components/PluginFrame.tsx
@@ -1,0 +1,104 @@
+import { createSignal, Show, onMount } from "solid-js";
+import type { PluginInfo } from "../stores/plugin-store.js";
+import { isDesktop } from "../stores/plugin-store.js";
+import { Empty } from "./ui/empty.js";
+
+interface PluginFrameProps {
+  plugin: PluginInfo;
+}
+
+const PluginFrame = (props: PluginFrameProps) => {
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal(false);
+
+  const isCrashed = () =>
+    props.plugin.status === "crashed" || props.plugin.status === "stopped";
+
+  const isStarting = () => props.plugin.status === "starting";
+
+  const handleLoad = () => {
+    setLoading(false);
+    setError(false);
+  };
+
+  const handleError = () => {
+    setLoading(false);
+    setError(true);
+  };
+
+  const handleRestart = () => {
+    if (!isDesktop()) return;
+    window.desktopBridge.plugins.restart(props.plugin.id).catch((err) => {
+      if (import.meta.env.DEV) console.error("[PluginFrame] restart failed:", err);
+    });
+  };
+
+  onMount(() => {
+    // Fallback timeout — if iframe doesn't fire load within 15s, show error
+    const timeout = setTimeout(() => {
+      if (loading()) {
+        setLoading(false);
+        setError(true);
+      }
+    }, 15_000);
+
+    return () => clearTimeout(timeout);
+  });
+
+  return (
+    <div class="relative flex h-full w-full flex-col">
+      {/* Error / crashed state */}
+      <Show when={isCrashed() || error()}>
+        <Empty
+          title={`Plugin ${isCrashed() ? props.plugin.status : "failed to load"}`}
+          description={`"${props.plugin.name}" is not responding.`}
+        >
+          <button
+            type="button"
+            onClick={handleRestart}
+            class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            Restart Plugin
+          </button>
+        </Empty>
+      </Show>
+
+      {/* Starting state */}
+      <Show when={isStarting() && !error()}>
+        <div class="flex flex-1 items-center justify-center">
+          <div class="flex animate-fade-in flex-col items-center gap-3">
+            <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <p class="text-muted-foreground">Starting {props.plugin.name}...</p>
+          </div>
+        </div>
+      </Show>
+
+      {/* Loading overlay */}
+      <Show when={loading() && props.plugin.status === "running"}>
+        <div class="absolute inset-0 z-10 flex items-center justify-center bg-background">
+          <div class="flex animate-fade-in flex-col items-center gap-3">
+            <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <p class="text-muted-foreground">Loading {props.plugin.name}...</p>
+          </div>
+        </div>
+      </Show>
+
+      {/* iframe — only render when plugin is running */}
+      <Show when={props.plugin.status === "running" && !error()}>
+        <iframe
+          src={`http://localhost:${props.plugin.port}/`}
+          sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
+          allow="clipboard-write"
+          referrerpolicy="no-referrer"
+          class="h-full w-full border-none"
+          data-plugin-id={props.plugin.id}
+          onLoad={handleLoad}
+          onError={handleError}
+          title={props.plugin.name}
+        />
+      </Show>
+    </div>
+  );
+};
+
+export default PluginFrame;

--- a/apps/web/src/components/PluginFrame.tsx
+++ b/apps/web/src/components/PluginFrame.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show, onMount } from "solid-js";
+import { createSignal, createEffect, on, Show, onMount } from "solid-js";
 import type { PluginInfo } from "../stores/plugin-store.js";
 import { isDesktop } from "../stores/plugin-store.js";
 import { Empty } from "./ui/empty.js";
@@ -10,6 +10,12 @@ interface PluginFrameProps {
 const PluginFrame = (props: PluginFrameProps) => {
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal(false);
+
+  // Reset state when switching to a different plugin
+  createEffect(on(() => props.plugin.id, () => {
+    setLoading(true);
+    setError(false);
+  }, { defer: true }));
 
   const isCrashed = () =>
     props.plugin.status === "crashed" || props.plugin.status === "stopped";
@@ -28,7 +34,7 @@ const PluginFrame = (props: PluginFrameProps) => {
 
   const handleRestart = () => {
     if (!isDesktop()) return;
-    window.desktopBridge.plugins.restart(props.plugin.id).catch((err) => {
+    window.desktopBridge!.plugins.restart(props.plugin.id).catch((err: unknown) => {
       if (import.meta.env.DEV) console.error("[PluginFrame] restart failed:", err);
     });
   };

--- a/apps/web/src/lib/plugin-bridge.ts
+++ b/apps/web/src/lib/plugin-bridge.ts
@@ -124,6 +124,15 @@ const handlers: Record<string, HandlerFn> = {
     if (!channelId || !content) {
       throw { code: "BAD_REQUEST", message: "channelId and content are required" };
     }
+    // Verify the channel belongs to the current server
+    const serverId = selectedServerId();
+    if (!serverId) {
+      throw { code: "BAD_REQUEST", message: "No server selected" };
+    }
+    const channels = channelCache[serverId];
+    if (!channels?.some((c) => c.id === channelId)) {
+      throw { code: "BAD_REQUEST", message: "Channel not found in current server" };
+    }
     await api(`/api/channels/${channelId}/messages`, {
       method: "POST",
       body: JSON.stringify({ content }),
@@ -145,14 +154,22 @@ const handlers: Record<string, HandlerFn> = {
     const to = params.to as string | undefined;
     const channelId = params.channelId as string | undefined;
     if (to === "channel" && channelId) {
-      // Navigation is handled by pushing to the router — we use a dynamic import
-      // to avoid circular deps. The sidebar already updates selectedChannelId.
+      // Validate that the channel exists in the current server
+      const serverId = selectedServerId();
+      if (!serverId) {
+        return { navigated: false };
+      }
+      const channels = channelCache[serverId];
+      if (!channels?.some((c) => c.id === (channelId as ChannelId))) {
+        return { navigated: false };
+      }
       const { setSelectedChannelId } = await import("../stores/app-store.js");
       const { clearActivePlugin } = await import("../stores/plugin-store.js");
       clearActivePlugin();
       setSelectedChannelId(channelId as ChannelId);
+      return { navigated: true };
     }
-    return { navigated: true };
+    return { navigated: false };
   },
 };
 

--- a/apps/web/src/lib/plugin-bridge.ts
+++ b/apps/web/src/lib/plugin-bridge.ts
@@ -1,0 +1,263 @@
+/**
+ * postMessage bridge — UnCorded shell side.
+ *
+ * Receives requests from plugin iframes, validates origin + permissions,
+ * dispatches handlers, and pushes gateway events to subscribed plugins.
+ */
+
+import type { ChannelId } from "@uncorded/protocol";
+import { readyData, channelCache } from "./gateway-store.js";
+import { api } from "./api.js";
+import {
+  plugins,
+  type PluginInfo,
+} from "../stores/plugin-store.js";
+import { selectedServerId } from "../stores/app-store.js";
+import { showToast } from "../components/ui/toast.js";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface PluginRequest {
+  type: "uncorded:request";
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface PluginResponse {
+  type: "uncorded:response";
+  id: string;
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+interface PluginEvent {
+  type: "uncorded:event";
+  event: string;
+  data: unknown;
+}
+
+// ── Origin allowlist ───────────────────────────────────────────────────────
+
+const allowedOrigins = new Map<string, string>(); // origin → pluginId
+
+export function updateAllowedOrigins(list: PluginInfo[]): void {
+  allowedOrigins.clear();
+  for (const p of list) {
+    if (p.status === "running") {
+      allowedOrigins.set(`http://localhost:${p.port}`, p.id);
+    }
+  }
+}
+
+// ── Permission checking ────────────────────────────────────────────────────
+
+const METHOD_PERMISSIONS: Record<string, string | null> = {
+  getUser: null,
+  getServer: null,
+  getChannels: null,
+  getMembers: "users:read",
+  getPresence: "presence:read",
+  sendMessage: "chat:write",
+  showToast: "ui:notifications",
+  navigate: "ui:navigate",
+};
+
+function checkPermission(pluginId: string, method: string): boolean {
+  const required = METHOD_PERMISSIONS[method];
+  if (required === null) return true;
+  if (required === undefined) return false; // unknown method → deny
+  const plugin = plugins().find((p) => p.id === pluginId);
+  return plugin?.permissions?.includes(required) ?? false;
+}
+
+// ── Request handlers ───────────────────────────────────────────────────────
+
+type HandlerFn = (pluginId: string, params: Record<string, unknown>) => Promise<unknown>;
+
+const handlers: Record<string, HandlerFn> = {
+  async getUser() {
+    const u = readyData.data?.user;
+    if (!u) return null;
+    return { id: u.id, username: u.username, displayName: u.displayName, avatarUrl: u.avatarUrl };
+  },
+
+  async getServer() {
+    const serverId = selectedServerId();
+    if (!serverId) return null;
+    const s = readyData.data?.servers.find((sv) => sv.id === serverId);
+    if (!s) return null;
+    return { id: s.id, name: s.name, iconUrl: s.iconUrl, ownerId: s.ownerId };
+  },
+
+  async getChannels() {
+    const serverId = selectedServerId();
+    if (!serverId) return [];
+    const cached = channelCache[serverId];
+    if (!cached) return [];
+    return cached.map((c) => ({
+      id: c.id,
+      name: c.name,
+      type: c.type,
+      position: c.position,
+      topic: c.topic,
+    }));
+  },
+
+  async getMembers() {
+    const serverId = selectedServerId();
+    if (!serverId) return [];
+    const members = await api<unknown[]>(`/api/servers/${serverId}/members`);
+    return members;
+  },
+
+  async getPresence() {
+    const serverId = selectedServerId();
+    if (!serverId) return [];
+    const presence = await api<unknown[]>(`/api/servers/${serverId}/presence`);
+    return presence;
+  },
+
+  async sendMessage(_pluginId, params) {
+    const channelId = params.channelId as ChannelId | undefined;
+    const content = params.content as string | undefined;
+    if (!channelId || !content) {
+      throw { code: "BAD_REQUEST", message: "channelId and content are required" };
+    }
+    await api(`/api/channels/${channelId}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ content }),
+    });
+    return { sent: true };
+  },
+
+  async showToast(_pluginId, params) {
+    const message = params.message as string | undefined;
+    const toastType = (params.type as "info" | "error") ?? "info";
+    if (!message) {
+      throw { code: "BAD_REQUEST", message: "message is required" };
+    }
+    showToast(message, toastType);
+    return { shown: true };
+  },
+
+  async navigate(_pluginId, params) {
+    const to = params.to as string | undefined;
+    const channelId = params.channelId as string | undefined;
+    if (to === "channel" && channelId) {
+      // Navigation is handled by pushing to the router — we use a dynamic import
+      // to avoid circular deps. The sidebar already updates selectedChannelId.
+      const { setSelectedChannelId } = await import("../stores/app-store.js");
+      const { clearActivePlugin } = await import("../stores/plugin-store.js");
+      clearActivePlugin();
+      setSelectedChannelId(channelId as ChannelId);
+    }
+    return { navigated: true };
+  },
+};
+
+// ── Message listener ───────────────────────────────────────────────────────
+
+function sendResponse(source: MessageEventSource, origin: string, response: PluginResponse): void {
+  (source as WindowProxy).postMessage(response, origin);
+}
+
+async function handleMessage(event: MessageEvent): Promise<void> {
+  const pluginId = allowedOrigins.get(event.origin);
+  if (!pluginId) return; // unknown origin — silently ignore
+
+  const data = event.data as PluginRequest | undefined;
+  if (!data || data.type !== "uncorded:request" || !data.id || !data.method) return;
+
+  const source = event.source;
+  if (!source) return;
+
+  // Permission check
+  if (!checkPermission(pluginId, data.method)) {
+    const required = METHOD_PERMISSIONS[data.method];
+    sendResponse(source, event.origin, {
+      type: "uncorded:response",
+      id: data.id,
+      error: {
+        code: "FORBIDDEN",
+        message: `Missing permission: ${required ?? data.method}`,
+      },
+    });
+    return;
+  }
+
+  // Dispatch to handler
+  const handler = handlers[data.method];
+  if (!handler) {
+    sendResponse(source, event.origin, {
+      type: "uncorded:response",
+      id: data.id,
+      error: { code: "UNKNOWN_METHOD", message: `Unknown method: ${data.method}` },
+    });
+    return;
+  }
+
+  try {
+    const result = await handler(pluginId, data.params ?? {});
+    sendResponse(source, event.origin, {
+      type: "uncorded:response",
+      id: data.id,
+      result,
+    });
+  } catch (err) {
+    const typed = err as { code?: string; message?: string };
+    sendResponse(source, event.origin, {
+      type: "uncorded:response",
+      id: data.id,
+      error: {
+        code: typed.code ?? "INTERNAL_ERROR",
+        message: typed.message ?? "An unexpected error occurred",
+      },
+    });
+  }
+}
+
+// ── Event broadcasting ─────────────────────────────────────────────────────
+
+/**
+ * Push a gateway event to all running plugin iframes that hold the required permission.
+ * Call this from gateway event handlers (message-store, presence-store, etc.).
+ */
+export function broadcastToPlugins(eventName: string, data: unknown, requiredPermission: string | null): void {
+  const iframes = document.querySelectorAll<HTMLIFrameElement>("iframe[data-plugin-id]");
+
+  for (const iframe of iframes) {
+    const pid = iframe.dataset.pluginId;
+    if (!pid) continue;
+
+    const plugin = plugins().find((p) => p.id === pid);
+    if (!plugin || plugin.status !== "running") continue;
+
+    if (requiredPermission && !plugin.permissions.includes(requiredPermission)) continue;
+
+    const origin = `http://localhost:${plugin.port}`;
+    const msg: PluginEvent = { type: "uncorded:event", event: eventName, data };
+    iframe.contentWindow?.postMessage(msg, origin);
+  }
+}
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+let listening = false;
+
+export function setupPluginBridge(): void {
+  if (listening) return;
+  listening = true;
+  window.addEventListener("message", handleMessage);
+}
+
+export function teardownPluginBridge(): void {
+  if (!listening) return;
+  listening = false;
+  window.removeEventListener("message", handleMessage);
+  allowedOrigins.clear();
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => teardownPluginBridge());
+}

--- a/apps/web/src/pages/ServerView.tsx
+++ b/apps/web/src/pages/ServerView.tsx
@@ -1,4 +1,4 @@
-import { createEffect, Show } from "solid-js";
+import { createEffect, lazy, Show } from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
 import type { ServerId } from "@uncorded/protocol";
 import { readyData, channelCache, channelCacheLoading } from "../lib/gateway-store.js";
@@ -8,9 +8,12 @@ import {
   selectedChannelId,
   setSelectedChannelId,
 } from "../stores/app-store.js";
+import { activePlugin } from "../stores/plugin-store.js";
 import ChatArea from "../components/ChatArea.js";
 import { Empty } from "../components/ui/empty.js";
 import ContentHeader from "../components/ContentHeader.js";
+
+const PluginFrame = lazy(() => import("../components/PluginFrame.js"));
 
 const ServerView = () => {
   const params = useParams<{ serverId: string }>();
@@ -58,50 +61,60 @@ const ServerView = () => {
 
   return (
     <div class="flex h-full flex-col">
-      <ContentHeader
-        title={serverName()}
-        breadcrumbs={[{ label: "Servers" }]}
-      />
+      {/* Plugin takes over the entire content area when active */}
       <Show
-        when={hasServer() && hasValidChannel()}
+        when={activePlugin()}
         fallback={
-          <Show
-            when={hasServer()}
-            fallback={
-              <Empty
-                title="Server not found"
-                description="You may not be a member of this server."
-              >
-                <button
-                  type="button"
-                  onClick={() => navigate("/home")}
-                  class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-                >
-                  &larr; Back to Home
-                </button>
-              </Empty>
-            }
-          >
+          <>
+            <ContentHeader
+              title={serverName()}
+              breadcrumbs={[{ label: "Servers" }]}
+            />
             <Show
-              when={!isLoadingChannels()}
+              when={hasServer() && hasValidChannel()}
               fallback={
-                <div class="flex flex-1 items-center justify-center">
-                  <div class="flex animate-fade-in flex-col items-center gap-3">
-                    <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-                    <p class="text-muted-foreground">Loading channels...</p>
-                  </div>
-                </div>
+                <Show
+                  when={hasServer()}
+                  fallback={
+                    <Empty
+                      title="Server not found"
+                      description="You may not be a member of this server."
+                    >
+                      <button
+                        type="button"
+                        onClick={() => navigate("/home")}
+                        class="mt-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+                      >
+                        &larr; Back to Home
+                      </button>
+                    </Empty>
+                  }
+                >
+                  <Show
+                    when={!isLoadingChannels()}
+                    fallback={
+                      <div class="flex flex-1 items-center justify-center">
+                        <div class="flex animate-fade-in flex-col items-center gap-3">
+                          <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                          <p class="text-muted-foreground">Loading channels...</p>
+                        </div>
+                      </div>
+                    }
+                  >
+                    <Empty
+                      title="No channels"
+                      description="This server has no channels yet."
+                    />
+                  </Show>
+                </Show>
               }
             >
-              <Empty
-                title="No channels"
-                description="This server has no channels yet."
-              />
+              <ChatArea />
             </Show>
-          </Show>
+          </>
         }
       >
-        <ChatArea />
+        {(plugin) => <PluginFrame plugin={plugin()} />}
       </Show>
     </div>
   );

--- a/apps/web/src/stores/index.ts
+++ b/apps/web/src/stores/index.ts
@@ -8,6 +8,7 @@ import { setupNotificationStore } from "./notification-store.js";
 import { setupGiftStore } from "./gift-store.js";
 import { setupDeletionStore } from "./deletion-store.js";
 import { setupShareSessionStore } from "./share-session-store.js";
+import { setupPluginStore } from "./plugin-store.js";
 
 export {
   setupMessageStore,
@@ -20,6 +21,7 @@ export {
   setupGiftStore,
   setupDeletionStore,
   setupShareSessionStore,
+  setupPluginStore,
 };
 
 export function setupStores() {
@@ -33,4 +35,5 @@ export function setupStores() {
   setupGiftStore();
   setupDeletionStore();
   setupShareSessionStore();
+  setupPluginStore();
 }

--- a/apps/web/src/stores/plugin-store.ts
+++ b/apps/web/src/stores/plugin-store.ts
@@ -53,15 +53,15 @@ export function setupPluginStore(): void {
 
   disposeRoot = createRoot((dispose) => {
     // Fetch initial plugin list
-    window.desktopBridge.plugins
+    window.desktopBridge!.plugins
       .getAll()
       .then((list) => setPlugins(list))
-      .catch((err) => {
+      .catch((err: unknown) => {
         if (import.meta.env.DEV) console.error("[plugin-store] getAll failed:", err);
       });
 
     // Subscribe to state changes from main process
-    unsubStateChange = window.desktopBridge.plugins.onStateChange((list) => {
+    unsubStateChange = window.desktopBridge!.plugins.onStateChange((list) => {
       setPlugins(list);
 
       // If the active plugin was removed or stopped, clear selection

--- a/apps/web/src/stores/plugin-store.ts
+++ b/apps/web/src/stores/plugin-store.ts
@@ -1,0 +1,95 @@
+import { createSignal, createRoot } from "solid-js";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface PluginInfo {
+  id: string;
+  name: string;
+  icon: string | null;
+  uiSlot: "content" | "panel";
+  header: boolean;
+  rightPanel: boolean;
+  status: "running" | "stopped" | "crashed" | "starting";
+  port: number;
+  permissions: string[];
+}
+
+// ── Desktop detection ──────────────────────────────────────────────────────
+
+export const isDesktop = () =>
+  typeof window !== "undefined" && "desktopBridge" in window;
+
+// ── Signals ────────────────────────────────────────────────────────────────
+
+const [plugins, setPlugins] = createSignal<PluginInfo[]>([]);
+const [activePluginId, setActivePluginId] = createSignal<string | null>(null);
+
+const activePlugin = () => plugins().find((p) => p.id === activePluginId()) ?? null;
+
+/** Plugins visible in the sidebar (running or starting). */
+const visiblePlugins = () =>
+  plugins().filter((p) => p.status === "running" || p.status === "starting");
+
+function clearActivePlugin() {
+  setActivePluginId(null);
+}
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+let unsubStateChange: (() => void) | null = null;
+let disposeRoot: (() => void) | null = null;
+
+function teardown() {
+  unsubStateChange?.();
+  unsubStateChange = null;
+  disposeRoot?.();
+  disposeRoot = null;
+}
+
+export function setupPluginStore(): void {
+  teardown();
+
+  if (!isDesktop()) return; // No plugin UI in browser
+
+  disposeRoot = createRoot((dispose) => {
+    // Fetch initial plugin list
+    window.desktopBridge.plugins
+      .getAll()
+      .then((list) => setPlugins(list))
+      .catch((err) => {
+        if (import.meta.env.DEV) console.error("[plugin-store] getAll failed:", err);
+      });
+
+    // Subscribe to state changes from main process
+    unsubStateChange = window.desktopBridge.plugins.onStateChange((list) => {
+      setPlugins(list);
+
+      // If the active plugin was removed or stopped, clear selection
+      const active = activePluginId();
+      if (active) {
+        const match = list.find((p) => p.id === active);
+        if (!match || match.status === "stopped") {
+          setActivePluginId(null);
+        }
+      }
+    });
+
+    return dispose;
+  });
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => teardown());
+}
+
+// ── Exports ────────────────────────────────────────────────────────────────
+
+export {
+  plugins,
+  setPlugins,
+  activePluginId,
+  setActivePluginId,
+  activePlugin,
+  visiblePlugins,
+  clearActivePlugin,
+};

--- a/apps/web/src/types/desktop-bridge.d.ts
+++ b/apps/web/src/types/desktop-bridge.d.ts
@@ -1,0 +1,30 @@
+import type { PluginInfo } from "../stores/plugin-store.js";
+
+interface DesktopBridgePlugins {
+  getAll(): Promise<PluginInfo[]>;
+  onStateChange(listener: (plugins: PluginInfo[]) => void): () => void;
+  start(pluginId: string): Promise<void>;
+  stop(pluginId: string): Promise<void>;
+  restart(pluginId: string): Promise<void>;
+  getPermissions(pluginId: string): Promise<string[]>;
+}
+
+interface DesktopBridge {
+  getSidecarStatus(): Promise<{ running: boolean; port: number | null }>;
+  getSidecarPort(): Promise<number | null>;
+  getDockerStatus(): Promise<{ available: boolean; bridgePort?: number }>;
+  plugins: DesktopBridgePlugins;
+  getUpdateState(): Promise<unknown>;
+  checkForUpdates(): Promise<unknown>;
+  downloadUpdate(): Promise<unknown>;
+  installUpdate(): Promise<unknown>;
+  onUpdateState(listener: (state: unknown) => void): () => void;
+  onSidecarReady(listener: (port: number) => void): () => void;
+  onSidecarError(listener: (error: string) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    desktopBridge: DesktopBridge;
+  }
+}

--- a/apps/web/src/types/desktop-bridge.d.ts
+++ b/apps/web/src/types/desktop-bridge.d.ts
@@ -25,6 +25,8 @@ interface DesktopBridge {
 
 declare global {
   interface Window {
-    desktopBridge: DesktopBridge;
+    desktopBridge?: DesktopBridge;
   }
 }
+
+export {};


### PR DESCRIPTION
## Summary

- **Plugin store** (`plugin-store.ts`) — SolidJS signals for plugin state, `isDesktop()` detection, preload bridge subscription with HMR teardown
- **Sidebar plugin tabs** — dynamic "Plugins" section below channels (desktop only) with status indicators (green=running, yellow=starting, red=crashed), click-to-activate; channel clicks clear active plugin
- **Content area switching** — `ServerView` swaps between `ChatArea` and lazy-loaded `PluginFrame` based on active plugin selection
- **PluginFrame component** — sandboxed iframe (`allow-scripts allow-forms allow-popups allow-same-origin`) with loading spinner, error/crashed state, and restart button
- **postMessage bridge** (`plugin-bridge.ts`) — dynamic origin allowlist, 8 request handlers (`getUser`, `getServer`, `getChannels`, `getMembers`, `getPresence`, `sendMessage`, `showToast`, `navigate`), fail-closed permission enforcement, event broadcasting
- **Preload bridge extensions** — `plugins` namespace with `getAll`, `onStateChange`, `start`, `stop`, `restart`, `getPermissions` IPC channels
- **Main process IPC** — plugin handlers forwarding to sidecar HTTP API, 3s polling for state changes with broadcast to renderer windows
- **Type safety** — `desktop-bridge.d.ts` for Window type augmentation in web app; zero typecheck errors

Browser users see no changes — all plugin UI is gated behind `isDesktop()`.

## Test plan

- [ ] Desktop app shows "Plugins" section in sidebar when plugins are installed
- [ ] Clicking a plugin tab swaps content area to plugin iframe
- [ ] Clicking a channel switches back to chat
- [ ] Plugin iframe loads and renders the plugin's frontend
- [ ] postMessage `getUser` returns current user info
- [ ] postMessage `sendMessage` with `chat:write` permission succeeds
- [ ] postMessage `sendMessage` without `chat:write` permission returns FORBIDDEN
- [ ] postMessage from unknown origin is silently ignored
- [ ] Plugin crash shows error state with restart button
- [ ] Browser (non-desktop) shows no plugin UI at all
- [ ] Existing chat functionality works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added plugin system support to the desktop app. Users can now view installed plugins in the sidebar with real-time status indicators (running, stopped, crashed, or starting).
  * Implemented plugin management controls enabling users to start, stop, and restart plugins.
  * Added dedicated plugin view frame for displaying plugin content within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->