### PR TITLE
feat: plugin scope separation — server vs personal plugins

### DIFF
--- a/apps/desktop/sidecar/bridge/auth.ts
+++ b/apps/desktop/sidecar/bridge/auth.ts
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto";
 
+export type ResolvedScope = "server" | "personal";
+
 export interface PluginContext {
   pluginId: string;
   serverId: string;
+  scope: ResolvedScope;
   permissions: string[];
 }
 

--- a/apps/desktop/sidecar/bridge/routes.ts
+++ b/apps/desktop/sidecar/bridge/routes.ts
@@ -34,6 +34,13 @@ function badRequestError(message: string) {
 }
 
 /**
+ * Check if a plugin is in personal scope (serverId starts with "personal:").
+ */
+function isPersonalScope(plugin: PluginContext): boolean {
+  return plugin.scope === "personal";
+}
+
+/**
  * Helper: get server data from gateway for the plugin's server.
  * The `plugin` property is set by the derive middleware in server.ts.
  */
@@ -52,6 +59,19 @@ export function createRoutes(deps: RouteDeps) {
     // --- Server info ---
     .get("/server", (ctx) => {
       const plugin = (ctx as unknown as { plugin: PluginContext }).plugin;
+      const ready = gateway.getReadyData();
+      if (!ready) throw gatewayError();
+
+      if (isPersonalScope(plugin)) {
+        return {
+          id: `personal:${ready.user.id}`,
+          name: `${ready.user.displayName ?? ready.user.username}'s Space`,
+          iconUrl: ready.user.avatarUrl ?? null,
+          memberCount: (ready.friends?.length ?? 0) + 1,
+          channelCount: ready.dmChannels?.length ?? 0,
+        };
+      }
+
       const { server } = getPluginServer(gateway, plugin);
       if (!server) throw gatewayError();
 
@@ -67,8 +87,15 @@ export function createRoutes(deps: RouteDeps) {
     // --- Members ---
     .get("/members", (ctx) => {
       const plugin = (ctx as unknown as { plugin: PluginContext }).plugin;
-      const { ready, server } = getPluginServer(gateway, plugin);
+      const ready = gateway.getReadyData();
       if (!ready) throw gatewayError();
+
+      if (isPersonalScope(plugin)) {
+        // Personal plugins see friends instead of server members
+        return { members: ready.friends ?? [] };
+      }
+
+      const { server } = getPluginServer(gateway, plugin);
       if (!server) return { members: [] };
 
       return { members: server.members };
@@ -77,8 +104,15 @@ export function createRoutes(deps: RouteDeps) {
     // --- Channels ---
     .get("/channels", (ctx) => {
       const plugin = (ctx as unknown as { plugin: PluginContext }).plugin;
-      const { ready, server } = getPluginServer(gateway, plugin);
+      const ready = gateway.getReadyData();
       if (!ready) throw gatewayError();
+
+      if (isPersonalScope(plugin)) {
+        // Personal plugins see DM channels instead of server channels
+        return { channels: ready.dmChannels ?? [] };
+      }
+
+      const { server } = getPluginServer(gateway, plugin);
       if (!server) return { channels: [] };
 
       return { channels: server.channels };

--- a/apps/desktop/sidecar/bridge/routes.ts
+++ b/apps/desktop/sidecar/bridge/routes.ts
@@ -34,7 +34,7 @@ function badRequestError(message: string) {
 }
 
 /**
- * Check if a plugin is in personal scope (serverId starts with "personal:").
+ * Check if a plugin is in personal scope (plugin.scope === "personal").
  */
 function isPersonalScope(plugin: PluginContext): boolean {
   return plugin.scope === "personal";

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -39,6 +39,8 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
         rightPanel: false,
         status: p.state === "installed" ? "stopped" : p.state,
         port: p.hostPort ?? 0,
+        scope: p.scope,
+        tunnelUrl: p.tunnelUrl,
         permissions: p.manifest.permissions,
       }));
     })
@@ -52,7 +54,8 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
         });
       }
       const serverId = typeof parsed.serverId === "string" ? parsed.serverId : "local";
-      const result = await options.plugins.install(parsed.manifest, serverId);
+      const scope = parsed.scope === "server" ? "server" as const : "personal" as const;
+      const result = await options.plugins.install(parsed.manifest, serverId, scope);
       if (result.errors && result.errors.length > 0) {
         throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
           status: 400,

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -53,9 +53,18 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
           headers: { "Content-Type": "application/json" },
         });
       }
-      const serverId = typeof parsed.serverId === "string" ? parsed.serverId : "local";
       const scope = parsed.scope === "server" ? "server" as const : "personal" as const;
