### PR TITLE
fix: end-to-end integration fixes — CJS paths, Docker Windows, plugin endpoints, preload bundling

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,0 +1,1 @@
+test-plugin/

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "dist-electron/main/index.js",
+  "main": "dist-electron/main/index.cjs",
   "scripts": {
     "dev": "bun run scripts/dev.ts",
-    "build:main": "tsdown src/main/index.ts src/main/preload.ts --out-dir dist-electron/main --format cjs --external electron",
+    "build:main": "tsdown src/main/index.ts --out-dir dist-electron/main --format cjs --external electron && tsdown src/main/preload.ts --out-dir dist-electron/main --format cjs --external electron",
     "build:sidecar": "bun build sidecar/index.ts --outdir dist-electron/sidecar --target bun",
     "build": "bun run build:main && bun run build:sidecar",
     "typecheck": "tsc --noEmit",

--- a/apps/desktop/scripts/dev.ts
+++ b/apps/desktop/scripts/dev.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dir, "..");
 const DIST = path.join(ROOT, "dist-electron", "main");
-const MAIN_JS = path.join(DIST, "index.js");
+const MAIN_JS = path.join(DIST, "index.cjs");
 
 let electronProcess: ChildProcess | null = null;
 let restartTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -27,6 +27,25 @@ function buildMain(): ChildProcess {
     [
       "tsdown",
       "src/main/index.ts",
+      "--out-dir", "dist-electron/main",
+      "--format", "cjs",
+      "--external", "electron",
+      "--watch",
+    ],
+    {
+      cwd: ROOT,
+      stdio: "inherit",
+      shell: true,
+    },
+  );
+}
+
+function buildPreload(): ChildProcess {
+  console.log("[dev] Building preload script...");
+  return spawn(
+    "bunx",
+    [
+      "tsdown",
       "src/main/preload.ts",
       "--out-dir", "dist-electron/main",
       "--format", "cjs",
@@ -55,6 +74,11 @@ function startElectron(): void {
 function spawnElectron(): void {
 
   console.log("[dev] Starting Electron...");
+  // Default to live URL unless UNCORDED_LOCAL=1 is set (for local web dev)
+  const useLocal = process.env["UNCORDED_LOCAL"] === "1";
+  const webUrl = useLocal ? "http://localhost:5173" : "https://uncorded.app";
+  console.log(`[dev] Loading web app from: ${webUrl}`);
+
   electronProcess = spawn(
     "bunx",
     ["electron", "."],
@@ -64,6 +88,7 @@ function spawnElectron(): void {
       env: {
         ...process.env,
         NODE_ENV: "development",
+        UNCORDED_WEB_URL: webUrl,
       },
       shell: true,
     },
@@ -87,8 +112,9 @@ function debounceRestart(): void {
   }, 500);
 }
 
-// Start build in watch mode
-const builder = buildMain();
+// Start both builds in watch mode
+const mainBuilder = buildMain();
+const preloadBuilder = buildPreload();
 
 // Wait for initial build, then start Electron
 const waitForBuild = setInterval(() => {
@@ -98,7 +124,7 @@ const waitForBuild = setInterval(() => {
 
     // Watch for rebuilds and restart Electron
     watch(DIST, { recursive: true }, (_event, filename) => {
-      if (filename?.endsWith(".js")) {
+      if (filename?.endsWith(".cjs") || filename?.endsWith(".js")) {
         debounceRestart();
       }
     });
@@ -106,14 +132,12 @@ const waitForBuild = setInterval(() => {
 }, 500);
 
 // Clean up on exit
-process.on("SIGINT", () => {
-  builder.kill();
+function cleanup() {
+  mainBuilder.kill();
+  preloadBuilder.kill();
   electronProcess?.kill();
   process.exit(0);
-});
+}
 
-process.on("SIGTERM", () => {
-  builder.kill();
-  electronProcess?.kill();
-  process.exit(0);
-});
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -28,6 +28,64 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     // Health check (unauthenticated)
     .get("/health", () => ({ status: "ok", timestamp: new Date().toISOString() }))
 
+    // --- Plugin management (called by Electron main process, no auth) ---
+    .get("/plugins", () => {
+      return options.plugins.list().map((p) => ({
+        id: p.pluginId,
+        name: p.manifest.name,
+        icon: p.manifest.icon ?? null,
+        uiSlot: p.manifest.ui?.type ?? "content",
+        header: false,
+        rightPanel: false,
+        status: p.state === "installed" ? "stopped" : p.state,
+        port: p.hostPort ?? 0,
+        permissions: p.manifest.permissions,
+      }));
+    })
+
+    .post("/plugins/install", async ({ body }) => {
+      const { manifest, serverId } = body as { manifest: unknown; serverId?: string };
+      const result = await options.plugins.install(manifest, serverId ?? "local");
+      if (result.errors && result.errors.length > 0) {
+        throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return { pluginId: result.pluginId, installed: true };
+    })
+
+    .post("/plugins/:id/start", async ({ params }) => {
+      await options.plugins.start(params.id);
+      return { pluginId: params.id, started: true };
+    })
+
+    .post("/plugins/:id/stop", async ({ params }) => {
+      await options.plugins.stop(params.id);
+      return { pluginId: params.id, stopped: true };
+    })
+
+    .post("/plugins/:id/restart", async ({ params }) => {
+      await options.plugins.restart(params.id);
+      return { pluginId: params.id, restarted: true };
+    })
+
+    .get("/plugins/:id/permissions", ({ params }) => {
+      const plugin = options.plugins.get(params.id);
+      if (!plugin) {
+        throw new Response(JSON.stringify({ error: "Plugin not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return plugin.manifest.permissions;
+    })
+
+    .post("/plugins/:id/uninstall", async ({ params }) => {
+      await options.plugins.uninstall(params.id);
+      return { pluginId: params.id, uninstalled: true };
+    })
+
     // Auth + permissions middleware for /bridge/* routes
     .derive(({ request, path }) => {
       // Skip auth for non-bridge routes

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -44,8 +44,15 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     })
 
     .post("/plugins/install", async ({ body }) => {
-      const { manifest, serverId } = body as { manifest: unknown; serverId?: string };
-      const result = await options.plugins.install(manifest, serverId ?? "local");
+      const parsed = body as Record<string, unknown> | null;
+      if (!parsed || typeof parsed !== "object" || !("manifest" in parsed) || parsed.manifest == null) {
+        throw new Response(JSON.stringify({ error: "Request body must include a 'manifest' object" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const serverId = typeof parsed.serverId === "string" ? parsed.serverId : "local";
+      const result = await options.plugins.install(parsed.manifest, serverId);
       if (result.errors && result.errors.length > 0) {
         throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
           status: 400,
@@ -56,18 +63,42 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     })
 
     .post("/plugins/:id/start", async ({ params }) => {
-      await options.plugins.start(params.id);
-      return { pluginId: params.id, started: true };
+      try {
+        await options.plugins.start(params.id);
+        return { pluginId: params.id, started: true };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        throw new Response(JSON.stringify({ error: message, pluginId: params.id }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
     })
 
     .post("/plugins/:id/stop", async ({ params }) => {
-      await options.plugins.stop(params.id);
-      return { pluginId: params.id, stopped: true };
+      try {
+        await options.plugins.stop(params.id);
+        return { pluginId: params.id, stopped: true };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        throw new Response(JSON.stringify({ error: message, pluginId: params.id }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
     })
 
     .post("/plugins/:id/restart", async ({ params }) => {
-      await options.plugins.restart(params.id);
-      return { pluginId: params.id, restarted: true };
+      try {
+        await options.plugins.restart(params.id);
+        return { pluginId: params.id, restarted: true };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        throw new Response(JSON.stringify({ error: message, pluginId: params.id }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
     })
 
     .get("/plugins/:id/permissions", ({ params }) => {
@@ -82,8 +113,16 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     })
 
     .post("/plugins/:id/uninstall", async ({ params }) => {
-      await options.plugins.uninstall(params.id);
-      return { pluginId: params.id, uninstalled: true };
+      try {
+        await options.plugins.uninstall(params.id);
+        return { pluginId: params.id, uninstalled: true };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        throw new Response(JSON.stringify({ error: message, pluginId: params.id }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
     })
 
     // Auth + permissions middleware for /bridge/* routes

--- a/apps/desktop/sidecar/docker/docker-host.ts
+++ b/apps/desktop/sidecar/docker/docker-host.ts
@@ -1,0 +1,39 @@
+import Dockerode from "dockerode";
+
+const DEFAULT_TCP_PORT = 2375;
+
+interface DockerHostConfig {
+  host: string;
+  port: number;
+}
+
+/**
+ * Parse DOCKER_HOST env var (tcp:// format) into a validated host/port pair.
+ * Falls back to port 2375 when the port is omitted or invalid.
+ */
+export function parseDockerHost(dockerHost: string): DockerHostConfig {
+  const url = new URL(dockerHost.replace("tcp://", "http://"));
+  const parsed = Number(url.port);
+  return {
+    host: url.hostname,
+    port: parsed > 0 ? parsed : DEFAULT_TCP_PORT,
+  };
+}
+
+/**
+ * Create a Dockerode client with platform-aware connection handling.
+ * - Respects DOCKER_HOST env var (tcp:// scheme)
+ * - Falls back to TCP proxy on Windows (Bun can't use named pipes)
+ * - Uses default Unix socket on other platforms
+ */
+export function createDockerClient(): Dockerode {
+  const dockerHost = process.env["DOCKER_HOST"];
+  if (dockerHost && dockerHost.startsWith("tcp://")) {
+    const { host, port } = parseDockerHost(dockerHost);
+    return new Dockerode({ host, port });
+  }
+  if (process.platform === "win32") {
+    return new Dockerode({ host: "127.0.0.1", port: DEFAULT_TCP_PORT });
+  }
+  return new Dockerode();
+}

--- a/apps/desktop/sidecar/docker/manager.ts
+++ b/apps/desktop/sidecar/docker/manager.ts
@@ -1,5 +1,6 @@
 import Dockerode from "dockerode";
 import path from "node:path";
+import { createDockerClient } from "./docker-host";
 
 export interface ContainerConfig {
   image: string;
@@ -31,18 +32,7 @@ export class DockerManager {
   private dataDir: string;
 
   constructor(dataDir: string) {
-    // Bun's HTTP client doesn't support Windows named pipes, so fall back
-    // to TCP if a DOCKER_HOST env var or known TCP proxy is available.
-    const dockerHost = process.env["DOCKER_HOST"];
-    if (dockerHost && dockerHost.startsWith("tcp://")) {
-      const url = new URL(dockerHost.replace("tcp://", "http://"));
-      this.docker = new Dockerode({ host: url.hostname, port: Number(url.port) });
-    } else if (process.platform === "win32") {
-      // Default Windows TCP proxy (socat bridge to Docker Desktop socket)
-      this.docker = new Dockerode({ host: "127.0.0.1", port: 2375 });
-    } else {
-      this.docker = new Dockerode();
-    }
+    this.docker = createDockerClient();
     this.dataDir = dataDir;
   }
 
@@ -59,17 +49,20 @@ export class DockerManager {
     try {
       await this.docker.getImage(image).inspect();
       return true;
-    } catch {
-      return false;
+    } catch (err: unknown) {
+      if (typeof err === "object" && err !== null && "statusCode" in err && (err as { statusCode: number }).statusCode === 404) {
+        return false;
+      }
+      throw err;
     }
   }
 
   async pullImage(
     image: string,
     onProgress?: (event: { status: string; progress?: string }) => void,
+    { skipIfExists = true }: { skipIfExists?: boolean } = {},
   ): Promise<void> {
-    // Skip pull if image already exists locally (e.g. locally-built images)
-    if (await this.imageExists(image)) {
+    if (skipIfExists && await this.imageExists(image)) {
       console.error(`[docker] Image ${image} already exists locally, skipping pull`);
       return;
     }

--- a/apps/desktop/sidecar/docker/manager.ts
+++ b/apps/desktop/sidecar/docker/manager.ts
@@ -31,7 +31,18 @@ export class DockerManager {
   private dataDir: string;
 
   constructor(dataDir: string) {
-    this.docker = new Dockerode();
+    // Bun's HTTP client doesn't support Windows named pipes, so fall back
+    // to TCP if a DOCKER_HOST env var or known TCP proxy is available.
+    const dockerHost = process.env["DOCKER_HOST"];
+    if (dockerHost && dockerHost.startsWith("tcp://")) {
+      const url = new URL(dockerHost.replace("tcp://", "http://"));
+      this.docker = new Dockerode({ host: url.hostname, port: Number(url.port) });
+    } else if (process.platform === "win32") {
+      // Default Windows TCP proxy (socat bridge to Docker Desktop socket)
+      this.docker = new Dockerode({ host: "127.0.0.1", port: 2375 });
+    } else {
+      this.docker = new Dockerode();
+    }
     this.dataDir = dataDir;
   }
 
@@ -44,10 +55,25 @@ export class DockerManager {
     }
   }
 
+  async imageExists(image: string): Promise<boolean> {
+    try {
+      await this.docker.getImage(image).inspect();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async pullImage(
     image: string,
     onProgress?: (event: { status: string; progress?: string }) => void,
   ): Promise<void> {
+    // Skip pull if image already exists locally (e.g. locally-built images)
+    if (await this.imageExists(image)) {
+      console.error(`[docker] Image ${image} already exists locally, skipping pull`);
+      return;
+    }
+
     const stream = await this.docker.pull(image);
     return new Promise((resolve, reject) => {
       this.docker.modem.followProgress(

--- a/apps/desktop/sidecar/docker/networks.ts
+++ b/apps/desktop/sidecar/docker/networks.ts
@@ -1,10 +1,22 @@
 import Dockerode from "dockerode";
 
+function createDockerClient(): Dockerode {
+  const dockerHost = process.env["DOCKER_HOST"];
+  if (dockerHost && dockerHost.startsWith("tcp://")) {
+    const url = new URL(dockerHost.replace("tcp://", "http://"));
+    return new Dockerode({ host: url.hostname, port: Number(url.port) });
+  }
+  if (process.platform === "win32") {
+    return new Dockerode({ host: "127.0.0.1", port: 2375 });
+  }
+  return new Dockerode();
+}
+
 export class NetworkManager {
   private docker: Dockerode;
 
   constructor() {
-    this.docker = new Dockerode();
+    this.docker = createDockerClient();
   }
 
   async createPluginNetwork(pluginId: string): Promise<string> {

--- a/apps/desktop/sidecar/docker/networks.ts
+++ b/apps/desktop/sidecar/docker/networks.ts
@@ -1,19 +1,7 @@
-import Dockerode from "dockerode";
-
-function createDockerClient(): Dockerode {
-  const dockerHost = process.env["DOCKER_HOST"];
-  if (dockerHost && dockerHost.startsWith("tcp://")) {
-    const url = new URL(dockerHost.replace("tcp://", "http://"));
-    return new Dockerode({ host: url.hostname, port: Number(url.port) });
-  }
-  if (process.platform === "win32") {
-    return new Dockerode({ host: "127.0.0.1", port: 2375 });
-  }
-  return new Dockerode();
-}
+import { createDockerClient } from "./docker-host";
 
 export class NetworkManager {
-  private docker: Dockerode;
+  private docker: ReturnType<typeof createDockerClient>;
 
   constructor() {
     this.docker = createDockerClient();

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -237,8 +237,8 @@ export class PluginLifecycle {
       await this.stop(pluginId);
     }
 
-    // Pull new image
-    await this.docker.pullImage(newManifest.runtime.image);
+    // Pull new image — force re-pull to pick up mutable tag changes (e.g. :latest)
+    await this.docker.pullImage(newManifest.runtime.image, undefined, { skipIfExists: false });
 
     // Create new container FIRST, then remove old one (rollback-safe)
     const bridgeToken = issueToken(pluginId, plugin.serverId, newManifest.permissions);

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -79,11 +79,11 @@ export class PluginLifecycle {
       const pluginDataDir = path.join(this.dataDir, "plugin-data", manifest.id);
       fs.mkdirSync(pluginDataDir, { recursive: true });
 
-      // Pull image
+      // Pull image — force pull to ensure we have the latest for mutable tags
       console.error(`[lifecycle] Pulling image: ${manifest.runtime.image}`);
       await this.docker.pullImage(manifest.runtime.image, (event) => {
         console.error(`[lifecycle] Pull: ${event.status} ${event.progress ?? ""}`);
-      });
+      }, { skipIfExists: false });
 
       // Create network
       await this.networks.createPluginNetwork(manifest.id);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,8 +15,9 @@ let isQuitting = false;
 const sidecar = new SidecarManager();
 
 const IS_DEV = !app.isPackaged;
-const WEB_URL = IS_DEV ? "http://localhost:5173" : "https://uncorded.app";
-const PRELOAD_PATH = path.join(__dirname, "preload.js");
+const WEB_URL = process.env["UNCORDED_WEB_URL"]
+  ?? (IS_DEV ? "http://localhost:5173" : "https://uncorded.app");
+const PRELOAD_PATH = path.join(__dirname, "preload.cjs");
 
 function createWindow(): BrowserWindow {
   const win = new BrowserWindow({

--- a/apps/web/src/lib/plugin-bridge.ts
+++ b/apps/web/src/lib/plugin-bridge.ts
@@ -56,11 +56,11 @@ const METHOD_PERMISSIONS: Record<string, string | null> = {
   getUser: null,
   getServer: null,
   getChannels: null,
-  getMembers: "users:read",
-  getPresence: "presence:read",
-  sendMessage: "chat:write",
-  showToast: "ui:notifications",
-  navigate: "ui:navigate",
+  getMembers: "members.read",
+  getPresence: "presence.read",
+  sendMessage: "messages.send",
+  showToast: "notifications.send",
+  navigate: null,
 };
 
 function checkPermission(pluginId: string, method: string): boolean {


### PR DESCRIPTION
## Summary

- **CJS extension mismatch**: tsdown outputs `.cjs` when `type: "module"` is set — updated `package.json` main field, dev script, and preload path references
- **Preload code-splitting**: Split index.ts and preload.ts into separate tsdown builds so preload is a single standalone file (Electron requirement)
- **Missing plugin management endpoints**: Added `GET /plugins`, `POST /plugins/install`, start, stop, restart, uninstall, and permissions endpoints to the bridge server
- **Dockerode Windows support**: Bun's HTTP client can't connect to Windows named pipes — added TCP fallback (`127.0.0.1:2375`) via socat proxy container
- **Local image pull hang**: Added `imageExists()` check to skip registry pull for locally-built Docker images
- **Permission format mismatch**: Aligned web plugin-bridge to use dot-separated permissions (`members.read`) matching the sidecar, instead of colon-separated (`users:read`)
- **Dev URL override**: Added `UNCORDED_WEB_URL` env var; dev script defaults to `uncorded.app` (use `UNCORDED_LOCAL=1` for local Vite dev server)

## Test plan

- [ ] `bun run build:main` produces `index.cjs` and `preload.cjs` with no shared chunks
- [ ] `bun run dev` launches Electron, sidecar spawns and prints ready message
- [ ] `POST /plugins/install` with a local Docker image installs without hanging
- [ ] `POST /plugins/:id/start` starts container, `GET /plugins` shows running status
- [ ] Plugin health check responds on mapped port
- [ ] `POST /plugins/:id/stop` and restart work correctly
- [ ] On Windows: Docker operations work via TCP proxy (socat container on 2375)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unauthenticated plugin-management HTTP endpoints for listing, installing and controlling plugins.
  * Introduced utilities to construct Docker clients from environment configuration.

* **Improvements**
  * Made desktop app web URL configurable via env and updated preload handling for dev.
  * Improved Docker handling (connection logic, image-exists checks, optional skip for pulls).
  * Revised plugin bridge permission strings.
* **Chores**
  * Ignored local test-plugin directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->