-      const result = await options.plugins.install(parsed.manifest, serverId, scope);
+      const serverId = typeof parsed.serverId === "string" ? parsed.serverId : undefined;
+
+      // Server-scoped installs must provide a real serverId
+      if (scope === "server" && !serverId) {
+        throw new Response(JSON.stringify({ error: "serverId is required for server-scoped plugins" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      const result = await options.plugins.install(parsed.manifest, serverId ?? "local", scope);
       if (result.errors && result.errors.length > 0) {
         throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
           status: 400,

--- a/apps/desktop/sidecar/index.ts
+++ b/apps/desktop/sidecar/index.ts
@@ -3,6 +3,7 @@ import { DockerManager } from "./docker/manager";
 import { GatewayClient } from "./gateway/client";
 import { SeedingEngine } from "./seeding/engine";
 import { PluginLifecycle } from "./plugins/lifecycle";
+import { TunnelManager } from "./tunnel/manager";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -16,7 +17,8 @@ fs.mkdirSync(DATA_DIR, { recursive: true });
 const docker = new DockerManager(DATA_DIR);
 const gateway = new GatewayClient();
 const seeding = new SeedingEngine(DATA_DIR);
-const plugins = new PluginLifecycle(docker, DATA_DIR);
+const tunnelManager = new TunnelManager(DATA_DIR);
+const plugins = new PluginLifecycle(docker, DATA_DIR, tunnelManager);
 
 // --- Start Bridge Server ---
 
@@ -34,6 +36,7 @@ const tokenPath = path.join(DATA_DIR, "gateway-token.txt");
 if (fs.existsSync(tokenPath)) {
   const token = fs.readFileSync(tokenPath, "utf-8").trim();
   if (token) {
+    plugins.setApiToken(token);
     await gateway.connect(token);
   }
 }
@@ -52,6 +55,7 @@ async function shutdown(): Promise<void> {
   console.error("[sidecar] Shutting down...");
 
   await plugins.stopAll();
+  await tunnelManager.destroyAll();
   gateway.destroy();
   await seeding.shutdown();
   await bridge.stop();

--- a/apps/desktop/sidecar/plugins/__tests__/manifest-scope.test.ts
+++ b/apps/desktop/sidecar/plugins/__tests__/manifest-scope.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseManifest } from "../manifest";
+
+function validManifest(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "test-plugin",
+    name: "Test Plugin",
+    version: "1.0.0",
+    description: "A test plugin",
+    author: "Test Author",
+    scope: "personal",
+    runtime: { image: "test:latest", port: 3000 },
+    permissions: ["server.read"],
+    ...overrides,
+  };
+}
+
+describe("parseManifest — scope field", () => {
+  it("accepts scope: 'personal'", () => {
+    const { manifest, errors } = parseManifest(validManifest({ scope: "personal" }));
+    expect(errors).toHaveLength(0);
+    expect(manifest.scope).toBe("personal");
+  });
+
+  it("accepts scope: 'server'", () => {
+    const { manifest, errors } = parseManifest(validManifest({ scope: "server" }));
+    expect(errors).toHaveLength(0);
+    expect(manifest.scope).toBe("server");
+  });
+
+  it("accepts scope: 'both'", () => {
+    const { manifest, errors } = parseManifest(validManifest({ scope: "both" }));
+    expect(errors).toHaveLength(0);
+    expect(manifest.scope).toBe("both");
+  });
+
+  it("rejects missing scope", () => {
+    const raw = validManifest();
+    delete (raw as Record<string, unknown>).scope;
+    const { errors } = parseManifest(raw);
+    expect(errors).toContain("scope must be 'server', 'personal', or 'both'");
+  });
+
+  it("rejects invalid scope value", () => {
+    const { errors } = parseManifest(validManifest({ scope: "global" }));
+    expect(errors).toContain("scope must be 'server', 'personal', or 'both'");
+  });
+
+  it("rejects numeric scope", () => {
+    const { errors } = parseManifest(validManifest({ scope: 42 }));
+    expect(errors).toContain("scope must be 'server', 'personal', or 'both'");
+  });
+
+  it("defaults to 'personal' in constructed manifest when scope is invalid", () => {
+    const { manifest } = parseManifest(validManifest({ scope: "invalid" }));
+    expect(manifest.scope).toBe("personal");
+  });
+});

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -4,8 +4,8 @@ import type { DockerManager } from "../docker/manager";
 import { NetworkManager } from "../docker/networks";
 import { HealthMonitor } from "../docker/health";
 import { ResourceEnforcer } from "../docker/resources";
-import { issueToken, revokePluginTokens } from "./tokens";
-import { parseManifest, type PluginManifest } from "./manifest";
+import { issueToken, reregisterToken, revokePluginTokens } from "./tokens";
+import { parseManifest, type PluginManifest, type PluginScope } from "./manifest";
 import type { ResolvedScope } from "../bridge/auth";
 import type { TunnelManager } from "../tunnel/manager";
 
@@ -76,6 +76,14 @@ export class PluginLifecycle {
     const { manifest, errors } = parseManifest(manifestRaw);
     if (errors.length > 0) {
       return { pluginId: "", errors };
+    }
+
+    // Validate requested scope is allowed by the manifest
+    if (!PluginLifecycle.isScopeAllowed(manifest.scope, scope)) {
+      return {
+        pluginId: manifest.id,
+        errors: [`Manifest scope "${manifest.scope}" does not allow installing as "${scope}"`],
+      };
     }
 
     // Check resources
@@ -151,10 +159,11 @@ export class PluginLifecycle {
     plugin.state = "starting";
     this.saveState();
 
-    // Token is baked into the container env at create time — register it in
-    // the auth store so the bridge can validate it (needed after sidecar restart)
+    // Token is baked into the container env at create time — re-register it in
+    // the auth store so the bridge can validate it (needed after sidecar restart).
+    // We must NOT issue a new token here because the container already has the old one.
     if (plugin.bridgeToken) {
-      issueToken(pluginId, plugin.serverId, plugin.manifest.permissions, plugin.scope);
+      reregisterToken(plugin.bridgeToken, pluginId, plugin.serverId, plugin.manifest.permissions, plugin.scope);
     }
 
     // Start container
@@ -179,6 +188,10 @@ export class PluginLifecycle {
 
     // Create tunnel for server-scope plugins
     if (plugin.scope === "server" && plugin.hostPort && this.tunnelManager) {
+      // Clear any stale tunnel URL from a previous run before attempting creation
+      plugin.tunnelUrl = null;
+      this.saveState();
+
       try {
         const tunnelUrl = await this.tunnelManager.create(pluginId, plugin.hostPort);
         plugin.tunnelUrl = tunnelUrl;
@@ -206,12 +219,14 @@ export class PluginLifecycle {
 
     await this.docker.stopContainer(plugin.containerId);
 
-    // Destroy tunnel for server-scope plugins
+    // Destroy tunnel for server-scope plugins (best-effort — never block stop)
     if (plugin.scope === "server" && this.tunnelManager) {
-      await this.tunnelManager.destroy(pluginId);
-      if (plugin.tunnelUrl) {
-        await this.reportTunnelUrl(plugin.serverId, pluginId, null, "stopped").catch(() => {});
+      try {
+        await this.tunnelManager.destroy(pluginId);
+      } catch (err) {
+        console.error(`[lifecycle] Tunnel destroy failed for ${pluginId}:`, err);
       }
+      await this.reportTunnelUrl(plugin.serverId, pluginId, null, "stopped").catch(() => {});
       plugin.tunnelUrl = null;
     }
 
@@ -265,6 +280,13 @@ export class PluginLifecycle {
 
     const { manifest: newManifest, errors } = parseManifest(newManifestRaw);
     if (errors.length > 0) return { errors };
+
+    // Validate the existing scope is still allowed by the new manifest
+    if (!PluginLifecycle.isScopeAllowed(newManifest.scope, plugin.scope)) {
+      return {
+        errors: [`Updated manifest scope "${newManifest.scope}" does not allow current scope "${plugin.scope}"`],
+      };
+    }
 
     const wasRunning = plugin.state === "running";
     if (wasRunning) {
@@ -360,6 +382,8 @@ export class PluginLifecycle {
 
   // --- Tunnel reporting ---
 
+  private static readonly REPORT_TIMEOUT_MS = 5_000;
+
   private async reportTunnelUrl(
     serverId: string,
     pluginId: string,
@@ -371,6 +395,12 @@ export class PluginLifecycle {
       return;
     }
 
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      PluginLifecycle.REPORT_TIMEOUT_MS,
+    );
+
     try {
       const res = await fetch(
         `${this.apiBaseUrl}/api/servers/${serverId}/plugins/${pluginId}/tunnel`,
@@ -381,6 +411,7 @@ export class PluginLifecycle {
             Cookie: `better-auth.session_token=${this.apiToken}`,
           },
           body: JSON.stringify({ tunnelUrl, state }),
+          signal: controller.signal,
         },
       );
 
@@ -388,8 +419,21 @@ export class PluginLifecycle {
         console.error(`[lifecycle] Failed to report tunnel URL: ${res.status}`);
       }
     } catch (err) {
-      console.error("[lifecycle] Error reporting tunnel URL:", err);
+      if (err instanceof DOMException && err.name === "AbortError") {
+        console.error("[lifecycle] Tunnel URL report timed out");
+      } else {
+        console.error("[lifecycle] Error reporting tunnel URL:", err);
+      }
+    } finally {
+      clearTimeout(timeout);
     }
+  }
+
+  // --- Helpers ---
+
+  private static isScopeAllowed(manifestScope: PluginScope, requestedScope: ResolvedScope): boolean {
+    if (manifestScope === "both") return true;
+    return manifestScope === requestedScope;
   }
 
   // --- State persistence ---

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -86,6 +86,14 @@ export class PluginLifecycle {
       };
     }
 
+    // Server-scoped plugins require a real serverId (not the "local" fallback or empty)
+    if (scope === "server" && (!serverId || serverId === "local")) {
+      return {
+        pluginId: manifest.id,
+        errors: ["Server-scoped plugins require a valid serverId"],
+      };
+    }
+
     // Check resources
     const resourceCheck = this.resources.validateAndReserve(manifest.resources ?? {});
     if (!resourceCheck.allowed) {
@@ -186,8 +194,12 @@ export class PluginLifecycle {
       );
     }
 
-    // Clear any stale tunnel URL for server-scope plugins before attempting creation
+    // Create tunnel for server-scope plugins
     if (plugin.scope === "server") {
+      // Clear any stale tunnel URL and notify backend before attempting recreation
+      if (plugin.tunnelUrl) {
+        await this.reportTunnelUrl(plugin.serverId, pluginId, null, "active").catch(() => {});
+      }
       plugin.tunnelUrl = null;
       this.saveState();
 
@@ -221,12 +233,15 @@ export class PluginLifecycle {
     await this.docker.stopContainer(plugin.containerId);
 
     // Destroy tunnel for server-scope plugins (best-effort — never block stop)
-    if (plugin.scope === "server" && this.tunnelManager) {
-      try {
-        await this.tunnelManager.destroy(pluginId);
-      } catch (err) {
-        console.error(`[lifecycle] Tunnel destroy failed for ${pluginId}:`, err);
+    if (plugin.scope === "server") {
+      if (this.tunnelManager) {
+        try {
+          await this.tunnelManager.destroy(pluginId);
+        } catch (err) {
+          console.error(`[lifecycle] Tunnel destroy failed for ${pluginId}:`, err);
+        }
       }
+      // Always notify backend to clear the tunnel URL, even without a local tunnelManager
       await this.reportTunnelUrl(plugin.serverId, pluginId, null, "stopped").catch(() => {});
       plugin.tunnelUrl = null;
     }
@@ -404,7 +419,7 @@ export class PluginLifecycle {
 
     try {
       const res = await fetch(
-        `${this.apiBaseUrl}/api/servers/${serverId}/plugins/${pluginId}/tunnel`,
+        `${this.apiBaseUrl}/api/servers/${encodeURIComponent(serverId)}/plugins/${encodeURIComponent(pluginId)}/tunnel`,
         {
           method: "PUT",
           headers: {

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -6,17 +6,20 @@ import { HealthMonitor } from "../docker/health";
 import { ResourceEnforcer } from "../docker/resources";
 import { issueToken, revokePluginTokens } from "./tokens";
 import { parseManifest, type PluginManifest } from "./manifest";
+import type { ResolvedScope } from "../bridge/auth";
 
 export type PluginState = "installed" | "starting" | "running" | "stopping" | "stopped" | "crashed" | "error";
 
 interface PluginRecord {
   pluginId: string;
   serverId: string;
+  scope: ResolvedScope;
   manifest: PluginManifest;
   containerId: string | null;
   state: PluginState;
   hostPort: number | null;
   bridgeToken: string | null;
+  tunnelUrl: string | null;
   previouslyRunning: boolean;
   installedAt: string;
   error?: string | undefined;
@@ -62,7 +65,7 @@ export class PluginLifecycle {
 
   // --- Public API ---
 
-  async install(manifestRaw: unknown, serverId: string): Promise<{ pluginId: string; errors?: string[] }> {
+  async install(manifestRaw: unknown, serverId: string, scope: ResolvedScope = "personal"): Promise<{ pluginId: string; errors?: string[] }> {
     const { manifest, errors } = parseManifest(manifestRaw);
     if (errors.length > 0) {
       return { pluginId: "", errors };
@@ -89,7 +92,7 @@ export class PluginLifecycle {
       await this.networks.createPluginNetwork(manifest.id);
 
       // Issue bridge token
-      const bridgeToken = issueToken(manifest.id, serverId, manifest.permissions);
+      const bridgeToken = issueToken(manifest.id, serverId, manifest.permissions, scope);
 
       // Create container
       const containerId = await this.docker.createContainer({
@@ -109,11 +112,13 @@ export class PluginLifecycle {
       const record: PluginRecord = {
         pluginId: manifest.id,
         serverId,
+        scope,
         manifest,
         containerId,
         state: "installed",
         hostPort: null,
         bridgeToken,
+        tunnelUrl: null,
         previouslyRunning: false,
         installedAt: new Date().toISOString(),
       };
@@ -142,7 +147,7 @@ export class PluginLifecycle {
     // Token is baked into the container env at create time — register it in
     // the auth store so the bridge can validate it (needed after sidecar restart)
     if (plugin.bridgeToken) {
-      issueToken(pluginId, plugin.serverId, plugin.manifest.permissions);
+      issueToken(pluginId, plugin.serverId, plugin.manifest.permissions, plugin.scope);
     }
 
     // Start container
@@ -241,7 +246,7 @@ export class PluginLifecycle {
     await this.docker.pullImage(newManifest.runtime.image, undefined, { skipIfExists: false });
 
     // Create new container FIRST, then remove old one (rollback-safe)
-    const bridgeToken = issueToken(pluginId, plugin.serverId, newManifest.permissions);
+    const bridgeToken = issueToken(pluginId, plugin.serverId, newManifest.permissions, plugin.scope);
     const newContainerId = await this.docker.createContainer({
       image: newManifest.runtime.image,
       pluginId,
@@ -328,6 +333,9 @@ export class PluginLifecycle {
         const raw = fs.readFileSync(this.statePath, "utf-8");
         const state = JSON.parse(raw) as StateFile;
         for (const [id, record] of Object.entries(state.plugins)) {
+          // Backwards compat: default missing scope/tunnelUrl for pre-scope installs
+          if (!record.scope) record.scope = "personal";
+          if (record.tunnelUrl === undefined) record.tunnelUrl = null;
           this.plugins.set(id, record);
         }
         console.error(`[lifecycle] Loaded ${this.plugins.size} plugins from state`);

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -186,20 +186,21 @@ export class PluginLifecycle {
       );
     }
 
-    // Create tunnel for server-scope plugins
-    if (plugin.scope === "server" && plugin.hostPort && this.tunnelManager) {
-      // Clear any stale tunnel URL from a previous run before attempting creation
+    // Clear any stale tunnel URL for server-scope plugins before attempting creation
+    if (plugin.scope === "server") {
       plugin.tunnelUrl = null;
       this.saveState();
 
-      try {
-        const tunnelUrl = await this.tunnelManager.create(pluginId, plugin.hostPort);
-        plugin.tunnelUrl = tunnelUrl;
-        this.saveState();
-        await this.reportTunnelUrl(plugin.serverId, pluginId, tunnelUrl, "active");
-      } catch (err) {
-        console.error(`[lifecycle] Failed to create tunnel for ${pluginId}:`, err);
-        // Plugin still runs, just no tunnel
+      if (plugin.hostPort && this.tunnelManager) {
+        try {
+          const tunnelUrl = await this.tunnelManager.create(pluginId, plugin.hostPort);
+          plugin.tunnelUrl = tunnelUrl;
+          this.saveState();
+          await this.reportTunnelUrl(plugin.serverId, pluginId, tunnelUrl, "active");
+        } catch (err) {
+          console.error(`[lifecycle] Failed to create tunnel for ${pluginId}:`, err);
+          // Plugin still runs, just no tunnel
+        }
       }
     }
 

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -7,6 +7,7 @@ import { ResourceEnforcer } from "../docker/resources";
 import { issueToken, revokePluginTokens } from "./tokens";
 import { parseManifest, type PluginManifest } from "./manifest";
 import type { ResolvedScope } from "../bridge/auth";
+import type { TunnelManager } from "../tunnel/manager";
 
 export type PluginState = "installed" | "starting" | "running" | "stopping" | "stopped" | "crashed" | "error";
 
@@ -34,13 +35,19 @@ export class PluginLifecycle {
   private networks: NetworkManager;
   private health: HealthMonitor;
   private resources: ResourceEnforcer;
+  private tunnelManager: TunnelManager | null;
+  private apiBaseUrl: string | null;
+  private apiToken: string | null;
   private dataDir: string;
   private statePath: string;
   private plugins = new Map<string, PluginRecord>();
   private bridgePort = 0;
 
-  constructor(docker: DockerManager, dataDir: string) {
+  constructor(docker: DockerManager, dataDir: string, tunnelManager?: TunnelManager) {
     this.docker = docker;
+    this.tunnelManager = tunnelManager ?? null;
+    this.apiBaseUrl = process.env["UNCORDED_API_URL"] ?? null;
+    this.apiToken = null;
     this.networks = new NetworkManager();
     this.health = new HealthMonitor(docker);
     this.resources = new ResourceEnforcer();
@@ -170,6 +177,19 @@ export class PluginLifecycle {
       );
     }
 
+    // Create tunnel for server-scope plugins
+    if (plugin.scope === "server" && plugin.hostPort && this.tunnelManager) {
+      try {
+        const tunnelUrl = await this.tunnelManager.create(pluginId, plugin.hostPort);
+        plugin.tunnelUrl = tunnelUrl;
+        this.saveState();
+        await this.reportTunnelUrl(plugin.serverId, pluginId, tunnelUrl, "active");
+      } catch (err) {
+        console.error(`[lifecycle] Failed to create tunnel for ${pluginId}:`, err);
+        // Plugin still runs, just no tunnel
+      }
+    }
+
     console.error(`[lifecycle] Started plugin: ${pluginId} on port ${plugin.hostPort}`);
   }
 
@@ -185,6 +205,15 @@ export class PluginLifecycle {
     revokePluginTokens(pluginId);
 
     await this.docker.stopContainer(plugin.containerId);
+
+    // Destroy tunnel for server-scope plugins
+    if (plugin.scope === "server" && this.tunnelManager) {
+      await this.tunnelManager.destroy(pluginId);
+      if (plugin.tunnelUrl) {
+        await this.reportTunnelUrl(plugin.serverId, pluginId, null, "stopped").catch(() => {});
+      }
+      plugin.tunnelUrl = null;
+    }
 
     plugin.state = "stopped";
     plugin.previouslyRunning = false;
@@ -315,6 +344,10 @@ export class PluginLifecycle {
     this.bridgePort = port;
   }
 
+  setApiToken(token: string): void {
+    this.apiToken = token;
+  }
+
   // --- Queries ---
 
   list(): PluginRecord[] {
@@ -323,6 +356,40 @@ export class PluginLifecycle {
 
   get(pluginId: string): PluginRecord | undefined {
     return this.plugins.get(pluginId);
+  }
+
+  // --- Tunnel reporting ---
+
+  private async reportTunnelUrl(
+    serverId: string,
+    pluginId: string,
+    tunnelUrl: string | null,
+    state: string,
+  ): Promise<void> {
+    if (!this.apiBaseUrl || !this.apiToken) {
+      console.error("[lifecycle] Cannot report tunnel URL: API URL or token not configured");
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `${this.apiBaseUrl}/api/servers/${serverId}/plugins/${pluginId}/tunnel`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `better-auth.session_token=${this.apiToken}`,
+          },
+          body: JSON.stringify({ tunnelUrl, state }),
+        },
+      );
+
+      if (!res.ok) {
+        console.error(`[lifecycle] Failed to report tunnel URL: ${res.status}`);
+      }
+    } catch (err) {
+      console.error("[lifecycle] Error reporting tunnel URL:", err);
+    }
   }
 
   // --- State persistence ---

--- a/apps/desktop/sidecar/plugins/manifest.ts
+++ b/apps/desktop/sidecar/plugins/manifest.ts
@@ -1,11 +1,14 @@
 import type { ResourceLimits } from "../docker/manager";
 
+export type PluginScope = "server" | "personal" | "both";
+
 export interface PluginManifest {
   id: string;
   name: string;
   version: string;
   description: string;
   author: string;
+  scope: PluginScope;
   icon?: string | undefined;
   repository?: string | undefined;
   license?: string | undefined;
@@ -30,6 +33,8 @@ export interface PluginManifest {
     panelWidth?: number | undefined;
   } | undefined;
 }
+
+const VALID_SCOPES = new Set<PluginScope>(["server", "personal", "both"]);
 
 const KNOWN_PERMISSIONS = new Set([
   "server.read",
@@ -95,6 +100,11 @@ export function parseManifest(raw: unknown): { manifest: PluginManifest; errors:
   if (typeof data["description"] !== "string") errors.push("Missing required field: description");
   if (typeof data["author"] !== "string") errors.push("Missing required field: author");
 
+  // Validate scope
+  if (typeof data["scope"] !== "string" || !VALID_SCOPES.has(data["scope"] as PluginScope)) {
+    errors.push("scope must be 'server', 'personal', or 'both'");
+  }
+
   // Validate version is semver
   if (typeof data["version"] === "string" && !SEMVER_REGEX.test(data["version"])) {
     errors.push(`Invalid version format: ${data["version"]} (must be semver)`);
@@ -137,6 +147,7 @@ export function parseManifest(raw: unknown): { manifest: PluginManifest; errors:
     version: String(data["version"] ?? "0.0.0"),
     description: String(data["description"] ?? ""),
     author: String(data["author"] ?? ""),
+    scope: VALID_SCOPES.has(data["scope"] as PluginScope) ? (data["scope"] as PluginScope) : "personal",
     icon: typeof data["icon"] === "string" ? data["icon"] : undefined,
     repository: typeof data["repository"] === "string" ? data["repository"] : undefined,
     license: typeof data["license"] === "string" ? data["license"] : undefined,

--- a/apps/desktop/sidecar/plugins/tokens.ts
+++ b/apps/desktop/sidecar/plugins/tokens.ts
@@ -26,6 +26,21 @@ export function issueToken(
   return token;
 }
 
+/**
+ * Re-register an existing token in the auth store without revoking/regenerating.
+ * Used on sidecar restart when the container still has the original token baked in.
+ */
+export function reregisterToken(
+  token: string,
+  pluginId: string,
+  serverId: string,
+  permissions: string[],
+  scope: ResolvedScope = "personal",
+): void {
+  const context: PluginContext = { pluginId, serverId, scope, permissions };
+  registerToken(token, context);
+}
+
 export function revokePluginTokens(pluginId: string): void {
   revokeAllForPlugin(pluginId);
 }

--- a/apps/desktop/sidecar/plugins/tokens.ts
+++ b/apps/desktop/sidecar/plugins/tokens.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { registerToken, revokeAllForPlugin, hashToken, type PluginContext } from "../bridge/auth";
+import { registerToken, revokeAllForPlugin, hashToken, type PluginContext, type ResolvedScope } from "../bridge/auth";
 
 const TOKEN_BYTES = 32; // 256-bit
 
@@ -9,13 +9,18 @@ export function generateToken(): string {
   return randomBytes(TOKEN_BYTES).toString("hex");
 }
 
-export function issueToken(pluginId: string, serverId: string, permissions: string[]): string {
+export function issueToken(
+  pluginId: string,
+  serverId: string,
+  permissions: string[],
+  scope: ResolvedScope = "personal",
+): string {
   // Revoke any existing tokens for this plugin
   revokeAllForPlugin(pluginId);
 
   // Generate and register new token
   const token = generateToken();
-  const context: PluginContext = { pluginId, serverId, permissions };
+  const context: PluginContext = { pluginId, serverId, scope, permissions };
   registerToken(token, context);
 
   return token;

--- a/apps/desktop/sidecar/tunnel/__tests__/manager.test.ts
+++ b/apps/desktop/sidecar/tunnel/__tests__/manager.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { mockSpawn, mockEnsureCloudflared, mockProcess } = vi.hoisted(() => {
+  const mockProcess = {
+    stderr: {
+      on: vi.fn(),
+    },
+    stdout: {
+      on: vi.fn(),
+    },
+    on: vi.fn(),
+    kill: vi.fn(),
+  };
+
+  const mockSpawn = vi.fn().mockReturnValue(mockProcess);
+  const mockEnsureCloudflared = vi.fn().mockResolvedValue("/usr/local/bin/cloudflared");
+
+  return { mockSpawn, mockEnsureCloudflared, mockProcess };
+});
+
+vi.mock("node:child_process", () => ({ spawn: mockSpawn }));
+vi.mock("../binary", () => ({ ensureCloudflared: mockEnsureCloudflared }));
+
+// ── Import after mocks ────────────────────────────────────────────────────
+
+import { TunnelManager } from "../manager";
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("TunnelManager", () => {
+  let manager: TunnelManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    manager = new TunnelManager("/tmp/test-data");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("create", () => {
+    it("spawns cloudflared and resolves with tunnel URL", async () => {
+      const createPromise = manager.create("test-plugin", 3000);
+
+      // Simulate cloudflared output on stderr
+      const stderrCallback = mockProcess.stderr.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "data",
+      )?.[1];
+      expect(stderrCallback).toBeDefined();
+
+      stderrCallback(Buffer.from(
+        "2026-01-01 INF | https://random-words.trycloudflare.com\n",
+      ));
+
+      const url = await createPromise;
+      expect(url).toBe("https://random-words.trycloudflare.com");
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "/usr/local/bin/cloudflared",
+        ["tunnel", "--url", "http://localhost:3000", "--no-autoupdate"],
+        expect.any(Object),
+      );
+    });
+
+    it("returns the tunnel URL from getUrl after creation", async () => {
+      const createPromise = manager.create("test-plugin", 3000);
+
+      const stderrCallback = mockProcess.stderr.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "data",
+      )?.[1];
+      stderrCallback(Buffer.from("https://abc-def.trycloudflare.com"));
+
+      await createPromise;
+      expect(manager.getUrl("test-plugin")).toBe("https://abc-def.trycloudflare.com");
+    });
+
+    it("returns null for unknown plugin", () => {
+      expect(manager.getUrl("nonexistent")).toBeNull();
+    });
+  });
+
+  describe("destroy", () => {
+    it("kills the tunnel process", async () => {
+      // Set up a tunnel first
+      const createPromise = manager.create("test-plugin", 3000);
+      const stderrCallback = mockProcess.stderr.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "data",
+      )?.[1];
+      stderrCallback(Buffer.from("https://abc.trycloudflare.com"));
+      await createPromise;
+
+      await manager.destroy("test-plugin");
+      expect(mockProcess.kill).toHaveBeenCalled();
+      expect(manager.getUrl("test-plugin")).toBeNull();
+    });
+
+    it("is a no-op for unknown plugin", async () => {
+      await expect(manager.destroy("nonexistent")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("destroyAll", () => {
+    it("cleans up all tunnels", async () => {
+      // Create first tunnel
+      const p1 = manager.create("plugin-1", 3001);
+      let stderrCb = mockProcess.stderr.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "data",
+      )?.[1];
+      stderrCb(Buffer.from("https://a.trycloudflare.com"));
+      await p1;
+
+      // Reset mock for second spawn
+      vi.clearAllMocks();
+      const mockProcess2 = {
+        stderr: { on: vi.fn() },
+        stdout: { on: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn(),
+      };
+      mockSpawn.mockReturnValue(mockProcess2);
+
+      const p2 = manager.create("plugin-2", 3002);
+      stderrCb = mockProcess2.stderr.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "data",
+      )?.[1];
+      stderrCb(Buffer.from("https://b.trycloudflare.com"));
+      await p2;
+
+      await manager.destroyAll();
+      expect(manager.getUrl("plugin-1")).toBeNull();
+      expect(manager.getUrl("plugin-2")).toBeNull();
+    });
+  });
+});

--- a/apps/desktop/sidecar/tunnel/__tests__/manager.test.ts
+++ b/apps/desktop/sidecar/tunnel/__tests__/manager.test.ts
@@ -27,6 +27,17 @@ vi.mock("../binary", () => ({ ensureCloudflared: mockEnsureCloudflared }));
 
 import { TunnelManager } from "../manager";
 
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function getStderrCallback(proc: typeof mockProcess): (data: Buffer) => void {
+  const entry = proc.stderr.on.mock.calls.find(
+    (c: unknown[]) => c[0] === "data",
+  );
+  expect(entry).toBeDefined();
+  expect(typeof entry![1]).toBe("function");
+  return entry![1] as (data: Buffer) => void;
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("TunnelManager", () => {
@@ -46,12 +57,7 @@ describe("TunnelManager", () => {
     it("spawns cloudflared and resolves with tunnel URL", async () => {
       const createPromise = manager.create("test-plugin", 3000);
 
-      // Simulate cloudflared output on stderr
-      const stderrCallback = mockProcess.stderr.on.mock.calls.find(
-        (c: unknown[]) => c[0] === "data",
-      )?.[1];
-      expect(stderrCallback).toBeDefined();
-
+      const stderrCallback = getStderrCallback(mockProcess);
       stderrCallback(Buffer.from(
         "2026-01-01 INF | https://random-words.trycloudflare.com\n",
       ));
@@ -68,9 +74,7 @@ describe("TunnelManager", () => {
     it("returns the tunnel URL from getUrl after creation", async () => {
       const createPromise = manager.create("test-plugin", 3000);
 
-      const stderrCallback = mockProcess.stderr.on.mock.calls.find(
-        (c: unknown[]) => c[0] === "data",
-      )?.[1];
+      const stderrCallback = getStderrCallback(mockProcess);
       stderrCallback(Buffer.from("https://abc-def.trycloudflare.com"));
 
       await createPromise;
@@ -125,9 +129,7 @@ describe("TunnelManager", () => {
     it("kills the tunnel process and waits for exit", async () => {
       // Set up a tunnel first
       const createPromise = manager.create("test-plugin", 3000);
-      const stderrCallback = mockProcess.stderr.on.mock.calls.find(
-        (c: unknown[]) => c[0] === "data",
-      )?.[1];
+      const stderrCallback = getStderrCallback(mockProcess);
       stderrCallback(Buffer.from("https://abc.trycloudflare.com"));
       await createPromise;
 
@@ -151,14 +153,18 @@ describe("TunnelManager", () => {
     it("cleans up all tunnels", async () => {
       // Create first tunnel
       const p1 = manager.create("plugin-1", 3001);
-      let stderrCb = mockProcess.stderr.on.mock.calls.find(
-        (c: unknown[]) => c[0] === "data",
-      )?.[1];
-      stderrCb(Buffer.from("https://a.trycloudflare.com"));
+      const stderrCb1 = getStderrCallback(mockProcess);
+      stderrCb1(Buffer.from("https://a.trycloudflare.com"));
       await p1;
 
-      // Reset mock for second spawn
-      vi.clearAllMocks();
+      // Save reference to first process's kill before clearing listener mocks
+      const firstKill = mockProcess.kill;
+
+      // Clear only listener mocks (not kill) for second spawn
+      mockProcess.stderr.on.mockClear();
+      mockProcess.stdout.on.mockClear();
+      mockProcess.on.mockClear();
+
       const mockProcess2 = {
         stderr: { on: vi.fn() },
         stdout: { on: vi.fn() },
@@ -168,10 +174,8 @@ describe("TunnelManager", () => {
       mockSpawn.mockReturnValue(mockProcess2);
 
       const p2 = manager.create("plugin-2", 3002);
-      stderrCb = mockProcess2.stderr.on.mock.calls.find(
-        (c: unknown[]) => c[0] === "data",
-      )?.[1];
-      stderrCb(Buffer.from("https://b.trycloudflare.com"));
+      const stderrCb2 = getStderrCallback(mockProcess2);
+      stderrCb2(Buffer.from("https://b.trycloudflare.com"));
       await p2;
 
       const destroyPromise = manager.destroyAll();
@@ -179,6 +183,8 @@ describe("TunnelManager", () => {
       await vi.advanceTimersByTimeAsync(6_000);
       await destroyPromise;
 
+      expect(firstKill).toHaveBeenCalled();
+      expect(mockProcess2.kill).toHaveBeenCalled();
       expect(manager.getUrl("plugin-1")).toBeNull();
       expect(manager.getUrl("plugin-2")).toBeNull();
     });

--- a/apps/desktop/sidecar/tunnel/__tests__/manager.test.ts
+++ b/apps/desktop/sidecar/tunnel/__tests__/manager.test.ts
@@ -80,10 +80,49 @@ describe("TunnelManager", () => {
     it("returns null for unknown plugin", () => {
       expect(manager.getUrl("nonexistent")).toBeNull();
     });
+
+    it("rejects on startup timeout", async () => {
+      const createPromise = manager.create("test-plugin", 3000);
+
+      // Advance past the 30s timeout
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      await expect(createPromise).rejects.toThrow("Tunnel startup timed out");
+      expect(mockProcess.kill).toHaveBeenCalled();
+      expect(manager.getUrl("test-plugin")).toBeNull();
+    });
+
+    it("rejects on premature process exit", async () => {
+      const createPromise = manager.create("test-plugin", 3000);
+
+      // Simulate process exit before URL is found
+      const exitCallback = mockProcess.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "exit",
+      )?.[1];
+      expect(exitCallback).toBeDefined();
+      exitCallback(1);
+
+      await expect(createPromise).rejects.toThrow("cloudflared exited with code 1");
+      expect(manager.getUrl("test-plugin")).toBeNull();
+    });
+
+    it("rejects on spawn error", async () => {
+      const createPromise = manager.create("test-plugin", 3000);
+
+      // Simulate spawn error
+      const errorCallback = mockProcess.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "error",
+      )?.[1];
+      expect(errorCallback).toBeDefined();
+      errorCallback(new Error("ENOENT: cloudflared not found"));
+
+      await expect(createPromise).rejects.toThrow("ENOENT: cloudflared not found");
+      expect(manager.getUrl("test-plugin")).toBeNull();
+    });
   });
 
   describe("destroy", () => {
-    it("kills the tunnel process", async () => {
+    it("kills the tunnel process and waits for exit", async () => {
       // Set up a tunnel first
       const createPromise = manager.create("test-plugin", 3000);
       const stderrCallback = mockProcess.stderr.on.mock.calls.find(
@@ -92,7 +131,13 @@ describe("TunnelManager", () => {
       stderrCallback(Buffer.from("https://abc.trycloudflare.com"));
       await createPromise;
 
-      await manager.destroy("test-plugin");
+      // destroy calls kill() then waits for exit (or timeout)
+      const destroyPromise = manager.destroy("test-plugin");
+
+      // Advance past DESTROY_TIMEOUT_MS to let the wait resolve
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      await destroyPromise;
       expect(mockProcess.kill).toHaveBeenCalled();
       expect(manager.getUrl("test-plugin")).toBeNull();
     });
@@ -129,7 +174,11 @@ describe("TunnelManager", () => {
       stderrCb(Buffer.from("https://b.trycloudflare.com"));
       await p2;
 
-      await manager.destroyAll();
+      const destroyPromise = manager.destroyAll();
+      // Let destroy timeouts elapse
+      await vi.advanceTimersByTimeAsync(6_000);
+      await destroyPromise;
+
       expect(manager.getUrl("plugin-1")).toBeNull();
       expect(manager.getUrl("plugin-2")).toBeNull();
     });

--- a/apps/desktop/sidecar/tunnel/binary.ts
+++ b/apps/desktop/sidecar/tunnel/binary.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+const CLOUDFLARED_RELEASES = "https://github.com/cloudflare/cloudflared/releases/latest/download";
+
+function getPlatformBinary(): { url: string; name: string } {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === "win32") {
+    return { url: `${CLOUDFLARED_RELEASES}/cloudflared-windows-amd64.exe`, name: "cloudflared.exe" };
+  }
+  if (platform === "darwin") {
+    const suffix = arch === "arm64" ? "darwin-arm64" : "darwin-amd64";
+    return { url: `${CLOUDFLARED_RELEASES}/cloudflared-${suffix}.tgz`, name: "cloudflared" };
+  }
+  // Linux
+  const suffix = arch === "arm64" ? "linux-arm64" : "linux-amd64";
+  return { url: `${CLOUDFLARED_RELEASES}/cloudflared-${suffix}`, name: "cloudflared" };
+}
+
+function findInPath(): string | null {
+  try {
+    const cmd = process.platform === "win32" ? "where cloudflared" : "which cloudflared";
+    const result = execSync(cmd, { encoding: "utf-8", timeout: 5000 }).trim();
+    if (result) return result.split("\n")[0]!.trim();
+  } catch {
+    // Not in PATH
+  }
+  return null;
+}
+
+/**
+ * Ensure the `cloudflared` binary is available.
+ * Checks PATH first, then checks the local cache, then downloads.
+ */
+export async function ensureCloudflared(dataDir: string): Promise<string> {
+  // 1. Check PATH
+  const pathBinary = findInPath();
+  if (pathBinary) {
+    console.error(`[tunnel] Found cloudflared in PATH: ${pathBinary}`);
+    return pathBinary;
+  }
+
+  // 2. Check local cache
+  const { url, name } = getPlatformBinary();
+  const binDir = path.join(dataDir, "bin");
+  const localPath = path.join(binDir, name);
+
+  if (fs.existsSync(localPath)) {
+    console.error(`[tunnel] Using cached cloudflared: ${localPath}`);
+    return localPath;
+  }
+
+  // 3. Download
+  console.error(`[tunnel] Downloading cloudflared from ${url}...`);
+  fs.mkdirSync(binDir, { recursive: true });
+
+  const response = await fetch(url, { redirect: "follow" });
+  if (!response.ok) {
+    throw new Error(`Failed to download cloudflared: ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+
+  if (url.endsWith(".tgz")) {
+    // macOS comes as tgz — extract
+    const tmpPath = path.join(binDir, "cloudflared.tgz");
+    fs.writeFileSync(tmpPath, buffer);
+    execSync(`tar -xzf "${tmpPath}" -C "${binDir}"`, { timeout: 30_000 });
+    fs.unlinkSync(tmpPath);
+  } else {
+    fs.writeFileSync(localPath, buffer);
+  }
+
+  // Make executable on Unix
+  if (process.platform !== "win32") {
+    fs.chmodSync(localPath, 0o755);
+  }
+
+  // Verify
+  try {
+    execSync(`"${localPath}" --version`, { encoding: "utf-8", timeout: 10_000 });
+  } catch (err) {
+    throw new Error(`Downloaded cloudflared binary is not working: ${err}`);
+  }
+
+  console.error(`[tunnel] Downloaded cloudflared to ${localPath}`);
+  return localPath;
+}

--- a/apps/desktop/sidecar/tunnel/binary.ts
+++ b/apps/desktop/sidecar/tunnel/binary.ts
@@ -57,7 +57,21 @@ export async function ensureCloudflared(dataDir: string): Promise<string> {
   console.error(`[tunnel] Downloading cloudflared from ${url}...`);
   fs.mkdirSync(binDir, { recursive: true });
 
-  const response = await fetch(url, { redirect: "follow" });
+  const controller = new AbortController();
+  const downloadTimeout = setTimeout(() => controller.abort(), 120_000); // 2 min timeout
+
+  let response: Response;
+  try {
+    response = await fetch(url, { redirect: "follow", signal: controller.signal });
+  } catch (err) {
+    clearTimeout(downloadTimeout);
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new Error("Cloudflared download timed out after 120s");
+    }
+    throw err;
+  }
+  clearTimeout(downloadTimeout);
+
   if (!response.ok) {
     throw new Error(`Failed to download cloudflared: ${response.status} ${response.statusText}`);
   }

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -1,0 +1,122 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { ensureCloudflared } from "./binary";
+
+interface TunnelInstance {
+  pluginId: string;
+  localPort: number;
+  url: string;
+  process: ChildProcess;
+}
+
+const TUNNEL_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+const STARTUP_TIMEOUT_MS = 30_000;
+
+export class TunnelManager {
+  private tunnels = new Map<string, TunnelInstance>();
+  private cloudflaredPath: string | null = null;
+  private dataDir: string;
+
+  constructor(dataDir: string) {
+    this.dataDir = dataDir;
+  }
+
+  /**
+   * Create a Cloudflare quick tunnel pointing at localhost:{port}.
+   * Returns the public HTTPS URL (e.g. https://xxx.trycloudflare.com).
+   */
+  async create(pluginId: string, localPort: number): Promise<string> {
+    // Destroy any existing tunnel for this plugin
+    await this.destroy(pluginId);
+
+    if (!this.cloudflaredPath) {
+      this.cloudflaredPath = await ensureCloudflared(this.dataDir);
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const child = spawn(this.cloudflaredPath!, [
+        "tunnel",
+        "--url",
+        `http://localhost:${localPort}`,
+        "--no-autoupdate",
+      ], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          child.kill();
+          reject(new Error(`Tunnel startup timed out after ${STARTUP_TIMEOUT_MS}ms`));
+        }
+      }, STARTUP_TIMEOUT_MS);
+
+      const handleData = (data: Buffer) => {
+        const line = data.toString();
+        if (resolved) return;
+
+        const match = TUNNEL_URL_REGEX.exec(line);
+        if (match) {
+          resolved = true;
+          clearTimeout(timeout);
+
+          const url = match[0];
+          this.tunnels.set(pluginId, { pluginId, localPort, url, process: child });
+          console.error(`[tunnel] Created tunnel for ${pluginId}: ${url}`);
+          resolve(url);
+        }
+      };
+
+      // cloudflared outputs the URL to stderr
+      child.stderr?.on("data", handleData);
+      child.stdout?.on("data", handleData);
+
+      child.on("error", (err) => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          reject(err);
+        }
+      });
+
+      child.on("exit", (code) => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          reject(new Error(`cloudflared exited with code ${code} before tunnel was ready`));
+        }
+        this.tunnels.delete(pluginId);
+      });
+    });
+  }
+
+  /**
+   * Destroy the tunnel for a plugin.
+   */
+  async destroy(pluginId: string): Promise<void> {
+    const tunnel = this.tunnels.get(pluginId);
+    if (!tunnel) return;
+
+    tunnel.process.kill();
+    this.tunnels.delete(pluginId);
+    console.error(`[tunnel] Destroyed tunnel for ${pluginId}`);
+  }
+
+  /**
+   * Destroy all active tunnels (graceful shutdown).
+   */
+  async destroyAll(): Promise<void> {
+    const ids = [...this.tunnels.keys()];
+    for (const id of ids) {
+      await this.destroy(id);
+    }
+  }
+
+  /**
+   * Get the current tunnel URL for a plugin, or null if no tunnel exists.
+   */
+  getUrl(pluginId: string): string | null {
+    return this.tunnels.get(pluginId)?.url ?? null;
+  }
+}

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -91,14 +91,34 @@ export class TunnelManager {
     });
   }
 
+  private static readonly DESTROY_TIMEOUT_MS = 5_000;
+
   /**
-   * Destroy the tunnel for a plugin.
+   * Destroy the tunnel for a plugin, waiting for the process to exit.
    */
   async destroy(pluginId: string): Promise<void> {
     const tunnel = this.tunnels.get(pluginId);
     if (!tunnel) return;
 
     tunnel.process.kill();
+
+    // Wait for the process to actually exit (with timeout)
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        resolve();
+      }, TunnelManager.DESTROY_TIMEOUT_MS);
+
+      tunnel.process.on("exit", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      tunnel.process.on("error", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
     this.tunnels.delete(pluginId);
     console.error(`[tunnel] Destroyed tunnel for ${pluginId}`);
   }

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -29,6 +29,8 @@ interface PluginInfo {
   rightPanel: boolean;
   status: "running" | "stopped" | "crashed" | "starting";
   port: number;
+  scope: "server" | "personal";
+  tunnelUrl: string | null;
   permissions: string[];
 }
 

--- a/apps/server/drizzle/0016_add_server_plugins.sql
+++ b/apps/server/drizzle/0016_add_server_plugins.sql
@@ -1,0 +1,21 @@
+-- Create server_plugin_state enum
+DO $$ BEGIN
+  CREATE TYPE "server_plugin_state" AS ENUM ('active', 'stopped', 'error');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+
+-- Create server_plugins table
+CREATE TABLE "server_plugins" (
+  "id" text PRIMARY KEY NOT NULL,
+  "server_id" text NOT NULL REFERENCES "servers"("id") ON DELETE CASCADE,
+  "plugin_id" text NOT NULL,
+  "installed_by" text NOT NULL REFERENCES "user"("id") ON DELETE RESTRICT,
+  "installed_at" timestamp DEFAULT now() NOT NULL,
+  "config" text,
+  "tunnel_url" text,
+  "state" "server_plugin_state" DEFAULT 'stopped' NOT NULL,
+  CONSTRAINT "server_plugins_server_plugin" UNIQUE("server_id", "plugin_id")
+);--> statement-breakpoint
+
+CREATE INDEX "server_plugins_server_id_idx" ON "server_plugins" ("server_id");

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1743177600000,
       "tag": "0015_add_plugin_installs",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1743264000000,
+      "tag": "0016_add_server_plugins",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -444,6 +444,34 @@ export const pollVotes = pgTable(
 
 // ─── Plugin Tables ──────────────────────────────────────────
 
+export const serverPluginStateEnum = pgEnum("server_plugin_state", [
+  "active",
+  "stopped",
+  "error",
+]);
+
+export const serverPlugins = pgTable(
+  "server_plugins",
+  {
+    id: id(),
+    serverId: text("server_id")
+      .notNull()
+      .references(() => servers.id, { onDelete: "cascade" }),
+    pluginId: text("plugin_id").notNull(),
+    installedBy: text("installed_by")
+      .notNull()
+      .references(() => user.id, { onDelete: "restrict" }),
+    installedAt: timestamp("installed_at", { mode: "date" }).defaultNow().notNull(),
+    config: text("config"),
+    tunnelUrl: text("tunnel_url"),
+    state: serverPluginStateEnum("state").default("stopped").notNull(),
+  },
+  (t) => [
+    unique("server_plugins_server_plugin").on(t.serverId, t.pluginId),
+    index("server_plugins_server_id_idx").on(t.serverId),
+  ],
+);
+
 export const pluginInstalls = pgTable(
   "plugin_installs",
   {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -24,6 +24,7 @@ import { turnRoutes } from "./routes/turn.js";
 import { fileReceiptRoutes } from "./routes/file-receipts.js";
 import { botRoutes, botAvatarRoutes } from "./routes/bots.js";
 import { pluginRoutes } from "./routes/plugins.js";
+import { serverPluginRoutes } from "./routes/server-plugins.js";
 import { gatewayTicketRoutes } from "./routes/gateway.js";
 import { gateway } from "./ws/gateway.js";
 import { subscribeCacheInvalidation, PubSubChannel } from "./lib/redis-pubsub.js";
@@ -85,6 +86,7 @@ const app = new Elysia()
   .use(botRoutes)
   .use(botAvatarRoutes)
   .use(pluginRoutes)
+  .use(serverPluginRoutes)
   .use(gatewayTicketRoutes)
   .use(gateway)
   .get("/health", () => ({ status: "ok" }))

--- a/apps/server/src/routes/__tests__/server-plugins.test.ts
+++ b/apps/server/src/routes/__tests__/server-plugins.test.ts
@@ -1,0 +1,262 @@
+/* oxlint-disable eslint(no-shadow) -- vi.hoisted destructuring pattern */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { mockRequireMember, mockRequireOwner, mockComputeEffectiveTier, selectResults, mockDb, deletedRows, insertedRow } =
+  vi.hoisted(() => {
+    const mockRequireMember = vi.fn().mockResolvedValue({});
+    const mockRequireOwner = vi.fn().mockResolvedValue({ ownerId: "owner1" });
+    const mockComputeEffectiveTier = vi.fn().mockResolvedValue("server_owner");
+
+    const selectResults: unknown[][] = [];
+    const deletedRows: unknown[][] = [];
+    const insertedRow: unknown[] = [];
+
+    const mockDb = {
+      select: vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() =>
+            Promise.resolve(selectResults.shift() ?? []),
+          ),
+        }),
+      })),
+      insert: vi.fn().mockImplementation(() => ({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockImplementation(() => {
+              const row = insertedRow.shift();
+              return Promise.resolve(row ? [row] : []);
+            }),
+          }),
+        }),
+      })),
+      delete: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockImplementation(() =>
+            Promise.resolve(deletedRows.shift() ?? []),
+          ),
+        }),
+      })),
+      update: vi.fn().mockImplementation(() => ({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockImplementation(() =>
+              Promise.resolve(selectResults.shift() ?? []),
+            ),
+          }),
+        }),
+      })),
+    };
+
+    return { mockRequireMember, mockRequireOwner, mockComputeEffectiveTier, selectResults, mockDb, deletedRows, insertedRow };
+  });
+
+// ── Module mocks ───────────────────────────────────────────────────────────
+
+vi.mock("drizzle-orm", () => ({ eq: vi.fn(), and: vi.fn() }));
+vi.mock("../../db/index.js", () => ({ db: mockDb }));
+vi.mock("../../db/schema.js", () => ({
+  serverPlugins: {
+    id: "server_plugins.id",
+    serverId: "server_plugins.server_id",
+    pluginId: "server_plugins.plugin_id",
+    installedBy: "server_plugins.installed_by",
+    tunnelUrl: "server_plugins.tunnel_url",
+    state: "server_plugins.state",
+  },
+}));
+vi.mock("../../helpers/permissions.js", () => ({
+  requireMember: mockRequireMember,
+  requireOwner: mockRequireOwner,
+}));
+vi.mock("../../helpers/resolve-tier.js", () => ({
+  computeEffectiveTier: mockComputeEffectiveTier,
+}));
+vi.mock("../../middleware/auth.js", () => ({
+  authResolve: () => () => ({ user: { id: "user1" }, session: {} }),
+}));
+
+// ── Import the Elysia instance (after mocks) ──────────────────────────────
+
+import { Elysia } from "elysia";
+import { AppError } from "@uncorded/shared";
+import { serverPluginRoutes } from "../server-plugins.js";
+
+// Wrap with error handler like the real app does
+const app = new Elysia()
+  .use(serverPluginRoutes)
+  .onError(({ error, set }) => {
+    if (error instanceof AppError) {
+      set.status = error.statusCode;
+      return { code: error.code, message: error.message };
+    }
+    set.status = 500;
+    return { code: "INTERNAL", message: "Internal server error" };
+  });
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(method: string, path: string, body?: unknown): Promise<Response> {
+  const opts: RequestInit = {
+    method,
+    headers: { "content-type": "application/json" },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  return app.handle(
+    new Request(`http://localhost${path}`, opts),
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("server plugin routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectResults.length = 0;
+    deletedRows.length = 0;
+    insertedRow.length = 0;
+    mockRequireMember.mockResolvedValue({});
+    mockRequireOwner.mockResolvedValue({ ownerId: "owner1" });
+    mockComputeEffectiveTier.mockResolvedValue("server_owner");
+  });
+
+  // ── GET /api/servers/:serverId/plugins ──────────────────────────────────
+
+  describe("GET /api/servers/:serverId/plugins", () => {
+    it("returns installed plugins for members", async () => {
+      selectResults.push([
+        {
+          id: "sp1",
+          pluginId: "claude-code",
+          state: "active",
+          tunnelUrl: "https://abc.trycloudflare.com",
+          installedBy: "owner1",
+          installedAt: new Date("2026-01-01"),
+          config: null,
+        },
+      ]);
+
+      const res = await makeRequest("GET", "/api/servers/server1/plugins");
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.plugins).toHaveLength(1);
+      expect(data.plugins[0].pluginId).toBe("claude-code");
+      expect(mockRequireMember).toHaveBeenCalledWith("user1", "server1");
+    });
+
+    it("calls requireMember for authorization", async () => {
+      selectResults.push([]);
+      await makeRequest("GET", "/api/servers/server1/plugins");
+      expect(mockRequireMember).toHaveBeenCalledWith("user1", "server1");
+    });
+  });
+
+  // ── POST /api/servers/:serverId/plugins ─────────────────────────────────
+
+  describe("POST /api/servers/:serverId/plugins", () => {
+    it("installs a plugin for server_owner tier users", async () => {
+      insertedRow.push({
+        id: "sp1",
+        pluginId: "claude-code",
+        serverId: "server1",
+        state: "stopped",
+      });
+
+      const res = await makeRequest("POST", "/api/servers/server1/plugins", {
+        pluginId: "claude-code",
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(mockRequireOwner).toHaveBeenCalledWith("user1", "server1");
+    });
+
+    it("rejects non-server_owner tier users", async () => {
+      mockComputeEffectiveTier.mockResolvedValueOnce("supporter");
+
+      const res = await makeRequest("POST", "/api/servers/server1/plugins", {
+        pluginId: "claude-code",
+      });
+      // ForbiddenError → 403 in production (with global error handler)
+      expect(res.ok).toBe(false);
+    });
+
+    it("rejects free tier users", async () => {
+      mockComputeEffectiveTier.mockResolvedValueOnce("free");
+
+      const res = await makeRequest("POST", "/api/servers/server1/plugins", {
+        pluginId: "claude-code",
+      });
+      expect(res.ok).toBe(false);
+    });
+  });
+
+  // ── DELETE /api/servers/:serverId/plugins/:pluginId ─────────────────────
+
+  describe("DELETE /api/servers/:serverId/plugins/:pluginId", () => {
+    it("uninstalls a plugin for the owner", async () => {
+      deletedRows.push([{ id: "sp1" }]);
+
+      const res = await makeRequest("DELETE", "/api/servers/server1/plugins/claude-code");
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(mockRequireOwner).toHaveBeenCalledWith("user1", "server1");
+    });
+
+    it("returns error when plugin not found", async () => {
+      deletedRows.push([]);
+
+      const res = await makeRequest("DELETE", "/api/servers/server1/plugins/nonexistent");
+      expect(res.ok).toBe(false);
+    });
+  });
+
+  // ── GET /api/servers/:serverId/plugins/:pluginId/tunnel ─────────────────
+
+  describe("GET /api/servers/:serverId/plugins/:pluginId/tunnel", () => {
+    it("returns tunnel URL for members", async () => {
+      selectResults.push([
+        { tunnelUrl: "https://abc.trycloudflare.com", state: "active" },
+      ]);
+
+      const res = await makeRequest("GET", "/api/servers/server1/plugins/claude-code/tunnel");
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.tunnelUrl).toBe("https://abc.trycloudflare.com");
+      expect(data.state).toBe("active");
+    });
+
+    it("returns error when plugin not found", async () => {
+      selectResults.push([]);
+
+      const res = await makeRequest("GET", "/api/servers/server1/plugins/nonexistent/tunnel");
+      expect(res.ok).toBe(false);
+    });
+  });
+
+  // ── PUT /api/servers/:serverId/plugins/:pluginId/tunnel ─────────────────
+
+  describe("PUT /api/servers/:serverId/plugins/:pluginId/tunnel", () => {
+    it("updates tunnel URL for the owner", async () => {
+      selectResults.push([
+        { id: "sp1", tunnelUrl: "https://new.trycloudflare.com" },
+      ]);
+
+      const res = await makeRequest("PUT", "/api/servers/server1/plugins/claude-code/tunnel", {
+        tunnelUrl: "https://new.trycloudflare.com",
+        state: "active",
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(mockRequireOwner).toHaveBeenCalledWith("user1", "server1");
+    });
+  });
+});

--- a/apps/server/src/routes/__tests__/server-plugins.test.ts
+++ b/apps/server/src/routes/__tests__/server-plugins.test.ts
@@ -76,6 +76,9 @@ vi.mock("../../helpers/resolve-tier.js", () => ({
 vi.mock("../../middleware/auth.js", () => ({
   authResolve: () => () => ({ user: { id: "user1" }, session: {} }),
 }));
+vi.mock("../../middleware/ip-rate-limit.js", () => ({
+  checkIpRateLimit: vi.fn().mockResolvedValue(true),
+}));
 
 // ── Import the Elysia instance (after mocks) ──────────────────────────────
 
@@ -212,6 +215,57 @@ describe("server plugin routes", () => {
       deletedRows.push([]);
 
       const res = await makeRequest("DELETE", "/api/servers/server1/plugins/nonexistent");
+      expect(res.ok).toBe(false);
+    });
+  });
+
+  // ── PATCH /api/servers/:serverId/plugins/:pluginId ───────────────────────
+
+  describe("PATCH /api/servers/:serverId/plugins/:pluginId", () => {
+    it("updates config successfully", async () => {
+      selectResults.push([
+        { id: "sp1", pluginId: "claude-code", state: "stopped", config: '{"key":"val"}' },
+      ]);
+
+      const res = await makeRequest("PATCH", "/api/servers/server1/plugins/claude-code", {
+        config: { key: "new-val" },
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(mockRequireOwner).toHaveBeenCalledWith("user1", "server1");
+    });
+
+    it("updates state successfully", async () => {
+      selectResults.push([
+        { id: "sp1", pluginId: "claude-code", state: "active" },
+      ]);
+
+      const res = await makeRequest("PATCH", "/api/servers/server1/plugins/claude-code", {
+        state: "stopped",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects empty update", async () => {
+      const res = await makeRequest("PATCH", "/api/servers/server1/plugins/claude-code", {});
+      expect(res.ok).toBe(false);
+    });
+
+    it("returns error when plugin not found", async () => {
+      selectResults.push([]);
+
+      const res = await makeRequest("PATCH", "/api/servers/server1/plugins/nonexistent", {
+        state: "stopped",
+      });
+      expect(res.ok).toBe(false);
+    });
+
+    it("rejects invalid state value", async () => {
+      const res = await makeRequest("PATCH", "/api/servers/server1/plugins/claude-code", {
+        state: "invalid-state",
+      });
       expect(res.ok).toBe(false);
     });
   });

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -25,6 +25,7 @@ const PLUGIN_CATALOG = [
     author: "UnCorded",
     icon: null,
     category: "AI",
+    scope: "both" as const,
     tags: ["ai", "developer-tools", "automation"],
   },
 ] as const;

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -1,0 +1,186 @@
+import { Elysia } from "elysia";
+import { eq, and } from "drizzle-orm";
+import { ForbiddenError, NotFoundError } from "@uncorded/shared";
+import { db } from "../db/index.js";
+import { serverPlugins } from "../db/schema.js";
+import { authResolve } from "../middleware/auth.js";
+import { requireMember, requireOwner } from "../helpers/permissions.js";
+import { computeEffectiveTier } from "../helpers/resolve-tier.js";
+
+// ── Routes ──────────────────────────────────────────────────────────────────
+
+export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/plugins" })
+  .resolve(authResolve())
+
+  // ── GET / — list installed server plugins (any member) ──────────────────
+  .get("/", async ({ user: sessionUser, params }) => {
+    await requireMember(sessionUser.id, params.serverId);
+
+    const rows = await db
+      .select()
+      .from(serverPlugins)
+      .where(eq(serverPlugins.serverId, params.serverId));
+
+    return {
+      plugins: rows.map((r) => ({
+        id: r.id,
+        pluginId: r.pluginId,
+        state: r.state,
+        tunnelUrl: r.tunnelUrl,
+        installedBy: r.installedBy,
+        installedAt: r.installedAt.toISOString(),
+        config: r.config ? JSON.parse(r.config) : {},
+      })),
+    };
+  })
+
+  // ── POST / — install server plugin (owner only, server_owner tier) ──────
+  .post("/", async ({ user: sessionUser, params, body }) => {
+    await requireOwner(sessionUser.id, params.serverId);
+
+    const tier = await computeEffectiveTier(sessionUser.id);
+    if (tier !== "server_owner") {
+      throw new ForbiddenError("Server Owner subscription required to install server plugins");
+    }
+
+    const { pluginId } = body as { pluginId: string };
+    if (!pluginId || typeof pluginId !== "string") {
+      throw new ForbiddenError("pluginId is required");
+    }
+
+    // Upsert — ignore if already installed
+    const [row] = await db
+      .insert(serverPlugins)
+      .values({
+        serverId: params.serverId,
+        pluginId,
+        installedBy: sessionUser.id,
+      })
+      .onConflictDoNothing({
+        target: [serverPlugins.serverId, serverPlugins.pluginId],
+      })
+      .returning();
+
+    // If conflict (already installed), fetch existing
+    if (!row) {
+      const [existing] = await db
+        .select()
+        .from(serverPlugins)
+        .where(
+          and(
+            eq(serverPlugins.serverId, params.serverId),
+            eq(serverPlugins.pluginId, pluginId),
+          ),
+        );
+      return { success: true, serverPlugin: existing };
+    }
+
+    return { success: true, serverPlugin: row };
+  })
+
+  // ── DELETE /:pluginId — uninstall server plugin (owner only) ────────────
+  .delete("/:pluginId", async ({ user: sessionUser, params }) => {
+    await requireOwner(sessionUser.id, params.serverId);
+
+    const deleted = await db
+      .delete(serverPlugins)
+      .where(
+        and(
+          eq(serverPlugins.serverId, params.serverId),
+          eq(serverPlugins.pluginId, params.pluginId),
+        ),
+      )
+      .returning();
+
+    if (deleted.length === 0) {
+      throw new NotFoundError("Server plugin");
+    }
+
+    return { success: true };
+  })
+
+  // ── PATCH /:pluginId — update config/state (owner only) ────────────────
+  .patch("/:pluginId", async ({ user: sessionUser, params, body }) => {
+    await requireOwner(sessionUser.id, params.serverId);
+
+    const updates = body as { config?: Record<string, unknown>; state?: string };
+    const setValues: Record<string, unknown> = {};
+
+    if (updates.config !== undefined) {
+      setValues.config = JSON.stringify(updates.config);
+    }
+    if (updates.state !== undefined) {
+      setValues.state = updates.state;
+    }
+
+    if (Object.keys(setValues).length === 0) {
+      throw new ForbiddenError("No fields to update");
+    }
+
+    const [updated] = await db
+      .update(serverPlugins)
+      .set(setValues)
+      .where(
+        and(
+          eq(serverPlugins.serverId, params.serverId),
+          eq(serverPlugins.pluginId, params.pluginId),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundError("Server plugin");
+    }
+
+    return { success: true, serverPlugin: updated };
+  })
+
+  // ── GET /:pluginId/tunnel — get tunnel URL (any member) ────────────────
+  .get("/:pluginId/tunnel", async ({ user: sessionUser, params }) => {
+    await requireMember(sessionUser.id, params.serverId);
+
+    const [row] = await db
+      .select({ tunnelUrl: serverPlugins.tunnelUrl, state: serverPlugins.state })
+      .from(serverPlugins)
+      .where(
+        and(
+          eq(serverPlugins.serverId, params.serverId),
+          eq(serverPlugins.pluginId, params.pluginId),
+        ),
+      );
+
+    if (!row) {
+      throw new NotFoundError("Server plugin");
+    }
+
+    return { tunnelUrl: row.tunnelUrl, state: row.state };
+  })
+
+  // ── PUT /:pluginId/tunnel — update tunnel URL (owner, called by sidecar)
+  .put("/:pluginId/tunnel", async ({ user: sessionUser, params, body }) => {
+    await requireOwner(sessionUser.id, params.serverId);
+
+    const { tunnelUrl, state } = body as { tunnelUrl: string | null; state?: string };
+
+    const setValues: Record<string, unknown> = { tunnelUrl };
+    if (state !== undefined) {
+      setValues.state = state;
+    }
+
+    const [updated] = await db
+      .update(serverPlugins)
+      .set(setValues)
+      .where(
+        and(
+          eq(serverPlugins.serverId, params.serverId),
+          eq(serverPlugins.pluginId, params.pluginId),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundError("Server plugin");
+    }
+
+    return { success: true, tunnelUrl: updated.tunnelUrl };
+  });

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -1,11 +1,33 @@
 import { Elysia } from "elysia";
 import { eq, and } from "drizzle-orm";
-import { ForbiddenError, NotFoundError } from "@uncorded/shared";
+import { ForbiddenError, NotFoundError, ValidationError, RateLimitError } from "@uncorded/shared";
 import { db } from "../db/index.js";
 import { serverPlugins } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
 import { requireMember, requireOwner } from "../helpers/permissions.js";
 import { computeEffectiveTier } from "../helpers/resolve-tier.js";
+import { checkIpRateLimit } from "../middleware/ip-rate-limit.js";
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const VALID_STATES = new Set(["active", "stopped", "error"]);
+
+function getClientIp(request: Request): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+function safeJsonParse(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    return JSON.parse(value) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
 
 // ── Routes ──────────────────────────────────────────────────────────────────
 
@@ -29,13 +51,18 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
         tunnelUrl: r.tunnelUrl,
         installedBy: r.installedBy,
         installedAt: r.installedAt.toISOString(),
-        config: r.config ? JSON.parse(r.config) : {},
+        config: safeJsonParse(r.config),
       })),
     };
   })
 
   // ── POST / — install server plugin (owner only, server_owner tier) ──────
-  .post("/", async ({ user: sessionUser, params, body }) => {
+  .post("/", async ({ user: sessionUser, params, body, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 10, 60_000, "server-plugin-install"))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
+
     await requireOwner(sessionUser.id, params.serverId);
 
     const tier = await computeEffectiveTier(sessionUser.id);
@@ -79,7 +106,12 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
   })
 
   // ── DELETE /:pluginId — uninstall server plugin (owner only) ────────────
-  .delete("/:pluginId", async ({ user: sessionUser, params }) => {
+  .delete("/:pluginId", async ({ user: sessionUser, params, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 10, 60_000, "server-plugin-uninstall"))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
+
     await requireOwner(sessionUser.id, params.serverId);
 
     const deleted = await db
@@ -110,6 +142,9 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
       setValues.config = JSON.stringify(updates.config);
     }
     if (updates.state !== undefined) {
+      if (!VALID_STATES.has(updates.state)) {
+        throw new ValidationError(`Invalid state: must be one of ${[...VALID_STATES].join(", ")}`);
+      }
       setValues.state = updates.state;
     }
 
@@ -164,6 +199,9 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
 
     const setValues: Record<string, unknown> = { tunnelUrl };
     if (state !== undefined) {
+      if (!VALID_STATES.has(state)) {
+        throw new ValidationError(`Invalid state: must be one of ${[...VALID_STATES].join(", ")}`);
+      }
       setValues.state = state;
     }
 

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -42,6 +42,11 @@ import {
   activePluginId,
   setActivePluginId,
   clearActivePlugin,
+  visibleServerPlugins,
+  activeServerPluginId,
+  setActiveServerPluginId,
+  fetchServerPlugins,
+  clearServerPlugins,
 } from "../stores/plugin-store.js";
 import SupportSheet from "./SupportSheet.js";
 import { showToast } from "./ui/toast.js";
@@ -99,6 +104,16 @@ const AppSidebar = () => {
   const isPaidUser = () =>
     readyData.data?.user.subscriptionTier !== undefined &&
     readyData.data?.user.subscriptionTier !== "free";
+
+  // Fetch server plugins when switching servers
+  createEffect(() => {
+    const sId = selectedServerId();
+    if (sId) {
+      fetchServerPlugins(sId);
+    } else {
+      clearServerPlugins();
+    }
+  });
 
   const handleLogout = async () => {
     await signOut();
@@ -434,9 +449,45 @@ const AppSidebar = () => {
           </Show>
         </SidebarGroup>
 
-        {/* Plugins — desktop only */}
+        {/* Server Plugins — shown when viewing a server, available to all users */}
+        <Show when={selectedServerId() && visibleServerPlugins().length > 0}>
+          <SidebarGroup label="Server Plugins" collapsible defaultOpen>
+            <SidebarMenu classList={{ hidden: sidebarState() === "collapsed" }}>
+              <For each={visibleServerPlugins()}>
+                {(plugin) => {
+                  const isActive = () => activeServerPluginId() === plugin.pluginId;
+                  return (
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        tooltip={plugin.pluginId}
+                        active={isActive()}
+                        onClick={() => {
+                          setActiveServerPluginId(plugin.pluginId);
+                          clearActivePlugin();
+                          const sId = selectedServerId();
+                          if (sId) navigate(`/servers/${sId}`);
+                          closeMobile();
+                        }}
+                      >
+                        <span class="relative flex h-4 w-4 shrink-0 items-center justify-center">
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5" />
+                          </svg>
+                          <span class="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-success" aria-hidden="true" />
+                        </span>
+                        <span class="truncate">{plugin.pluginId}</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                }}
+              </For>
+            </SidebarMenu>
+          </SidebarGroup>
+        </Show>
+
+        {/* My Plugins — desktop only, shown when in DMs/home or always for personal plugins */}
         <Show when={isDesktop() && visiblePlugins().length > 0}>
-          <SidebarGroup label="Plugins" collapsible defaultOpen>
+          <SidebarGroup label={selectedServerId() ? "My Plugins" : "Plugins"} collapsible defaultOpen>
             <SidebarMenu classList={{ hidden: sidebarState() === "collapsed" }}>
               <For each={visiblePlugins()}>
                 {(plugin) => {
@@ -456,6 +507,7 @@ const AppSidebar = () => {
                         active={isPluginActive()}
                         onClick={() => {
                           setActivePluginId(plugin.id);
+                          setActiveServerPluginId(null);
                           const sId = selectedServerId();
                           if (sId) navigate(`/servers/${sId}`);
                           closeMobile();

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -456,10 +456,16 @@ const AppSidebar = () => {
               <For each={visibleServerPlugins()}>
                 {(plugin) => {
                   const isActive = () => activeServerPluginId() === plugin.pluginId;
+                  // Format pluginId as display name: "claude-code" → "Claude Code"
+                  const displayName = () =>
+                    plugin.pluginId
+                      .split(/[-_]/)
+                      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+                      .join(" ");
                   return (
                     <SidebarMenuItem>
                       <SidebarMenuButton
-                        tooltip={plugin.pluginId}
+                        tooltip={displayName()}
                         active={isActive()}
                         onClick={() => {
                           setActiveServerPluginId(plugin.pluginId);
@@ -475,7 +481,7 @@ const AppSidebar = () => {
                           </svg>
                           <span class="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-success" aria-hidden="true" />
                         </span>
-                        <span class="truncate">{plugin.pluginId}</span>
+                        <span class="truncate">{displayName()}</span>
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                   );

--- a/apps/web/src/components/PluginFrame.tsx
+++ b/apps/web/src/components/PluginFrame.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, on, Show, onMount } from "solid-js";
+import { createSignal, createEffect, Show, onCleanup } from "solid-js";
 import type { PluginInfo } from "../stores/plugin-store.js";
 import { isDesktop } from "../stores/plugin-store.js";
 import { Empty } from "./ui/empty.js";
@@ -12,12 +12,6 @@ interface PluginFrameProps {
 const PluginFrame = (props: PluginFrameProps) => {
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal(false);
-
-  // Reset state when switching to a different plugin
-  createEffect(on(() => props.plugin.id, () => {
-    setLoading(true);
-    setError(false);
-  }, { defer: true }));
 
   const isCrashed = () =>
     props.plugin.status === "crashed" || props.plugin.status === "stopped";
@@ -58,16 +52,21 @@ const PluginFrame = (props: PluginFrameProps) => {
   const timeoutMs = () =>
     (props.tunnelUrl || props.plugin.tunnelUrl) ? 20_000 : 15_000;
 
-  onMount(() => {
-    // Fallback timeout — if iframe doesn't fire load in time, show error
+  // Reactive timeout — restarts when plugin ID or timeout duration changes
+  createEffect(() => {
+    void props.plugin.id; // track plugin switches (SolidJS reactivity)
+    const ms = timeoutMs();
+    setLoading(true);
+    setError(false);
+
     const timeout = setTimeout(() => {
       if (loading()) {
         setLoading(false);
         setError(true);
       }
-    }, timeoutMs());
+    }, ms);
 
-    return () => clearTimeout(timeout);
+    onCleanup(() => clearTimeout(timeout));
   });
 
   return (

--- a/apps/web/src/components/PluginFrame.tsx
+++ b/apps/web/src/components/PluginFrame.tsx
@@ -5,6 +5,8 @@ import { Empty } from "./ui/empty.js";
 
 interface PluginFrameProps {
   plugin: PluginInfo;
+  /** Override URL for server plugins loaded via tunnel */
+  tunnelUrl?: string | null;
 }
 
 const PluginFrame = (props: PluginFrameProps) => {
@@ -39,14 +41,31 @@ const PluginFrame = (props: PluginFrameProps) => {
     });
   };
 
+  // Determine the iframe URL based on scope
+  const iframeUrl = () => {
+    // Tunnel URL takes priority (server plugin for browser user)
+    if (props.tunnelUrl) return props.tunnelUrl;
+    // Server plugin with tunnel URL from plugin info
+    if (props.plugin.scope === "server" && props.plugin.tunnelUrl) return props.plugin.tunnelUrl;
+    // Local plugin (personal or server on desktop owner)
+    if (props.plugin.port) return `http://localhost:${props.plugin.port}/`;
+    return null;
+  };
+
+  const isOffline = () => !iframeUrl();
+
+  // Longer timeout for tunnel URLs (network latency)
+  const timeoutMs = () =>
+    (props.tunnelUrl || props.plugin.tunnelUrl) ? 20_000 : 15_000;
+
   onMount(() => {
-    // Fallback timeout — if iframe doesn't fire load within 15s, show error
+    // Fallback timeout — if iframe doesn't fire load in time, show error
     const timeout = setTimeout(() => {
       if (loading()) {
         setLoading(false);
         setError(true);
       }
-    }, 15_000);
+    }, timeoutMs());
 
     return () => clearTimeout(timeout);
   });
@@ -89,10 +108,18 @@ const PluginFrame = (props: PluginFrameProps) => {
         </div>
       </Show>
 
-      {/* iframe — only render when plugin is running */}
-      <Show when={props.plugin.status === "running" && !error()}>
+      {/* Offline state — server plugin with no tunnel URL */}
+      <Show when={isOffline() && !isCrashed() && !error()}>
+        <Empty
+          title="Plugin offline"
+          description={`"${props.plugin.name}" is not currently running on the server owner's machine.`}
+        />
+      </Show>
+
+      {/* iframe — only render when plugin is running and URL is available */}
+      <Show when={(props.plugin.status === "running" || props.tunnelUrl) && !error() && !isOffline()}>
         <iframe
-          src={`http://localhost:${props.plugin.port}/`}
+          src={iframeUrl()!}
           sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
           allow="clipboard-write"
           referrerpolicy="no-referrer"

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createResource, For, Show } from "solid-js";
-import type { ServerId, PluginId } from "@uncorded/protocol";
+import type { ServerId, PluginId, UserId } from "@uncorded/protocol";
 import { api, ApiRequestError } from "../../lib/api.js";
 import { showToast } from "../ui/toast.js";
 import { Button } from "../ui/button.js";
@@ -15,7 +15,7 @@ interface ServerPlugin {
   pluginId: PluginId;
   state: "active" | "stopped" | "error";
   tunnelUrl: string | null;
-  installedBy: string;
+  installedBy: UserId;
   installedAt: string;
   config: Record<string, unknown>;
 }
@@ -45,7 +45,7 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     () => props.serverId,
     async (serverId) => {
       const res = await api<{ plugins: ServerPlugin[] }>(
-        `/api/servers/${serverId}/plugins`,
+        `/api/servers/${encodeURIComponent(serverId)}/plugins`,
       );
       return res.plugins;
     },
@@ -69,7 +69,7 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     if (installing()) return;
     setInstalling(pluginId);
     try {
-      await api(`/api/servers/${props.serverId}/plugins`, {
+      await api(`/api/servers/${encodeURIComponent(props.serverId)}/plugins`, {
         method: "POST",
         body: JSON.stringify({ pluginId }),
       });
@@ -90,7 +90,7 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     if (uninstalling()) return;
     setUninstalling(pluginId);
     try {
-      await api(`/api/servers/${props.serverId}/plugins/${pluginId}`, {
+      await api(`/api/servers/${encodeURIComponent(props.serverId)}/plugins/${encodeURIComponent(pluginId)}`, {
         method: "DELETE",
       });
       mutateInstalled((prev) => prev?.filter((p) => p.pluginId !== pluginId));

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -35,7 +35,7 @@ interface CatalogPlugin {
 
 const ServerPluginsTab = (props: ServerPluginsProps) => {
   const [installing, setInstalling] = createSignal<PluginId | null>(null);
-  const [uninstalling, setUninstalling] = createSignal<string | null>(null);
+  const [uninstalling, setUninstalling] = createSignal<PluginId | null>(null);
 
   const isServerOwnerTier = () =>
     readyData.data?.user.subscriptionTier === "server_owner";
@@ -86,7 +86,7 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     }
   }
 
-  async function handleUninstall(pluginId: string) {
+  async function handleUninstall(pluginId: PluginId) {
     if (uninstalling()) return;
     setUninstalling(pluginId);
     try {

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -1,0 +1,244 @@
+import { createSignal, createResource, For, Show } from "solid-js";
+import type { ServerId, PluginId } from "@uncorded/protocol";
+import { api, ApiRequestError } from "../../lib/api.js";
+import { showToast } from "../ui/toast.js";
+import { Button } from "../ui/button.js";
+import { readyData } from "../../lib/gateway-store.js";
+import { isDesktop } from "../../stores/plugin-store.js";
+
+interface ServerPluginsProps {
+  serverId: ServerId;
+}
+
+interface ServerPlugin {
+  id: string;
+  pluginId: PluginId;
+  state: "active" | "stopped" | "error";
+  tunnelUrl: string | null;
+  installedBy: string;
+  installedAt: string;
+  config: Record<string, unknown>;
+}
+
+interface CatalogPlugin {
+  id: PluginId;
+  name: string;
+  description: string;
+  author: string;
+  icon: string | null;
+  category: string;
+  scope: "server" | "personal" | "both";
+  tags: string[];
+  installCount: number;
+  installed: boolean;
+}
+
+const ServerPluginsTab = (props: ServerPluginsProps) => {
+  const [installing, setInstalling] = createSignal<PluginId | null>(null);
+  const [uninstalling, setUninstalling] = createSignal<string | null>(null);
+
+  const isServerOwnerTier = () =>
+    readyData.data?.user.subscriptionTier === "server_owner";
+
+  // Fetch installed server plugins
+  const [installed, { refetch: refetchInstalled, mutate: mutateInstalled }] = createResource(
+    () => props.serverId,
+    async (serverId) => {
+      const res = await api<{ plugins: ServerPlugin[] }>(
+        `/api/servers/${serverId}/plugins`,
+      );
+      return res.plugins;
+    },
+  );
+
+  // Fetch catalog (filtered to server/both scope)
+  const [catalog] = createResource(async () => {
+    const res = await api<{ plugins: CatalogPlugin[] }>("/api/plugins");
+    return res.plugins.filter(
+      (p) => p.scope === "server" || p.scope === "both",
+    );
+  });
+
+  const installedPluginIds = () =>
+    new Set((installed() ?? []).map((p) => p.pluginId));
+
+  const availablePlugins = () =>
+    (catalog() ?? []).filter((p) => !installedPluginIds().has(p.id));
+
+  async function handleInstall(pluginId: PluginId) {
+    if (installing()) return;
+    setInstalling(pluginId);
+    try {
+      await api(`/api/servers/${props.serverId}/plugins`, {
+        method: "POST",
+        body: JSON.stringify({ pluginId }),
+      });
+      showToast("Server plugin installed", "info");
+      await refetchInstalled();
+    } catch (err) {
+      const msg =
+        err instanceof ApiRequestError
+          ? err.body.message
+          : "Failed to install plugin";
+      showToast(msg, "error");
+    } finally {
+      setInstalling(null);
+    }
+  }
+
+  async function handleUninstall(pluginId: string) {
+    if (uninstalling()) return;
+    setUninstalling(pluginId);
+    try {
+      await api(`/api/servers/${props.serverId}/plugins/${pluginId}`, {
+        method: "DELETE",
+      });
+      mutateInstalled((prev) => prev?.filter((p) => p.pluginId !== pluginId));
+      showToast("Server plugin uninstalled", "info");
+    } catch (err) {
+      const msg =
+        err instanceof ApiRequestError
+          ? err.body.message
+          : "Failed to uninstall plugin";
+      showToast(msg, "error");
+    } finally {
+      setUninstalling(null);
+    }
+  }
+
+  const stateLabel = (state: string) => {
+    switch (state) {
+      case "active":
+        return "Running";
+      case "stopped":
+        return "Stopped";
+      case "error":
+        return "Error";
+      default:
+        return state;
+    }
+  };
+
+  const stateColor = (state: string) => {
+    switch (state) {
+      case "active":
+        return "bg-success";
+      case "stopped":
+        return "bg-muted-foreground";
+      case "error":
+        return "bg-destructive";
+      default:
+        return "bg-muted-foreground";
+    }
+  };
+
+  return (
+    <div class="space-y-6">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">Server Plugins</h2>
+        <p class="text-sm text-muted-foreground">
+          Manage plugins that run for all members of this server.
+        </p>
+      </div>
+
+      {/* Tier gate */}
+      <Show when={!isServerOwnerTier()}>
+        <div class="rounded-lg border border-warning/50 bg-warning/10 p-4">
+          <p class="text-sm font-medium text-foreground">Server Owner tier required</p>
+          <p class="mt-1 text-sm text-muted-foreground">
+            Upgrade to the Server Owner plan to install and manage server plugins.
+          </p>
+        </div>
+      </Show>
+
+      {/* Installed plugins */}
+      <Show when={!installed.loading} fallback={
+        <div class="h-20 animate-skeleton rounded-xl border border-border bg-muted" />
+      }>
+        <Show when={(installed() ?? []).length > 0}>
+          <div class="space-y-3">
+            <h3 class="text-sm font-medium text-muted-foreground">Installed</h3>
+            <For each={installed()}>
+              {(plugin) => (
+                <div class="flex items-center justify-between rounded-lg border border-border bg-card p-4">
+                  <div class="flex items-center gap-3">
+                    <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                      <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5" />
+                      </svg>
+                    </div>
+                    <div>
+                      <div class="flex items-center gap-2">
+                        <span class="font-medium text-foreground">{plugin.pluginId}</span>
+                        <span class="flex items-center gap-1 text-xs text-muted-foreground">
+                          <span class={`inline-block h-1.5 w-1.5 rounded-full ${stateColor(plugin.state)}`} />
+                          {stateLabel(plugin.state)}
+                        </span>
+                      </div>
+                      <Show when={plugin.tunnelUrl}>
+                        <p class="mt-0.5 text-xs text-muted-foreground font-mono truncate max-w-[300px]">
+                          {plugin.tunnelUrl}
+                        </p>
+                      </Show>
+                    </div>
+                  </div>
+                  <Show when={isServerOwnerTier()}>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleUninstall(plugin.pluginId)}
+                      disabled={uninstalling() === plugin.pluginId}
+                    >
+                      {uninstalling() === plugin.pluginId ? "Removing..." : "Uninstall"}
+                    </Button>
+                  </Show>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Show>
+
+      {/* Available plugins */}
+      <Show when={isServerOwnerTier() && availablePlugins().length > 0}>
+        <div class="space-y-3">
+          <h3 class="text-sm font-medium text-muted-foreground">Available</h3>
+          <For each={availablePlugins()}>
+            {(plugin) => (
+              <div class="flex items-center justify-between rounded-lg border border-border bg-card/50 p-4">
+                <div>
+                  <div class="flex items-center gap-2">
+                    <span class="font-medium text-foreground">{plugin.name}</span>
+                    <span class="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                      {plugin.scope === "both" ? "Server + Personal" : "Server"}
+                    </span>
+                  </div>
+                  <p class="mt-1 text-sm text-muted-foreground">{plugin.description}</p>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => handleInstall(plugin.id)}
+                  disabled={installing() === plugin.id}
+                >
+                  {installing() === plugin.id ? "Installing..." : "Install for Server"}
+                </Button>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      {/* Desktop hint */}
+      <Show when={!isDesktop() && isServerOwnerTier()}>
+        <div class="rounded-lg border border-border bg-muted/50 p-4">
+          <p class="text-sm text-muted-foreground">
+            Server plugins run on the desktop app. Install them here, then start them from
+            the desktop client.
+          </p>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default ServerPluginsTab;

--- a/apps/web/src/pages/ServerSettings.tsx
+++ b/apps/web/src/pages/ServerSettings.tsx
@@ -7,14 +7,16 @@ const OverviewTab = lazy(() => import("../components/settings/server-overview.js
 const ChannelsTab = lazy(() => import("../components/settings/channel-management.js"));
 const MembersTab = lazy(() => import("../components/settings/member-management.js"));
 const InvitesTab = lazy(() => import("../components/settings/invite-management.js"));
+const PluginsTab = lazy(() => import("../components/settings/server-plugins.js"));
 
-type Tab = "overview" | "channels" | "members" | "invites";
+type Tab = "overview" | "channels" | "members" | "invites" | "plugins";
 
 const tabs: { id: Tab; label: string }[] = [
   { id: "overview", label: "Overview" },
   { id: "channels", label: "Channels" },
   { id: "members", label: "Members" },
   { id: "invites", label: "Invites" },
+  { id: "plugins", label: "Plugins" },
 ];
 
 const ServerSettings = () => {
@@ -104,6 +106,9 @@ const ServerSettings = () => {
             </Show>
             <Show when={activeTab() === "invites"}>
               <InvitesTab serverId={serverId()!} />
+            </Show>
+            <Show when={activeTab() === "plugins"}>
+              <PluginsTab serverId={serverId()!} />
             </Show>
           </div>
         </div>

--- a/apps/web/src/pages/settings/PluginsSettings.tsx
+++ b/apps/web/src/pages/settings/PluginsSettings.tsx
@@ -14,6 +14,7 @@ interface Plugin {
   author: string;
   icon: string | null;
   category: string;
+  scope: "server" | "personal" | "both";
   tags: string[];
   installCount: number;
   installed: boolean;
@@ -54,10 +55,14 @@ const PluginsSettings = () => {
     return res.plugins;
   });
 
+  // Only show personal/both scope plugins in user settings
+  const personalPlugins = () =>
+    (plugins() ?? []).filter((p) => p.scope === "personal" || p.scope === "both");
+
   const filteredPlugins = () => {
     const q = search().toLowerCase();
-    if (!q) return plugins() ?? [];
-    return (plugins() ?? []).filter(
+    if (!q) return personalPlugins();
+    return personalPlugins().filter(
       (p) =>
         p.name.toLowerCase().includes(q) ||
         p.description.toLowerCase().includes(q),
@@ -256,7 +261,7 @@ function PluginCard(props: {
                 }}
                 disabled={props.installing}
               >
-                {props.installing ? "Installing..." : "Install"}
+                {props.installing ? "Installing..." : "Install for Me"}
               </Button>
             }
           >

--- a/apps/web/src/stores/plugin-store.ts
+++ b/apps/web/src/stores/plugin-store.ts
@@ -11,6 +11,8 @@ export interface PluginInfo {
   rightPanel: boolean;
   status: "running" | "stopped" | "crashed" | "starting";
   port: number;
+  scope: "server" | "personal";
+  tunnelUrl: string | null;
   permissions: string[];
 }
 

--- a/apps/web/src/stores/plugin-store.ts
+++ b/apps/web/src/stores/plugin-store.ts
@@ -1,4 +1,5 @@
 import { createSignal, createRoot } from "solid-js";
+import { api } from "../lib/api.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -14,6 +15,15 @@ export interface PluginInfo {
   scope: "server" | "personal";
   tunnelUrl: string | null;
   permissions: string[];
+}
+
+export interface ServerPluginInfo {
+  id: string;
+  pluginId: string;
+  state: "active" | "stopped" | "error";
+  tunnelUrl: string | null;
+  installedBy: string;
+  installedAt: string;
 }
 
 // ── Desktop detection ──────────────────────────────────────────────────────
@@ -34,6 +44,37 @@ const visiblePlugins = () =>
 
 function clearActivePlugin() {
   setActivePluginId(null);
+}
+
+// ── Server plugins (fetched from API, available to all users) ─────────────
+
+const [serverPlugins, setServerPlugins] = createSignal<ServerPluginInfo[]>([]);
+const [activeServerPluginId, setActiveServerPluginId] = createSignal<string | null>(null);
+const [serverPluginsLoading, setServerPluginsLoading] = createSignal(false);
+
+const activeServerPlugin = () =>
+  serverPlugins().find((p) => p.pluginId === activeServerPluginId()) ?? null;
+
+const visibleServerPlugins = () =>
+  serverPlugins().filter((p) => p.state === "active");
+
+async function fetchServerPlugins(serverId: string): Promise<void> {
+  setServerPluginsLoading(true);
+  try {
+    const res = await api<{ plugins: ServerPluginInfo[] }>(
+      `/api/servers/${serverId}/plugins`,
+    );
+    setServerPlugins(res.plugins);
+  } catch {
+    setServerPlugins([]);
+  } finally {
+    setServerPluginsLoading(false);
+  }
+}
+
+function clearServerPlugins() {
+  setServerPlugins([]);
+  setActiveServerPluginId(null);
 }
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
@@ -94,4 +135,13 @@ export {
   activePlugin,
   visiblePlugins,
   clearActivePlugin,
+  serverPlugins,
+  setServerPlugins,
+  activeServerPluginId,
+  setActiveServerPluginId,
+  activeServerPlugin,
+  visibleServerPlugins,
+  serverPluginsLoading,
+  fetchServerPlugins,
+  clearServerPlugins,
 };


### PR DESCRIPTION
## Summary

- **Phase 2.5a — Scope Foundation**: Add `scope: "server" | "personal" | "both"` to plugin manifests, `server_plugins` DB table with migration, CRUD API routes with tier enforcement (`/api/servers/:serverId/plugins`), scope-aware bridge routes (personal plugins see friends/DMs instead of server data), and frontend type updates
- **Phase 2.5b — Cloudflare Tunnel Integration**: `TunnelManager` spawns `cloudflared tunnel --url` for server-scope plugins on start, parses the `*.trycloudflare.com` URL, tears down on stop, and reports URLs to the backend API. Includes auto-download of the `cloudflared` binary
- **Phase 2.5c — UI Integration**: Server Settings gets a Plugins tab (owner-only, server_owner tier gate), User Settings filters to personal/both scope, sidebar shows "Server Plugins" when in a server (fetched from API, any member) and "My Plugins" for desktop personal plugins, PluginFrame loads from tunnel URL for server plugins
- **Phase 2.5d — Testing**: Server plugin API tests (CRUD, tier enforcement, tunnel URL updates), manifest scope validation tests, tunnel manager tests (spawn, URL parsing, cleanup)

## Test plan

- [x] `bun run typecheck` — all 6 packages pass
- [x] `bun run lint` — 0 errors (27 pre-existing warnings)
- [x] `bun run test` — 43 tests pass across 5 test files
- [ ] Manual: install "both"-scope plugin as personal → localhost iframe works
- [ ] Manual: install "server"-scope plugin → tunnel URL appears in backend DB
- [ ] Manual: free user views server plugins → works; can't install → 403
- [ ] Manual: server owner offline → server plugin state shows "stopped" for members

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-scoped plugins: owners can install/manage plugins for an entire server (separate from personal plugins).
  * Public tunnels: per-server tunnel URLs with lifecycle reporting; renderer now shows tunnel state and URL.
  * UI: Server Plugins tab and sidebar group; PluginFrame supports tunnel overrides and shows a dedicated "Plugin offline" state; install button label updated to "Install for Me".

* **Backend**
  * New server plugin API and persistent DB support; plugin scope respected during install and listing.

* **Tests**
  * Added tests for tunnel manager and manifest scope parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->