### PR TITLE
feat: Excalidraw Boards server plugin

### DIFF
--- a/plugins/excalidraw/.dockerignore
+++ b/plugins/excalidraw/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+*.md

--- a/plugins/excalidraw/.dockerignore
+++ b/plugins/excalidraw/.dockerignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .git
 *.md
+.env

--- a/plugins/excalidraw/Dockerfile
+++ b/plugins/excalidraw/Dockerfile
@@ -1,0 +1,26 @@
+FROM oven/bun:1-alpine AS build
+
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile || bun install
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN bun build src/server.ts --outdir dist --target bun
+
+# --- Production ---
+FROM oven/bun:1-alpine
+
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY public/ ./public/
+
+RUN mkdir -p /app/data/boards
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:3000/health || exit 1
+
+CMD ["bun", "run", "dist/server.js"]

--- a/plugins/excalidraw/Dockerfile
+++ b/plugins/excalidraw/Dockerfile
@@ -6,19 +6,25 @@ RUN bun install --frozen-lockfile || bun install
 
 COPY tsconfig.json ./
 COPY src/ ./src/
-RUN bun build src/server.ts --outdir dist --target bun
+COPY public/ ./public/
+COPY scripts/ ./scripts/
+RUN bun run build
 
 # --- Production ---
 FROM oven/bun:1-alpine
 
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
 WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
-COPY public/ ./public/
+COPY --from=build /app/public ./public
 
-RUN mkdir -p /app/data/boards
+RUN mkdir -p /app/data/boards && chown -R appuser:appgroup /app
 
 EXPOSE 3000
+
+USER appuser
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:3000/health || exit 1

--- a/plugins/excalidraw/bun.lock
+++ b/plugins/excalidraw/bun.lock
@@ -5,25 +5,558 @@
     "": {
       "name": "excalidraw-boards",
       "dependencies": {
-        "crypto": "^1.0.1",
+        "@excalidraw/excalidraw": "^0.18.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
       },
       "devDependencies": {
         "@types/bun": "^1.2.0",
+        "esbuild": "^0.25.0",
         "typescript": "^5.7.0",
       },
     },
   },
   "packages": {
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@6.0.2", "", {}, "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@excalidraw/excalidraw": ["@excalidraw/excalidraw@0.18.0", "", { "dependencies": { "@braintree/sanitize-url": "6.0.2", "@excalidraw/laser-pointer": "1.3.1", "@excalidraw/mermaid-to-excalidraw": "1.1.2", "@excalidraw/random-username": "1.1.0", "@radix-ui/react-popover": "1.1.6", "@radix-ui/react-tabs": "1.0.2", "browser-fs-access": "0.29.1", "canvas-roundrect-polyfill": "0.0.1", "clsx": "1.1.1", "cross-env": "7.0.3", "es6-promise-pool": "2.5.0", "fractional-indexing": "3.2.0", "fuzzy": "0.1.3", "image-blob-reduce": "3.0.1", "jotai": "2.11.0", "jotai-scope": "0.7.2", "lodash.debounce": "4.0.8", "lodash.throttle": "4.1.1", "nanoid": "3.3.3", "open-color": "1.9.1", "pako": "2.0.3", "perfect-freehand": "1.2.0", "pica": "7.1.1", "png-chunk-text": "1.0.0", "png-chunks-encode": "1.0.0", "png-chunks-extract": "1.0.0", "points-on-curve": "1.0.1", "pwacompat": "2.0.17", "roughjs": "4.6.4", "sass": "1.51.0", "tunnel-rat": "0.1.2" }, "peerDependencies": { "react": "^17.0.2 || ^18.2.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.2.0 || ^19.0.0" } }, "sha512-QkIiS+5qdy8lmDWTKsuy0sK/fen/LRDtbhm2lc2xcFcqhv2/zdg95bYnl+wnwwXGHo7kEmP65BSiMHE7PJ3Zpw=="],
+
+    "@excalidraw/laser-pointer": ["@excalidraw/laser-pointer@1.3.1", "", {}, "sha512-psA1z1N2qeAfsORdXc9JmD2y4CmDwmuMRxnNdJHZexIcPwaNEyIpNcelw+QkL9rz9tosaN9krXuKaRqYpRAR6g=="],
+
+    "@excalidraw/markdown-to-text": ["@excalidraw/markdown-to-text@0.1.2", "", {}, "sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg=="],
+
+    "@excalidraw/mermaid-to-excalidraw": ["@excalidraw/mermaid-to-excalidraw@1.1.2", "", { "dependencies": { "@excalidraw/markdown-to-text": "0.1.2", "mermaid": "10.9.3", "nanoid": "4.0.2" } }, "sha512-hAFv/TTIsOdoy0dL5v+oBd297SQ+Z88gZ5u99fCIFuEMHfQuPgLhU/ztKhFSTs7fISwVo6fizny/5oQRR3d4tQ=="],
+
+    "@excalidraw/random-username": ["@excalidraw/random-username@1.1.0", "", {}, "sha512-nULYsQxkWHnbmHvcs+efMkJ4/9TtvNyFeLyHdeGxW0zHs6P+jYVqcRff9A6Vq9w9JXeDRnRh2VKvTtS19GW2qA=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.1", "", {}, "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.2", "", { "dependencies": { "@radix-ui/react-primitive": "2.0.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0", "@radix-ui/react-context": "1.0.0", "@radix-ui/react-primitive": "1.0.1", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q=="],
+
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.5", "", { "dependencies": { "@radix-ui/primitive": "1.1.1", "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-callback-ref": "1.1.0", "@radix-ui/react-use-escape-keydown": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-callback-ref": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.0", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.1", "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-context": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.5", "@radix-ui/react-focus-guards": "1.1.1", "@radix-ui/react-focus-scope": "1.1.2", "@radix-ui/react-id": "1.1.0", "@radix-ui/react-popper": "1.2.2", "@radix-ui/react-portal": "1.1.4", "@radix-ui/react-presence": "1.1.2", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-slot": "1.1.2", "@radix-ui/react-use-controllable-state": "1.1.0", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.2", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.2", "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-context": "1.1.1", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-callback-ref": "1.1.0", "@radix-ui/react-use-layout-effect": "1.1.0", "@radix-ui/react-use-rect": "1.1.0", "@radix-ui/react-use-size": "1.1.0", "@radix-ui/rect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.4", "", { "dependencies": { "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.2", "", { "dependencies": { "@radix-ui/react-slot": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w=="],
+
+    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.0.2", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/primitive": "1.0.0", "@radix-ui/react-collection": "1.0.1", "@radix-ui/react-compose-refs": "1.0.0", "@radix-ui/react-context": "1.0.0", "@radix-ui/react-direction": "1.0.0", "@radix-ui/react-id": "1.0.0", "@radix-ui/react-primitive": "1.0.1", "@radix-ui/react-use-callback-ref": "1.0.0", "@radix-ui/react-use-controllable-state": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-HLK+CqD/8pN6GfJm3U+cqpqhSKYAWiOJDe+A+8MfxBnOue39QEeMa43csUn2CXCHQT0/mewh1LrrG4tfkM9DMA=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ=="],
+
+    "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.0.2", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/primitive": "1.0.0", "@radix-ui/react-context": "1.0.0", "@radix-ui/react-direction": "1.0.0", "@radix-ui/react-id": "1.0.0", "@radix-ui/react-presence": "1.0.0", "@radix-ui/react-primitive": "1.0.1", "@radix-ui/react-roving-focus": "1.0.2", "@radix-ui/react-use-controllable-state": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-gOUwh+HbjCuL0UCo8kZ+kdUEG8QtpdO4sMQduJ34ZEz0r4922g9REOBM+vIsfwtGxSug4Yb1msJMJYN2Bk8TpQ=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.1.0", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.0", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.0", "", { "dependencies": { "@radix-ui/rect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.0", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.0", "", {}, "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/mdast": ["@types/mdast@3.0.15", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
+    "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browser-fs-access": ["browser-fs-access@0.29.1", "", {}, "sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw=="],
+
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
-    "crypto": ["crypto@1.0.1", "", {}, "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="],
+    "canvas-roundrect-polyfill": ["canvas-roundrect-polyfill@0.0.1", "", {}, "sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "clsx": ["clsx@1.1.1", "", {}, "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "crc-32": ["crc-32@0.3.0", "", {}, "sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA=="],
+
+    "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cytoscape": ["cytoscape@3.33.1", "", {}, "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.10", "", { "dependencies": { "d3": "^7.8.2", "lodash-es": "^4.17.21" } }, "sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A=="],
+
+    "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "diff": ["diff@5.2.2", "", {}, "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="],
+
+    "dompurify": ["dompurify@3.1.6", "", {}, "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="],
+
+    "elkjs": ["elkjs@0.9.3", "", {}, "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ=="],
+
+    "es6-promise-pool": ["es6-promise-pool@2.5.0", "", {}, "sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "fractional-indexing": ["fractional-indexing@3.2.0", "", {}, "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "fuzzy": ["fuzzy@0.1.3", "", {}, "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "glur": ["glur@1.1.2", "", {}, "sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "image-blob-reduce": ["image-blob-reduce@3.0.1", "", { "dependencies": { "pica": "^7.1.0" } }, "sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q=="],
+
+    "immutable": ["immutable@4.3.8", "", {}, "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jotai": ["jotai@2.11.0", "", { "peerDependencies": { "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ=="],
+
+    "jotai-scope": ["jotai-scope@0.7.2", "", { "peerDependencies": { "jotai": ">=2.9.2", "react": ">=17.0.0" } }, "sha512-Gwed97f3dDObrO43++2lRcgOqw4O2sdr4JCjP/7eHK1oPACDJ7xKHGScpJX9XaflU+KBHXF+VhwECnzcaQiShg=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "katex": ["katex@0.16.44", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
+
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
+    "lodash.throttle": ["lodash.throttle@4.1.1", "", {}, "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@1.3.1", "", { "dependencies": { "@types/mdast": "^3.0.0", "@types/unist": "^2.0.0", "decode-named-character-reference": "^1.0.0", "mdast-util-to-string": "^3.1.0", "micromark": "^3.0.0", "micromark-util-decode-numeric-character-reference": "^1.0.0", "micromark-util-decode-string": "^1.0.0", "micromark-util-normalize-identifier": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0", "unist-util-stringify-position": "^3.0.0", "uvu": "^0.5.0" } }, "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@3.2.0", "", { "dependencies": { "@types/mdast": "^3.0.0" } }, "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg=="],
+
+    "mermaid": ["mermaid@10.9.3", "", { "dependencies": { "@braintree/sanitize-url": "^6.0.1", "@types/d3-scale": "^4.0.3", "@types/d3-scale-chromatic": "^3.0.0", "cytoscape": "^3.28.1", "cytoscape-cose-bilkent": "^4.1.0", "d3": "^7.4.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.10", "dayjs": "^1.11.7", "dompurify": "^3.0.5 <3.1.7", "elkjs": "^0.9.0", "katex": "^0.16.9", "khroma": "^2.0.0", "lodash-es": "^4.17.21", "mdast-util-from-markdown": "^1.3.0", "non-layered-tidy-tree-layout": "^2.0.2", "stylis": "^4.1.3", "ts-dedent": "^2.2.0", "uuid": "^9.0.0", "web-worker": "^1.2.0" } }, "sha512-V80X1isSEvAewIL3xhmz/rVmc27CVljcsbWxkxlWJWY/1kQa4XOABqpDl2qQLGKzpKm6WbTfUEKImBlUfFYArw=="],
+
+    "micromark": ["micromark@3.2.0", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "micromark-core-commonmark": "^1.0.1", "micromark-factory-space": "^1.0.0", "micromark-util-character": "^1.0.0", "micromark-util-chunked": "^1.0.0", "micromark-util-combine-extensions": "^1.0.0", "micromark-util-decode-numeric-character-reference": "^1.0.0", "micromark-util-encode": "^1.0.0", "micromark-util-normalize-identifier": "^1.0.0", "micromark-util-resolve-all": "^1.0.0", "micromark-util-sanitize-uri": "^1.0.0", "micromark-util-subtokenize": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.1", "uvu": "^0.5.0" } }, "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@1.1.0", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-factory-destination": "^1.0.0", "micromark-factory-label": "^1.0.0", "micromark-factory-space": "^1.0.0", "micromark-factory-title": "^1.0.0", "micromark-factory-whitespace": "^1.0.0", "micromark-util-character": "^1.0.0", "micromark-util-chunked": "^1.0.0", "micromark-util-classify-character": "^1.0.0", "micromark-util-html-tag-name": "^1.0.0", "micromark-util-normalize-identifier": "^1.0.0", "micromark-util-resolve-all": "^1.0.0", "micromark-util-subtokenize": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.1", "uvu": "^0.5.0" } }, "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@1.1.0", "", { "dependencies": { "micromark-util-character": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0" } }, "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg=="],
+
+    "micromark-factory-label": ["micromark-factory-label@1.1.0", "", { "dependencies": { "micromark-util-character": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0", "uvu": "^0.5.0" } }, "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w=="],
+
+    "micromark-factory-space": ["micromark-factory-space@1.1.0", "", { "dependencies": { "micromark-util-character": "^1.0.0", "micromark-util-types": "^1.0.0" } }, "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ=="],
+
+    "micromark-factory-title": ["micromark-factory-title@1.1.0", "", { "dependencies": { "micromark-factory-space": "^1.0.0", "micromark-util-character": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0" } }, "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@1.1.0", "", { "dependencies": { "micromark-factory-space": "^1.0.0", "micromark-util-character": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0" } }, "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ=="],
+
+    "micromark-util-character": ["micromark-util-character@1.2.0", "", { "dependencies": { "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0" } }, "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@1.1.0", "", { "dependencies": { "micromark-util-symbol": "^1.0.0" } }, "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@1.1.0", "", { "dependencies": { "micromark-util-character": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0" } }, "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@1.1.0", "", { "dependencies": { "micromark-util-chunked": "^1.0.0", "micromark-util-types": "^1.0.0" } }, "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@1.1.0", "", { "dependencies": { "micromark-util-symbol": "^1.0.0" } }, "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@1.1.0", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^1.0.0", "micromark-util-decode-numeric-character-reference": "^1.0.0", "micromark-util-symbol": "^1.0.0" } }, "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@1.1.0", "", {}, "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@1.2.0", "", {}, "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@1.1.0", "", { "dependencies": { "micromark-util-symbol": "^1.0.0" } }, "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@1.1.0", "", { "dependencies": { "micromark-util-types": "^1.0.0" } }, "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@1.2.0", "", { "dependencies": { "micromark-util-character": "^1.0.0", "micromark-util-encode": "^1.0.0", "micromark-util-symbol": "^1.0.0" } }, "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@1.1.0", "", { "dependencies": { "micromark-util-chunked": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.0", "uvu": "^0.5.0" } }, "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@1.1.0", "", {}, "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="],
+
+    "micromark-util-types": ["micromark-util-types@1.1.0", "", {}, "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "multimath": ["multimath@2.0.0", "", { "dependencies": { "glur": "^1.1.2", "object-assign": "^4.1.1" } }, "sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g=="],
+
+    "nanoid": ["nanoid@3.3.3", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="],
+
+    "non-layered-tidy-tree-layout": ["non-layered-tidy-tree-layout@2.0.2", "", {}, "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "open-color": ["open-color@1.9.1", "", {}, "sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw=="],
+
+    "pako": ["pako@2.0.3", "", {}, "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "perfect-freehand": ["perfect-freehand@1.2.0", "", {}, "sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw=="],
+
+    "pica": ["pica@7.1.1", "", { "dependencies": { "glur": "^1.1.2", "inherits": "^2.0.3", "multimath": "^2.0.0", "object-assign": "^4.1.1", "webworkify": "^1.5.0" } }, "sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "png-chunk-text": ["png-chunk-text@1.0.0", "", {}, "sha512-DEROKU3SkkLGWNMzru3xPVgxyd48UGuMSZvioErCure6yhOc/pRH2ZV+SEn7nmaf7WNf3NdIpH+UTrRdKyq9Lw=="],
+
+    "png-chunks-encode": ["png-chunks-encode@1.0.0", "", { "dependencies": { "crc-32": "^0.3.0", "sliced": "^1.0.1" } }, "sha512-J1jcHgbQRsIIgx5wxW9UmCymV3wwn4qCCJl6KYgEU/yHCh/L2Mwq/nMOkRPtmV79TLxRZj5w3tH69pvygFkDqA=="],
+
+    "png-chunks-extract": ["png-chunks-extract@1.0.0", "", { "dependencies": { "crc-32": "^0.3.0" } }, "sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q=="],
+
+    "points-on-curve": ["points-on-curve@1.0.1", "", {}, "sha512-3nmX4/LIiyuwGLwuUrfhTlDeQFlAhi7lyK/zcRNGhalwapDWgAGR82bUpmn2mA03vII3fvNCG8jAONzKXwpxAg=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
+    "pwacompat": ["pwacompat@2.0.17", "", {}, "sha512-6Du7IZdIy7cHiv7AhtDy4X2QRM8IAD5DII69mt5qWibC2d15ZU8DmBG1WdZKekG11cChSu4zkSUGPF9sweOl6w=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
+    "roughjs": ["roughjs@4.6.4", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sass": ["sass@1.51.0", "", { "dependencies": { "chokidar": ">=3.0.0 <4.0.0", "immutable": "^4.0.0", "source-map-js": ">=0.6.2 <2.0.0" }, "bin": { "sass": "sass.js" } }, "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "sliced": ["sliced@1.0.1", "", {}, "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@3.0.3", "", { "dependencies": { "@types/unist": "^2.0.0" } }, "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg=="],
+
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "uvu": ["uvu@0.5.6", "", { "dependencies": { "dequal": "^2.0.0", "diff": "^5.0.0", "kleur": "^4.0.3", "sade": "^1.7.3" }, "bin": { "uvu": "bin.js" } }, "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA=="],
+
+    "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
+
+    "webworkify": ["webworkify@1.5.0", "", {}, "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "@excalidraw/mermaid-to-excalidraw/nanoid": ["nanoid@4.0.2", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/primitive": ["@radix-ui/primitive@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" } }, "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-context": ["@radix-ui/react-context@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-id": ["@radix-ui/react-id@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-layout-effect": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-callback-ref": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg=="],
+
+    "@radix-ui/react-tabs/@radix-ui/primitive": ["@radix-ui/primitive@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" } }, "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-context": ["@radix-ui/react-context@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-id": ["@radix-ui/react-id@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-layout-effect": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence": ["@radix-ui/react-presence@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0", "@radix-ui/react-use-layout-effect": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-callback-ref": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "points-on-path/points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "roughjs/points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
   }
 }

--- a/plugins/excalidraw/bun.lock
+++ b/plugins/excalidraw/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "excalidraw-boards",
+      "dependencies": {
+        "crypto": "^1.0.1",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "crypto": ["crypto@1.0.1", "", {}, "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/plugins/excalidraw/package.json
+++ b/plugins/excalidraw/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "excalidraw-boards",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "bun build src/server.ts --outdir dist --target bun",
+    "start": "bun run dist/server.js",
+    "dev": "bun run src/server.ts"
+  },
+  "dependencies": {
+    "crypto": "^1.0.1"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/plugins/excalidraw/package.json
+++ b/plugins/excalidraw/package.json
@@ -4,15 +4,19 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/server.ts --outdir dist --target bun",
+    "build": "bun build src/server.ts --outdir dist --target bun && bun run build:client",
+    "build:client": "node scripts/build-client.mjs",
     "start": "bun run dist/server.js",
     "dev": "bun run src/server.ts"
   },
   "dependencies": {
-    "crypto": "^1.0.1"
+    "@excalidraw/excalidraw": "^0.18.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@types/bun": "^1.2.0",
+    "esbuild": "^0.25.0",
     "typescript": "^5.7.0"
   }
 }

--- a/plugins/excalidraw/public/board.html
+++ b/plugins/excalidraw/public/board.html
@@ -125,7 +125,15 @@
     ];
 
     function getColorForClient(clientId, allClientIds) {
-      const idx = allClientIds.indexOf(clientId);
+      let idx = allClientIds.indexOf(clientId);
+      if (idx === -1) {
+        // Pointer arrived before room-users — use hash-based fallback
+        let hash = 0;
+        for (let i = 0; i < clientId.length; i++) {
+          hash = (hash * 31 + clientId.charCodeAt(i)) | 0;
+        }
+        idx = Math.abs(hash);
+      }
       return COLLAB_COLORS[idx % COLLAB_COLORS.length];
     }
 

--- a/plugins/excalidraw/public/board.html
+++ b/plugins/excalidraw/public/board.html
@@ -12,54 +12,60 @@
 
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { height: 100%; overflow: hidden; }
+    html, body { height: 100%; overflow: hidden; background: #0A0A0A; }
     #root { width: 100%; height: 100vh; }
 
-    .top-bar {
+    .nav-bar {
       position: absolute;
-      top: 12px;
+      bottom: 12px;
       left: 50%;
       transform: translateX(-50%);
       z-index: 10;
       display: flex;
       align-items: center;
-      gap: 12px;
-      background: #1a1a2e;
-      border: 1px solid #2a2a4a;
-      border-radius: 10px;
-      padding: 6px 14px;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      font-size: 13px;
-      color: #e0e0e0;
+      gap: 10px;
+      background: var(--island-bg-color, #232329);
+      border-radius: 8px;
+      padding: 8px 14px;
+      font-family: "Assistant", -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 12px;
+      color: #E8E8E8;
       pointer-events: auto;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     }
 
-    .top-bar a {
-      color: #7c5cfc;
+    .nav-bar a {
+      color: #F87171;
       text-decoration: none;
       font-weight: 500;
     }
 
-    .top-bar a:hover { text-decoration: underline; }
+    .nav-bar a:hover { text-decoration: underline; }
 
     .user-count {
       display: flex;
       align-items: center;
-      gap: 5px;
-      color: #4ade80;
-      font-size: 12px;
+      gap: 4px;
+      color: #16A37F;
+      font-size: 11px;
     }
 
     .user-dot {
-      width: 6px;
-      height: 6px;
+      width: 5px;
+      height: 5px;
       border-radius: 50%;
-      background: #4ade80;
+      background: #16A37F;
     }
 
     .status {
-      font-size: 11px;
-      color: #7a7a9a;
+      font-size: 10px;
+      color: #6B6B6B;
+    }
+
+    .separator {
+      width: 1px;
+      height: 14px;
+      background: #2A2A2A;
     }
 
     .loading-overlay {
@@ -68,8 +74,8 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: #1a1a2e;
-      color: #e0e0e0;
+      background: #0A0A0A;
+      color: #E8E8E8;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       font-size: 1rem;
       z-index: 100;
@@ -87,26 +93,104 @@
   </div>
 
   <script type="module">
-    import React, { useState, useCallback, useEffect, useRef } from "https://esm.sh/react@18.3.1";
-    import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
-    import { Excalidraw } from "https://esm.sh/@excalidraw/excalidraw@0.18.0";
+    import {
+      Excalidraw,
+      React,
+      useState,
+      useCallback,
+      useEffect,
+      useRef,
+      createRoot,
+      reconcileElements,
+      restoreElements,
+      getSceneVersion,
+    } from "/excalidraw-bundle.js";
 
-    // Extract board ID from URL: /board/:id
     const boardId = window.location.pathname.split("/board/")[1];
     if (!boardId) {
       document.getElementById("loading").textContent = "Invalid board URL";
       throw new Error("No board ID");
     }
 
+    // Collaborator colors palette
+    const COLLAB_COLORS = [
+      { background: "#FF6B6B40", stroke: "#FF6B6B" },
+      { background: "#4ECDC440", stroke: "#4ECDC4" },
+      { background: "#45B7D140", stroke: "#45B7D1" },
+      { background: "#96CEB440", stroke: "#96CEB4" },
+      { background: "#FFEAA740", stroke: "#FFEAA7" },
+      { background: "#DDA0DD40", stroke: "#DDA0DD" },
+      { background: "#98D8C840", stroke: "#98D8C8" },
+      { background: "#F7DC6F40", stroke: "#F7DC6F" },
+    ];
+
+    function getColorForClient(clientId, allClientIds) {
+      const idx = allClientIds.indexOf(clientId);
+      return COLLAB_COLORS[idx % COLLAB_COLORS.length];
+    }
+
     function App() {
-      const [excalidrawAPI, setExcalidrawAPI] = useState(null);
       const [userCount, setUserCount] = useState(1);
       const [connected, setConnected] = useState(false);
+      const apiRef = useRef(null);
       const wsRef = useRef(null);
-      const suppressOnChange = useRef(false);
-      const sendTimeoutRef = useRef(null);
+      const myClientIdRef = useRef(null);
+      const collaboratorsRef = useRef(new Map());
+      const roomClientsRef = useRef([]);
+      const lastVersionRef = useRef(0);
+      const lastSentElementsRef = useRef(new Map());  // id → version
+      const throttleRef = useRef({ timer: null, lastSend: 0 });
 
-      // Connect WebSocket
+      // Apply a full remote scene (scene-init) using reconcileElements
+      const applyFullScene = useCallback((remoteRawElements) => {
+        const api = apiRef.current;
+        if (!api) return;
+
+        const remoteElements = restoreElements(remoteRawElements, null, {
+          refreshDimensions: false,
+          repairBindings: false,
+        });
+        const localElements = api.getSceneElementsIncludingDeleted();
+        const appState = api.getAppState();
+        const reconciled = reconcileElements(localElements, remoteElements, appState);
+
+        api.updateScene({ elements: reconciled, captureUpdate: "NEVER" });
+        lastVersionRef.current = getSceneVersion(reconciled);
+      }, []);
+
+      // Apply incremental delta — merge only changed elements by version
+      const applyDelta = useCallback((changedElements) => {
+        const api = apiRef.current;
+        if (!api) return;
+
+        const localElements = api.getSceneElementsIncludingDeleted();
+        const localMap = new Map(localElements.map(el => [el.id, el]));
+        let changed = false;
+
+        for (const remote of changedElements) {
+          const local = localMap.get(remote.id);
+          // Accept remote if: new element, or remote version is higher
+          if (!local || (remote.version || 0) > (local.version || 0)) {
+            localMap.set(remote.id, remote);
+            changed = true;
+          }
+        }
+
+        if (changed) {
+          const merged = Array.from(localMap.values());
+          api.updateScene({ elements: merged, captureUpdate: "NEVER" });
+          lastVersionRef.current = getSceneVersion(merged);
+        }
+      }, []);
+
+      // Update collaborators map and push to Excalidraw
+      const updateCollaborators = useCallback(() => {
+        const api = apiRef.current;
+        if (!api) return;
+        api.updateScene({ collaborators: collaboratorsRef.current });
+      }, []);
+
+      // Connect WebSocket ONCE
       useEffect(() => {
         const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
         const wsUrl = `${proto}//${window.location.host}/ws/room/${boardId}`;
@@ -125,28 +209,62 @@
             try {
               const msg = JSON.parse(event.data);
 
-              if (msg.type === "user-count") {
-                setUserCount(msg.count);
-                return;
-              }
+              switch (msg.type) {
+                case "client-id":
+                  myClientIdRef.current = msg.id;
+                  break;
 
-              if (msg.type === "scene-init" && excalidrawAPI) {
-                suppressOnChange.current = true;
-                excalidrawAPI.updateScene({
-                  elements: msg.elements,
-                  captureUpdate: "NEVER",
-                });
-                setTimeout(() => { suppressOnChange.current = false; }, 100);
-                return;
-              }
+                case "scene-init":
+                  if (msg.elements && apiRef.current) {
+                    applyFullScene(msg.elements);
+                  }
+                  break;
 
-              if (msg.type === "scene-update" && excalidrawAPI) {
-                suppressOnChange.current = true;
-                excalidrawAPI.updateScene({
-                  elements: msg.elements,
-                  captureUpdate: "NEVER",
-                });
-                setTimeout(() => { suppressOnChange.current = false; }, 100);
+                case "scene-update":
+                  if (msg.elements && apiRef.current) {
+                    applyDelta(msg.elements);
+                  }
+                  break;
+
+                case "pointer-update": {
+                  const collabs = collaboratorsRef.current;
+                  const existing = collabs.get(msg.clientId) || {};
+                  collabs.set(msg.clientId, {
+                    ...existing,
+                    pointer: msg.pointer,
+                    button: msg.button,
+                    color: getColorForClient(msg.clientId, roomClientsRef.current.map(c => c.id)),
+                  });
+                  collaboratorsRef.current = new Map(collabs);
+                  updateCollaborators();
+                  break;
+                }
+
+                case "room-users": {
+                  roomClientsRef.current = msg.clients;
+                  const myId = myClientIdRef.current;
+                  setUserCount(msg.clients.length);
+
+                  // Clean up collaborators for clients that left
+                  const activeIds = new Set(msg.clients.map(c => c.id));
+                  const collabs = collaboratorsRef.current;
+                  for (const [id] of collabs) {
+                    if (!activeIds.has(id)) {
+                      collabs.delete(id);
+                    }
+                  }
+                  // Ensure all active clients (except self) are in the map
+                  for (const client of msg.clients) {
+                    if (client.id !== myId && !collabs.has(client.id)) {
+                      collabs.set(client.id, {
+                        color: getColorForClient(client.id, msg.clients.map(c => c.id)),
+                      });
+                    }
+                  }
+                  collaboratorsRef.current = new Map(collabs);
+                  updateCollaborators();
+                  break;
+                }
               }
             } catch {
               // Non-JSON message, ignore
@@ -156,7 +274,6 @@
           ws.onclose = () => {
             setConnected(false);
             wsRef.current = null;
-            // Reconnect after 2s
             reconnectTimer = setTimeout(connect, 2000);
           };
 
@@ -171,27 +288,71 @@
           clearTimeout(reconnectTimer);
           if (ws) ws.close();
         };
-      }, [excalidrawAPI]);
+      }, [applyFullScene, applyDelta, updateCollaborators]);
 
-      // Debounced scene broadcast
-      const handleChange = useCallback((elements, appState, files) => {
-        if (suppressOnChange.current) return;
+      // Send scene updates — throttled, incremental deltas only
+      const handleChange = useCallback((elements) => {
         if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
 
-        // Debounce: send at most every 100ms
-        if (sendTimeoutRef.current) return;
-        sendTimeoutRef.current = setTimeout(() => {
-          sendTimeoutRef.current = null;
-          if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        const allElements = Array.from(elements);
+        const version = getSceneVersion(allElements);
+        if (version === lastVersionRef.current) return;
+        lastVersionRef.current = version;
+
+        function sendDelta() {
+          if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+
+          // Find elements that changed since last send
+          const prevSent = lastSentElementsRef.current;
+          const changed = [];
+          const newSentMap = new Map();
+
+          for (const el of allElements) {
+            newSentMap.set(el.id, el.version || 0);
+            const prevVersion = prevSent.get(el.id);
+            if (prevVersion === undefined || (el.version || 0) !== prevVersion) {
+              changed.push(el);
+            }
+          }
+
+          lastSentElementsRef.current = newSentMap;
+
+          if (changed.length > 0) {
             wsRef.current.send(JSON.stringify({
               type: "scene-update",
-              elements: Array.from(elements),
+              elements: changed,
             }));
           }
-        }, 100);
+        }
+
+        // Throttle: send immediately if enough time passed, otherwise schedule
+        const now = Date.now();
+        const t = throttleRef.current;
+        const THROTTLE_MS = 33; // ~30fps
+
+        if (now - t.lastSend >= THROTTLE_MS) {
+          t.lastSend = now;
+          sendDelta();
+        } else {
+          if (t.timer) clearTimeout(t.timer);
+          t.timer = setTimeout(() => {
+            t.timer = null;
+            t.lastSend = Date.now();
+            sendDelta();
+          }, THROTTLE_MS - (now - t.lastSend));
+        }
       }, []);
 
-      // Remove loading overlay once mounted
+      // Send pointer updates for cursor sharing
+      const handlePointerUpdate = useCallback((payload) => {
+        if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+        wsRef.current.send(JSON.stringify({
+          type: "pointer-update",
+          pointer: payload.pointer,
+          button: payload.button,
+        }));
+      }, []);
+
       useEffect(() => {
         const el = document.getElementById("loading");
         if (el) el.remove();
@@ -202,14 +363,16 @@
         null,
         React.createElement(
           "div",
-          { className: "top-bar" },
-          React.createElement("a", { href: "/" }, "All Boards"),
+          { className: "nav-bar" },
+          React.createElement("a", { href: "/" }, "Back to Boards"),
+          React.createElement("span", { className: "separator" }),
           React.createElement(
             "span",
             { className: "user-count" },
             React.createElement("span", { className: "user-dot" }),
             `${userCount} user${userCount !== 1 ? "s" : ""}`
           ),
+          React.createElement("span", { className: "separator" }),
           React.createElement(
             "span",
             { className: "status" },
@@ -217,12 +380,14 @@
           )
         ),
         React.createElement(Excalidraw, {
-          excalidrawAPI: (api) => setExcalidrawAPI(api),
+          excalidrawAPI: (api) => { apiRef.current = api; },
           onChange: handleChange,
+          onPointerUpdate: handlePointerUpdate,
+          isCollaborating: true,
           theme: "dark",
           initialData: {
             appState: {
-              viewBackgroundColor: "#1a1a2e",
+              viewBackgroundColor: "#f8f9fa",
             },
           },
         })

--- a/plugins/excalidraw/public/board.html
+++ b/plugins/excalidraw/public/board.html
@@ -204,12 +204,14 @@
         const wsUrl = `${proto}//${window.location.host}/ws/room/${boardId}`;
         let ws;
         let reconnectTimer;
+        let reconnectDelay = 2000;
 
         function connect() {
           ws = new WebSocket(wsUrl);
           wsRef.current = ws;
 
           ws.onopen = () => {
+            reconnectDelay = 2000;
             setConnected(true);
           };
 
@@ -274,15 +276,18 @@
                   break;
                 }
               }
-            } catch {
-              // Non-JSON message, ignore
+            } catch (err) {
+              if (!(err instanceof SyntaxError)) {
+                console.warn("Error handling WS message:", err);
+              }
             }
           };
 
           ws.onclose = () => {
             setConnected(false);
             wsRef.current = null;
-            reconnectTimer = setTimeout(connect, 2000);
+            reconnectTimer = setTimeout(connect, reconnectDelay);
+            reconnectDelay = Math.min(reconnectDelay * 2, 30000);
           };
 
           ws.onerror = () => {

--- a/plugins/excalidraw/public/board.html
+++ b/plugins/excalidraw/public/board.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Excalidraw Board</title>
+
+  <link
+    rel="stylesheet"
+    href="https://esm.sh/@excalidraw/excalidraw@0.18.0/dist/prod/index.css"
+  />
+
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; }
+    #root { width: 100%; height: 100vh; }
+
+    .top-bar {
+      position: absolute;
+      top: 12px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 10;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      background: #1a1a2e;
+      border: 1px solid #2a2a4a;
+      border-radius: 10px;
+      padding: 6px 14px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 13px;
+      color: #e0e0e0;
+      pointer-events: auto;
+    }
+
+    .top-bar a {
+      color: #7c5cfc;
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .top-bar a:hover { text-decoration: underline; }
+
+    .user-count {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      color: #4ade80;
+      font-size: 12px;
+    }
+
+    .user-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #4ade80;
+    }
+
+    .status {
+      font-size: 11px;
+      color: #7a7a9a;
+    }
+
+    .loading-overlay {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 1rem;
+      z-index: 100;
+    }
+  </style>
+
+  <script>
+    window.EXCALIDRAW_ASSET_PATH =
+      "https://esm.sh/@excalidraw/excalidraw@0.18.0/dist/prod/";
+  </script>
+</head>
+<body>
+  <div id="root">
+    <div class="loading-overlay" id="loading">Loading Excalidraw...</div>
+  </div>
+
+  <script type="module">
+    import React, { useState, useCallback, useEffect, useRef } from "https://esm.sh/react@18.3.1";
+    import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
+    import { Excalidraw } from "https://esm.sh/@excalidraw/excalidraw@0.18.0";
+
+    // Extract board ID from URL: /board/:id
+    const boardId = window.location.pathname.split("/board/")[1];
+    if (!boardId) {
+      document.getElementById("loading").textContent = "Invalid board URL";
+      throw new Error("No board ID");
+    }
+
+    function App() {
+      const [excalidrawAPI, setExcalidrawAPI] = useState(null);
+      const [userCount, setUserCount] = useState(1);
+      const [connected, setConnected] = useState(false);
+      const wsRef = useRef(null);
+      const suppressOnChange = useRef(false);
+      const sendTimeoutRef = useRef(null);
+
+      // Connect WebSocket
+      useEffect(() => {
+        const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+        const wsUrl = `${proto}//${window.location.host}/ws/room/${boardId}`;
+        let ws;
+        let reconnectTimer;
+
+        function connect() {
+          ws = new WebSocket(wsUrl);
+          wsRef.current = ws;
+
+          ws.onopen = () => {
+            setConnected(true);
+          };
+
+          ws.onmessage = (event) => {
+            try {
+              const msg = JSON.parse(event.data);
+
+              if (msg.type === "user-count") {
+                setUserCount(msg.count);
+                return;
+              }
+
+              if (msg.type === "scene-init" && excalidrawAPI) {
+                suppressOnChange.current = true;
+                excalidrawAPI.updateScene({
+                  elements: msg.elements,
+                  captureUpdate: "NEVER",
+                });
+                setTimeout(() => { suppressOnChange.current = false; }, 100);
+                return;
+              }
+
+              if (msg.type === "scene-update" && excalidrawAPI) {
+                suppressOnChange.current = true;
+                excalidrawAPI.updateScene({
+                  elements: msg.elements,
+                  captureUpdate: "NEVER",
+                });
+                setTimeout(() => { suppressOnChange.current = false; }, 100);
+              }
+            } catch {
+              // Non-JSON message, ignore
+            }
+          };
+
+          ws.onclose = () => {
+            setConnected(false);
+            wsRef.current = null;
+            // Reconnect after 2s
+            reconnectTimer = setTimeout(connect, 2000);
+          };
+
+          ws.onerror = () => {
+            ws.close();
+          };
+        }
+
+        connect();
+
+        return () => {
+          clearTimeout(reconnectTimer);
+          if (ws) ws.close();
+        };
+      }, [excalidrawAPI]);
+
+      // Debounced scene broadcast
+      const handleChange = useCallback((elements, appState, files) => {
+        if (suppressOnChange.current) return;
+        if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+
+        // Debounce: send at most every 100ms
+        if (sendTimeoutRef.current) return;
+        sendTimeoutRef.current = setTimeout(() => {
+          sendTimeoutRef.current = null;
+          if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+            wsRef.current.send(JSON.stringify({
+              type: "scene-update",
+              elements: Array.from(elements),
+            }));
+          }
+        }, 100);
+      }, []);
+
+      // Remove loading overlay once mounted
+      useEffect(() => {
+        const el = document.getElementById("loading");
+        if (el) el.remove();
+      }, []);
+
+      return React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(
+          "div",
+          { className: "top-bar" },
+          React.createElement("a", { href: "/" }, "All Boards"),
+          React.createElement(
+            "span",
+            { className: "user-count" },
+            React.createElement("span", { className: "user-dot" }),
+            `${userCount} user${userCount !== 1 ? "s" : ""}`
+          ),
+          React.createElement(
+            "span",
+            { className: "status" },
+            connected ? "Connected" : "Reconnecting..."
+          )
+        ),
+        React.createElement(Excalidraw, {
+          excalidrawAPI: (api) => setExcalidrawAPI(api),
+          onChange: handleChange,
+          theme: "dark",
+          initialData: {
+            appState: {
+              viewBackgroundColor: "#1a1a2e",
+            },
+          },
+        })
+      );
+    }
+
+    const root = createRoot(document.getElementById("root"));
+    root.render(React.createElement(App));
+  </script>
+</body>
+</html>

--- a/plugins/excalidraw/public/index.html
+++ b/plugins/excalidraw/public/index.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Excalidraw Boards</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      min-height: 100vh;
+    }
+
+    .container {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 2rem;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: #fff;
+    }
+
+    h1 span {
+      color: #7c5cfc;
+    }
+
+    .create-section {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    input[type="text"] {
+      background: #16213e;
+      border: 1px solid #2a2a4a;
+      border-radius: 8px;
+      padding: 0.5rem 0.75rem;
+      color: #e0e0e0;
+      font-size: 0.875rem;
+      outline: none;
+      width: 200px;
+      transition: border-color 0.2s;
+    }
+
+    input[type="text"]:focus {
+      border-color: #7c5cfc;
+    }
+
+    input[type="text"]::placeholder {
+      color: #5a5a7a;
+    }
+
+    button {
+      background: #7c5cfc;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 0.5rem 1rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    button:hover {
+      background: #6a4ae8;
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .boards-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .board-card {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: #16213e;
+      border: 1px solid #2a2a4a;
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+      cursor: pointer;
+      transition: border-color 0.2s, background 0.2s;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .board-card:hover {
+      border-color: #7c5cfc;
+      background: #1a2744;
+    }
+
+    .board-info {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .board-name {
+      font-weight: 500;
+      font-size: 1rem;
+      color: #fff;
+    }
+
+    .board-meta {
+      font-size: 0.75rem;
+      color: #7a7a9a;
+    }
+
+    .board-right {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .active-badge {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.75rem;
+      color: #4ade80;
+    }
+
+    .active-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #4ade80;
+    }
+
+    .delete-btn {
+      background: transparent;
+      color: #7a7a9a;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.75rem;
+      border-radius: 6px;
+    }
+
+    .delete-btn:hover {
+      background: #3a1a1a;
+      color: #f87171;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 3rem 1rem;
+      color: #5a5a7a;
+    }
+
+    .empty-state p {
+      margin-bottom: 0.5rem;
+      font-size: 1rem;
+    }
+
+    .empty-state small {
+      font-size: 0.8rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1><span>Excalidraw</span> Boards</h1>
+      <div class="create-section">
+        <input type="text" id="board-name" placeholder="New board name..." />
+        <button id="create-btn">Create</button>
+      </div>
+    </header>
+
+    <div id="boards-list" class="boards-list">
+      <div class="empty-state">
+        <p>Loading boards...</p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const listEl = document.getElementById('boards-list');
+    const nameInput = document.getElementById('board-name');
+    const createBtn = document.getElementById('create-btn');
+
+    function timeAgo(dateStr) {
+      const diff = Date.now() - new Date(dateStr).getTime();
+      const mins = Math.floor(diff / 60000);
+      if (mins < 1) return 'just now';
+      if (mins < 60) return mins + 'm ago';
+      const hrs = Math.floor(mins / 60);
+      if (hrs < 24) return hrs + 'h ago';
+      const days = Math.floor(hrs / 24);
+      return days + 'd ago';
+    }
+
+    async function loadBoards() {
+      try {
+        const res = await fetch('/api/boards');
+        const boards = await res.json();
+
+        if (boards.length === 0) {
+          listEl.innerHTML = `
+            <div class="empty-state">
+              <p>No boards yet</p>
+              <small>Create one to get started</small>
+            </div>`;
+          return;
+        }
+
+        // Sort by last modified (newest first)
+        boards.sort((a, b) => new Date(b.lastModified) - new Date(a.lastModified));
+
+        listEl.innerHTML = boards.map(b => `
+          <a class="board-card" href="/board/${b.id}" data-id="${b.id}">
+            <div class="board-info">
+              <span class="board-name">${escapeHtml(b.name)}</span>
+              <span class="board-meta">Modified ${timeAgo(b.lastModified)}</span>
+            </div>
+            <div class="board-right">
+              ${b.activeUsers > 0 ? `
+                <span class="active-badge">
+                  <span class="active-dot"></span>
+                  ${b.activeUsers} active
+                </span>
+              ` : ''}
+              <button class="delete-btn" onclick="deleteBoard(event, '${b.id}')">Delete</button>
+            </div>
+          </a>
+        `).join('');
+      } catch (err) {
+        listEl.innerHTML = `<div class="empty-state"><p>Failed to load boards</p></div>`;
+      }
+    }
+
+    function escapeHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
+    async function createNewBoard() {
+      const name = nameInput.value.trim();
+      if (!name) return;
+
+      createBtn.disabled = true;
+      try {
+        const res = await fetch('/api/boards', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name }),
+        });
+        if (res.ok) {
+          const board = await res.json();
+          nameInput.value = '';
+          window.location.href = `/board/${board.id}`;
+        }
+      } finally {
+        createBtn.disabled = false;
+      }
+    }
+
+    async function deleteBoard(e, id) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!confirm('Delete this board?')) return;
+
+      await fetch(`/api/boards/${id}`, { method: 'DELETE' });
+      loadBoards();
+    }
+
+    createBtn.addEventListener('click', createNewBoard);
+    nameInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') createNewBoard();
+    });
+
+    loadBoards();
+    // Refresh board list every 10s for active user counts
+    setInterval(loadBoards, 10000);
+  </script>
+</body>
+</html>

--- a/plugins/excalidraw/public/index.html
+++ b/plugins/excalidraw/public/index.html
@@ -9,8 +9,8 @@
 
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: #1a1a2e;
-      color: #e0e0e0;
+      background: #0A0A0A;
+      color: #E8E8E8;
       min-height: 100vh;
     }
 
@@ -30,11 +30,11 @@
     h1 {
       font-size: 1.5rem;
       font-weight: 600;
-      color: #fff;
+      color: #E8E8E8;
     }
 
     h1 span {
-      color: #7c5cfc;
+      color: #16A37F;
     }
 
     .create-section {
@@ -43,11 +43,11 @@
     }
 
     input[type="text"] {
-      background: #16213e;
-      border: 1px solid #2a2a4a;
-      border-radius: 8px;
+      background: #111111;
+      border: 1px solid #2A2A2A;
+      border-radius: 6px;
       padding: 0.5rem 0.75rem;
-      color: #e0e0e0;
+      color: #E8E8E8;
       font-size: 0.875rem;
       outline: none;
       width: 200px;
@@ -55,18 +55,18 @@
     }
 
     input[type="text"]:focus {
-      border-color: #7c5cfc;
+      border-color: #16A37F;
     }
 
     input[type="text"]::placeholder {
-      color: #5a5a7a;
+      color: #6B6B6B;
     }
 
     button {
-      background: #7c5cfc;
-      color: #fff;
+      background: #16A37F;
+      color: #0A0A0A;
       border: none;
-      border-radius: 8px;
+      border-radius: 6px;
       padding: 0.5rem 1rem;
       font-size: 0.875rem;
       font-weight: 500;
@@ -75,7 +75,7 @@
     }
 
     button:hover {
-      background: #6a4ae8;
+      background: #139169;
     }
 
     button:disabled {
@@ -93,9 +93,9 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      background: #16213e;
-      border: 1px solid #2a2a4a;
-      border-radius: 10px;
+      background: #111111;
+      border: 1px solid #2A2A2A;
+      border-radius: 6px;
       padding: 1rem 1.25rem;
       cursor: pointer;
       transition: border-color 0.2s, background 0.2s;
@@ -104,8 +104,8 @@
     }
 
     .board-card:hover {
-      border-color: #7c5cfc;
-      background: #1a2744;
+      border-color: #16A37F;
+      background: #181818;
     }
 
     .board-info {
@@ -117,12 +117,12 @@
     .board-name {
       font-weight: 500;
       font-size: 1rem;
-      color: #fff;
+      color: #E8E8E8;
     }
 
     .board-meta {
       font-size: 0.75rem;
-      color: #7a7a9a;
+      color: #6B6B6B;
     }
 
     .board-right {
@@ -136,33 +136,33 @@
       align-items: center;
       gap: 0.35rem;
       font-size: 0.75rem;
-      color: #4ade80;
+      color: #16A37F;
     }
 
     .active-dot {
       width: 6px;
       height: 6px;
       border-radius: 50%;
-      background: #4ade80;
+      background: #16A37F;
     }
 
     .delete-btn {
       background: transparent;
-      color: #7a7a9a;
+      color: #6B6B6B;
       padding: 0.25rem 0.5rem;
       font-size: 0.75rem;
-      border-radius: 6px;
+      border-radius: 4px;
     }
 
     .delete-btn:hover {
-      background: #3a1a1a;
-      color: #f87171;
+      background: #1a0a0a;
+      color: #F87171;
     }
 
     .empty-state {
       text-align: center;
       padding: 3rem 1rem;
-      color: #5a5a7a;
+      color: #6B6B6B;
     }
 
     .empty-state p {
@@ -222,7 +222,6 @@
           return;
         }
 
-        // Sort by last modified (newest first)
         boards.sort((a, b) => new Date(b.lastModified) - new Date(a.lastModified));
 
         listEl.innerHTML = boards.map(b => `
@@ -268,7 +267,13 @@
           const board = await res.json();
           nameInput.value = '';
           window.location.href = `/board/${board.id}`;
+        } else {
+          const err = await res.json().catch(() => ({ error: 'Failed to create board' }));
+          alert(err.error || 'Failed to create board');
         }
+      } catch (err) {
+        console.error('Create board error:', err);
+        alert('Network error — could not create board');
       } finally {
         createBtn.disabled = false;
       }
@@ -279,8 +284,18 @@
       e.stopPropagation();
       if (!confirm('Delete this board?')) return;
 
-      await fetch(`/api/boards/${id}`, { method: 'DELETE' });
-      loadBoards();
+      try {
+        const res = await fetch(`/api/boards/${id}`, { method: 'DELETE' });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: 'Failed to delete board' }));
+          alert(err.error || 'Failed to delete board');
+          return;
+        }
+        loadBoards();
+      } catch (err) {
+        console.error('Delete board error:', err);
+        alert('Network error — could not delete board');
+      }
     }
 
     createBtn.addEventListener('click', createNewBoard);
@@ -289,7 +304,6 @@
     });
 
     loadBoards();
-    // Refresh board list every 10s for active user counts
     setInterval(loadBoards, 10000);
   </script>
 </body>

--- a/plugins/excalidraw/public/index.html
+++ b/plugins/excalidraw/public/index.html
@@ -97,9 +97,7 @@
       border: 1px solid #2A2A2A;
       border-radius: 6px;
       padding: 1rem 1.25rem;
-      cursor: pointer;
       transition: border-color 0.2s, background 0.2s;
-      text-decoration: none;
       color: inherit;
     }
 
@@ -108,10 +106,14 @@
       background: #181818;
     }
 
-    .board-info {
+    .board-link {
       display: flex;
       flex-direction: column;
       gap: 0.25rem;
+      text-decoration: none;
+      color: inherit;
+      flex: 1;
+      min-width: 0;
     }
 
     .board-name {
@@ -225,11 +227,11 @@
         boards.sort((a, b) => new Date(b.lastModified) - new Date(a.lastModified));
 
         listEl.innerHTML = boards.map(b => `
-          <a class="board-card" href="/board/${b.id}" data-id="${b.id}">
-            <div class="board-info">
+          <div class="board-card" data-id="${b.id}">
+            <a class="board-link" href="/board/${b.id}">
               <span class="board-name">${escapeHtml(b.name)}</span>
               <span class="board-meta">Modified ${timeAgo(b.lastModified)}</span>
-            </div>
+            </a>
             <div class="board-right">
               ${b.activeUsers > 0 ? `
                 <span class="active-badge">
@@ -239,7 +241,7 @@
               ` : ''}
               <button class="delete-btn" onclick="deleteBoard(event, '${b.id}')">Delete</button>
             </div>
-          </a>
+          </div>
         `).join('');
       } catch (err) {
         listEl.innerHTML = `<div class="empty-state"><p>Failed to load boards</p></div>`;
@@ -252,11 +254,14 @@
       return div.innerHTML;
     }
 
+    let creating = false;
     async function createNewBoard() {
       const name = nameInput.value.trim();
-      if (!name) return;
+      if (!name || creating) return;
 
+      creating = true;
       createBtn.disabled = true;
+      nameInput.disabled = true;
       try {
         const res = await fetch('/api/boards', {
           method: 'POST',
@@ -275,7 +280,9 @@
         console.error('Create board error:', err);
         alert('Network error — could not create board');
       } finally {
+        creating = false;
         createBtn.disabled = false;
+        nameInput.disabled = false;
       }
     }
 

--- a/plugins/excalidraw/scripts/build-client.mjs
+++ b/plugins/excalidraw/scripts/build-client.mjs
@@ -1,0 +1,55 @@
+import { build } from "esbuild";
+import { createRequire } from "module";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Resolve the exact paths for top-level react packages to guarantee
+// all transitive imports resolve to the SAME files (no duplicates).
+const reactResolves = {};
+for (const pkg of [
+  "react",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "react-dom",
+  "react-dom/client",
+]) {
+  try {
+    reactResolves[pkg] = require.resolve(pkg);
+  } catch {
+    // jsx-dev-runtime may not exist in prod
+  }
+}
+
+await build({
+  entryPoints: ["src/excalidraw-entry.ts"],
+  bundle: true,
+  format: "esm",
+  outfile: "public/excalidraw-bundle.js",
+  minify: true,
+  define: {
+    "process.env.NODE_ENV": '"production"',
+  },
+  plugins: [
+    {
+      name: "react-singleton",
+      setup(build) {
+        // Force every import of react/react-dom to the top-level install
+        build.onResolve(
+          { filter: /^react(-dom)?(\/.*)?$/ },
+          (args) => {
+            const resolved = reactResolves[args.path];
+            if (resolved) {
+              return { path: resolved };
+            }
+            return null;
+          }
+        );
+      },
+    },
+  ],
+});
+
+console.log("Client bundle built → public/excalidraw-bundle.js");

--- a/plugins/excalidraw/src/boards.ts
+++ b/plugins/excalidraw/src/boards.ts
@@ -1,0 +1,102 @@
+import { readdir, readFile, writeFile, mkdir, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+const DATA_DIR = process.env.DATA_DIR ?? "/app/data";
+const BOARDS_DIR = join(DATA_DIR, "boards");
+
+export interface BoardMeta {
+  id: string;
+  name: string;
+  createdAt: string;
+  lastModified: string;
+}
+
+export interface BoardData {
+  elements: unknown[];
+  appState?: Record<string, unknown>;
+}
+
+async function ensureDir(): Promise<void> {
+  await mkdir(BOARDS_DIR, { recursive: true });
+}
+
+function indexPath(): string {
+  return join(BOARDS_DIR, "index.json");
+}
+
+function boardPath(id: string): string {
+  return join(BOARDS_DIR, `${id}.json`);
+}
+
+async function readIndex(): Promise<BoardMeta[]> {
+  try {
+    const raw = await readFile(indexPath(), "utf-8");
+    return JSON.parse(raw) as BoardMeta[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeIndex(boards: BoardMeta[]): Promise<void> {
+  await ensureDir();
+  await writeFile(indexPath(), JSON.stringify(boards, null, 2));
+}
+
+export async function listBoards(): Promise<BoardMeta[]> {
+  return readIndex();
+}
+
+export async function createBoard(name: string): Promise<BoardMeta> {
+  await ensureDir();
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const meta: BoardMeta = { id, name, createdAt: now, lastModified: now };
+  const boards = await readIndex();
+  boards.push(meta);
+  await writeIndex(boards);
+
+  const data: BoardData = { elements: [] };
+  await writeFile(boardPath(id), JSON.stringify(data));
+
+  return meta;
+}
+
+export async function getBoard(id: string): Promise<BoardData | null> {
+  try {
+    const raw = await readFile(boardPath(id), "utf-8");
+    return JSON.parse(raw) as BoardData;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveBoard(id: string, data: BoardData): Promise<void> {
+  await ensureDir();
+  await writeFile(boardPath(id), JSON.stringify(data));
+
+  // Update lastModified in index
+  const boards = await readIndex();
+  const entry = boards.find((b) => b.id === id);
+  if (entry) {
+    entry.lastModified = new Date().toISOString();
+    await writeIndex(boards);
+  }
+}
+
+export async function deleteBoard(id: string): Promise<boolean> {
+  const boards = await readIndex();
+  const idx = boards.findIndex((b) => b.id === id);
+  if (idx === -1) return false;
+
+  boards.splice(idx, 1);
+  await writeIndex(boards);
+
+  try {
+    await unlink(boardPath(id));
+  } catch {
+    // Board file may not exist
+  }
+
+  return true;
+}

--- a/plugins/excalidraw/src/boards.ts
+++ b/plugins/excalidraw/src/boards.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, writeFile, mkdir, unlink } from "node:fs/promises";
+import { readFile, writeFile, mkdir, unlink, rename } from "node:fs/promises";
 import { join } from "node:path";
 
 const DATA_DIR = process.env.DATA_DIR ?? "/app/data";
@@ -14,6 +14,18 @@ export interface BoardMeta {
 export interface BoardData {
   elements: unknown[];
   appState?: Record<string, unknown>;
+}
+
+// Simple async mutex to serialize index read-modify-write
+let lockPromise: Promise<void> = Promise.resolve();
+
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = lockPromise;
+  let resolve: () => void;
+  lockPromise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return prev.then(fn).finally(() => resolve!());
 }
 
 async function ensureDir(): Promise<void> {
@@ -32,14 +44,19 @@ async function readIndex(): Promise<BoardMeta[]> {
   try {
     const raw = await readFile(indexPath(), "utf-8");
     return JSON.parse(raw) as BoardMeta[];
-  } catch {
-    return [];
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+      return [];
+    }
+    throw new Error(`Failed to read board index: ${err}`);
   }
 }
 
-async function writeIndex(boards: BoardMeta[]): Promise<void> {
+async function writeIndexAtomic(boards: BoardMeta[]): Promise<void> {
   await ensureDir();
-  await writeFile(indexPath(), JSON.stringify(boards, null, 2));
+  const tmpPath = indexPath() + ".tmp";
+  await writeFile(tmpPath, JSON.stringify(boards, null, 2));
+  await rename(tmpPath, indexPath());
 }
 
 export async function listBoards(): Promise<BoardMeta[]> {
@@ -47,56 +64,66 @@ export async function listBoards(): Promise<BoardMeta[]> {
 }
 
 export async function createBoard(name: string): Promise<BoardMeta> {
-  await ensureDir();
-  const id = crypto.randomUUID();
-  const now = new Date().toISOString();
+  return withLock(async () => {
+    await ensureDir();
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
 
-  const meta: BoardMeta = { id, name, createdAt: now, lastModified: now };
-  const boards = await readIndex();
-  boards.push(meta);
-  await writeIndex(boards);
+    // Write board file first, then publish to index
+    const data: BoardData = { elements: [] };
+    await writeFile(boardPath(id), JSON.stringify(data));
 
-  const data: BoardData = { elements: [] };
-  await writeFile(boardPath(id), JSON.stringify(data));
+    const meta: BoardMeta = { id, name, createdAt: now, lastModified: now };
+    const boards = await readIndex();
+    boards.push(meta);
+    await writeIndexAtomic(boards);
 
-  return meta;
+    return meta;
+  });
 }
 
 export async function getBoard(id: string): Promise<BoardData | null> {
   try {
     const raw = await readFile(boardPath(id), "utf-8");
     return JSON.parse(raw) as BoardData;
-  } catch {
-    return null;
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+      return null;
+    }
+    throw new Error(`Failed to read board ${id}: ${err}`);
   }
 }
 
 export async function saveBoard(id: string, data: BoardData): Promise<void> {
-  await ensureDir();
-  await writeFile(boardPath(id), JSON.stringify(data));
+  return withLock(async () => {
+    await ensureDir();
+    await writeFile(boardPath(id), JSON.stringify(data));
 
-  // Update lastModified in index
-  const boards = await readIndex();
-  const entry = boards.find((b) => b.id === id);
-  if (entry) {
-    entry.lastModified = new Date().toISOString();
-    await writeIndex(boards);
-  }
+    // Update lastModified in index
+    const boards = await readIndex();
+    const entry = boards.find((b) => b.id === id);
+    if (entry) {
+      entry.lastModified = new Date().toISOString();
+      await writeIndexAtomic(boards);
+    }
+  });
 }
 
 export async function deleteBoard(id: string): Promise<boolean> {
-  const boards = await readIndex();
-  const idx = boards.findIndex((b) => b.id === id);
-  if (idx === -1) return false;
+  return withLock(async () => {
+    const boards = await readIndex();
+    const idx = boards.findIndex((b) => b.id === id);
+    if (idx === -1) return false;
 
-  boards.splice(idx, 1);
-  await writeIndex(boards);
+    boards.splice(idx, 1);
+    await writeIndexAtomic(boards);
 
-  try {
-    await unlink(boardPath(id));
-  } catch {
-    // Board file may not exist
-  }
+    try {
+      await unlink(boardPath(id));
+    } catch {
+      // Board file may not exist
+    }
 
-  return true;
+    return true;
+  });
 }

--- a/plugins/excalidraw/src/excalidraw-entry.ts
+++ b/plugins/excalidraw/src/excalidraw-entry.ts
@@ -1,0 +1,8 @@
+export {
+  Excalidraw,
+  reconcileElements,
+  restoreElements,
+  getSceneVersion,
+} from "@excalidraw/excalidraw";
+export { default as React, useState, useCallback, useEffect, useRef } from "react";
+export { createRoot } from "react-dom/client";

--- a/plugins/excalidraw/src/room.ts
+++ b/plugins/excalidraw/src/room.ts
@@ -1,0 +1,153 @@
+import type { ServerWebSocket } from "bun";
+import { saveBoard, getBoard } from "./boards.js";
+import type { BoardData } from "./boards.js";
+
+interface Client {
+  ws: ServerWebSocket<{ boardId: string }>;
+}
+
+interface Room {
+  boardId: string;
+  clients: Set<Client>;
+  saveTimer: ReturnType<typeof setInterval> | null;
+  lastElements: unknown[] | null;
+}
+
+const rooms = new Map<string, Room>();
+
+const AUTO_SAVE_INTERVAL = 30_000; // 30 seconds
+
+function getOrCreateRoom(boardId: string): Room {
+  let room = rooms.get(boardId);
+  if (!room) {
+    room = {
+      boardId,
+      clients: new Set(),
+      saveTimer: null,
+      lastElements: null,
+    };
+    rooms.set(boardId, room);
+  }
+  return room;
+}
+
+function startAutoSave(room: Room): void {
+  if (room.saveTimer) return;
+  room.saveTimer = setInterval(async () => {
+    if (room.lastElements) {
+      await saveBoard(room.boardId, { elements: room.lastElements });
+    }
+  }, AUTO_SAVE_INTERVAL);
+}
+
+function stopAutoSave(room: Room): void {
+  if (room.saveTimer) {
+    clearInterval(room.saveTimer);
+    room.saveTimer = null;
+  }
+}
+
+export function addClient(ws: ServerWebSocket<{ boardId: string }>): void {
+  const { boardId } = ws.data;
+  const room = getOrCreateRoom(boardId);
+  const client: Client = { ws };
+  room.clients.add(client);
+  startAutoSave(room);
+
+  // Send current board state to the new client
+  getBoard(boardId).then((data) => {
+    if (data && data.elements.length > 0) {
+      try {
+        ws.send(
+          JSON.stringify({ type: "scene-init", elements: data.elements })
+        );
+      } catch {
+        // Client may have disconnected
+      }
+    }
+  });
+}
+
+export function removeClient(ws: ServerWebSocket<{ boardId: string }>): void {
+  const { boardId } = ws.data;
+  const room = rooms.get(boardId);
+  if (!room) return;
+
+  // Find and remove the client
+  for (const client of room.clients) {
+    if (client.ws === ws) {
+      room.clients.delete(client);
+      break;
+    }
+  }
+
+  // Broadcast updated user count
+  broadcastUserCount(room);
+
+  // If room is empty, save and clean up
+  if (room.clients.size === 0) {
+    stopAutoSave(room);
+    if (room.lastElements) {
+      saveBoard(room.boardId, { elements: room.lastElements });
+    }
+    rooms.delete(boardId);
+  }
+}
+
+export function handleMessage(
+  ws: ServerWebSocket<{ boardId: string }>,
+  message: string | Buffer
+): void {
+  const { boardId } = ws.data;
+  const room = rooms.get(boardId);
+  if (!room) return;
+
+  // Try to parse and track elements for auto-save
+  if (typeof message === "string") {
+    try {
+      const parsed = JSON.parse(message);
+      if (parsed.type === "scene-update" && Array.isArray(parsed.elements)) {
+        room.lastElements = parsed.elements;
+      }
+    } catch {
+      // Binary or non-JSON message — relay as-is
+    }
+  }
+
+  // Relay to all other clients in the room
+  for (const client of room.clients) {
+    if (client.ws !== ws) {
+      try {
+        client.ws.send(message);
+      } catch {
+        // Client may have disconnected
+      }
+    }
+  }
+}
+
+function broadcastUserCount(room: Room): void {
+  const msg = JSON.stringify({
+    type: "user-count",
+    count: room.clients.size,
+  });
+  for (const client of room.clients) {
+    try {
+      client.ws.send(msg);
+    } catch {
+      // Ignore
+    }
+  }
+}
+
+export function getRoomUserCount(boardId: string): number {
+  return rooms.get(boardId)?.clients.size ?? 0;
+}
+
+export function getAllRoomCounts(): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const [boardId, room] of rooms) {
+    counts.set(boardId, room.clients.size);
+  }
+  return counts;
+}

--- a/plugins/excalidraw/src/room.ts
+++ b/plugins/excalidraw/src/room.ts
@@ -1,9 +1,9 @@
 import type { ServerWebSocket } from "bun";
 import { saveBoard, getBoard } from "./boards.js";
-import type { BoardData } from "./boards.js";
 
 interface Client {
-  ws: ServerWebSocket<{ boardId: string }>;
+  id: string;
+  ws: ServerWebSocket<{ boardId: string; clientId: string }>;
 }
 
 interface Room {
@@ -15,7 +15,7 @@ interface Room {
 
 const rooms = new Map<string, Room>();
 
-const AUTO_SAVE_INTERVAL = 30_000; // 30 seconds
+const AUTO_SAVE_INTERVAL = 30_000;
 
 function getOrCreateRoom(boardId: string): Room {
   let room = rooms.get(boardId);
@@ -33,9 +33,11 @@ function getOrCreateRoom(boardId: string): Room {
 
 function startAutoSave(room: Room): void {
   if (room.saveTimer) return;
-  room.saveTimer = setInterval(async () => {
+  room.saveTimer = setInterval(() => {
     if (room.lastElements) {
-      await saveBoard(room.boardId, { elements: room.lastElements });
+      saveBoard(room.boardId, { elements: room.lastElements }).catch((err) => {
+        console.error(`Auto-save failed for board ${room.boardId}:`, err);
+      });
     }
   }, AUTO_SAVE_INTERVAL);
 }
@@ -47,33 +49,35 @@ function stopAutoSave(room: Room): void {
   }
 }
 
-export function addClient(ws: ServerWebSocket<{ boardId: string }>): void {
-  const { boardId } = ws.data;
+export function addClient(ws: ServerWebSocket<{ boardId: string; clientId: string }>): void {
+  const { boardId, clientId } = ws.data;
   const room = getOrCreateRoom(boardId);
-  const client: Client = { ws };
+  const client: Client = { id: clientId, ws };
   room.clients.add(client);
   startAutoSave(room);
 
-  // Send current board state to the new client
-  getBoard(boardId).then((data) => {
-    if (data && data.elements.length > 0) {
-      try {
-        ws.send(
-          JSON.stringify({ type: "scene-init", elements: data.elements })
-        );
-      } catch {
-        // Client may have disconnected
+  // Tell the new client their assigned ID
+  trySend(ws, JSON.stringify({ type: "client-id", id: clientId }));
+
+  // Send current scene to the new client — prefer in-memory over disk
+  if (room.lastElements && room.lastElements.length > 0) {
+    trySend(ws, JSON.stringify({ type: "scene-init", elements: room.lastElements }));
+    broadcastRoomUsers(room);
+  } else {
+    getBoard(boardId).then((data) => {
+      if (data && data.elements.length > 0) {
+        trySend(ws, JSON.stringify({ type: "scene-init", elements: data.elements }));
       }
-    }
-  });
+      broadcastRoomUsers(room);
+    });
+  }
 }
 
-export function removeClient(ws: ServerWebSocket<{ boardId: string }>): void {
+export function removeClient(ws: ServerWebSocket<{ boardId: string; clientId: string }>): void {
   const { boardId } = ws.data;
   const room = rooms.get(boardId);
   if (!room) return;
 
-  // Find and remove the client
   for (const client of room.clients) {
     if (client.ws === ws) {
       room.clients.delete(client);
@@ -81,67 +85,87 @@ export function removeClient(ws: ServerWebSocket<{ boardId: string }>): void {
     }
   }
 
-  // Broadcast updated user count
-  broadcastUserCount(room);
+  broadcastRoomUsers(room);
 
-  // If room is empty, save and clean up
   if (room.clients.size === 0) {
     stopAutoSave(room);
     if (room.lastElements) {
-      saveBoard(room.boardId, { elements: room.lastElements });
+      saveBoard(room.boardId, { elements: room.lastElements }).catch((err) => {
+        console.error(`Final save failed for board ${room.boardId}:`, err);
+      });
     }
     rooms.delete(boardId);
   }
 }
 
 export function handleMessage(
-  ws: ServerWebSocket<{ boardId: string }>,
+  ws: ServerWebSocket<{ boardId: string; clientId: string }>,
   message: string | Buffer
 ): void {
-  const { boardId } = ws.data;
+  const { boardId, clientId } = ws.data;
   const room = rooms.get(boardId);
   if (!room) return;
 
-  // Try to parse and track elements for auto-save
   if (typeof message === "string") {
     try {
       const parsed = JSON.parse(message);
+
       if (parsed.type === "scene-update" && Array.isArray(parsed.elements)) {
+        // Track for auto-save
         room.lastElements = parsed.elements;
+
+        // Relay to all other clients with sender's clientId
+        const relayMsg = JSON.stringify({
+          type: "scene-update",
+          elements: parsed.elements,
+          clientId,
+        });
+        for (const client of room.clients) {
+          if (client.ws !== ws) {
+            trySend(client.ws, relayMsg);
+          }
+        }
+        return;
+      }
+
+      if (parsed.type === "pointer-update") {
+        // Volatile relay — don't track, just forward with clientId
+        const relayMsg = JSON.stringify({
+          type: "pointer-update",
+          clientId,
+          pointer: parsed.pointer,
+          button: parsed.button,
+        });
+        for (const client of room.clients) {
+          if (client.ws !== ws) {
+            trySend(client.ws, relayMsg);
+          }
+        }
+        return;
       }
     } catch {
-      // Binary or non-JSON message — relay as-is
-    }
-  }
-
-  // Relay to all other clients in the room
-  for (const client of room.clients) {
-    if (client.ws !== ws) {
-      try {
-        client.ws.send(message);
-      } catch {
-        // Client may have disconnected
-      }
+      // Non-JSON or malformed — ignore
     }
   }
 }
 
-function broadcastUserCount(room: Room): void {
+function broadcastRoomUsers(room: Room): void {
+  const clients = Array.from(room.clients).map((c) => ({ id: c.id }));
   const msg = JSON.stringify({
-    type: "user-count",
-    count: room.clients.size,
+    type: "room-users",
+    clients,
   });
   for (const client of room.clients) {
-    try {
-      client.ws.send(msg);
-    } catch {
-      // Ignore
-    }
+    trySend(client.ws, msg);
   }
 }
 
-export function getRoomUserCount(boardId: string): number {
-  return rooms.get(boardId)?.clients.size ?? 0;
+function trySend(ws: ServerWebSocket<unknown>, msg: string): void {
+  try {
+    ws.send(msg);
+  } catch {
+    // Client may have disconnected
+  }
 }
 
 export function getAllRoomCounts(): Map<string, number> {

--- a/plugins/excalidraw/src/server.ts
+++ b/plugins/excalidraw/src/server.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join, extname } from "node:path";
+import { join, extname, resolve, normalize } from "node:path";
 import { listBoards, createBoard, deleteBoard, getBoard } from "./boards.js";
 import {
   addClient,
@@ -40,7 +40,7 @@ function json(data: unknown, status = 200): Response {
   });
 }
 
-const server = Bun.serve<{ boardId: string }>({
+const server = Bun.serve<{ boardId: string; clientId: string }>({
   port: PORT,
   hostname: "0.0.0.0",
 
@@ -61,11 +61,12 @@ const server = Bun.serve<{ boardId: string }>({
       if (!board) {
         return json({ error: "Board not found" }, 404);
       }
-      const upgraded = server.upgrade(req, { data: { boardId } });
+      const clientId = crypto.randomUUID();
+      const upgraded = server.upgrade(req, { data: { boardId, clientId } });
       if (!upgraded) {
         return new Response("WebSocket upgrade failed", { status: 400 });
       }
-      return undefined as unknown as Response;
+      return;
     }
 
     // --- API routes ---
@@ -113,9 +114,13 @@ const server = Bun.serve<{ boardId: string }>({
       return serveStatic(join(PUBLIC_DIR, "index.html"));
     }
 
-    // Serve other static files from public/
-    const safePath = pathname.replace(/\.\./g, "");
-    return serveStatic(join(PUBLIC_DIR, safePath));
+    // Serve other static files from public/ with path traversal protection
+    const decoded = decodeURIComponent(pathname);
+    const resolved = resolve(PUBLIC_DIR, normalize(decoded).replace(/^\/+/, ""));
+    if (!resolved.startsWith(PUBLIC_DIR)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+    return serveStatic(resolved);
   },
 
   websocket: {

--- a/plugins/excalidraw/src/server.ts
+++ b/plugins/excalidraw/src/server.ts
@@ -106,6 +106,10 @@ const server = Bun.serve<{ boardId: string; clientId: string }>({
     // --- Board editor page ---
     const boardMatch = pathname.match(/^\/board\/([a-f0-9-]+)$/);
     if (boardMatch) {
+      const board = await getBoard(boardMatch[1]!);
+      if (!board) {
+        return json({ error: "Board not found" }, 404);
+      }
       return serveStatic(join(PUBLIC_DIR, "board.html"));
     }
 
@@ -115,7 +119,12 @@ const server = Bun.serve<{ boardId: string; clientId: string }>({
     }
 
     // Serve other static files from public/ with path traversal protection
-    const decoded = decodeURIComponent(pathname);
+    let decoded;
+    try {
+      decoded = decodeURIComponent(pathname);
+    } catch {
+      return new Response("Bad Request", { status: 400 });
+    }
     const resolved = resolve(PUBLIC_DIR, normalize(decoded).replace(/^\/+/, ""));
     if (!resolved.startsWith(PUBLIC_DIR)) {
       return new Response("Forbidden", { status: 403 });

--- a/plugins/excalidraw/src/server.ts
+++ b/plugins/excalidraw/src/server.ts
@@ -1,0 +1,134 @@
+import { readFile } from "node:fs/promises";
+import { join, extname } from "node:path";
+import { listBoards, createBoard, deleteBoard, getBoard } from "./boards.js";
+import {
+  addClient,
+  removeClient,
+  handleMessage,
+  getAllRoomCounts,
+} from "./room.js";
+
+const PORT = Number(process.env.PORT) || 3000;
+const PUBLIC_DIR = join(import.meta.dir, "..", "public");
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+};
+
+async function serveStatic(filePath: string): Promise<Response> {
+  try {
+    const content = await readFile(filePath);
+    const ext = extname(filePath);
+    return new Response(content, {
+      headers: { "Content-Type": MIME_TYPES[ext] ?? "application/octet-stream" },
+    });
+  } catch {
+    return new Response("Not Found", { status: 404 });
+  }
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const server = Bun.serve<{ boardId: string }>({
+  port: PORT,
+  hostname: "0.0.0.0",
+
+  async fetch(req, server) {
+    const url = new URL(req.url);
+    const { pathname } = url;
+
+    // --- Health check ---
+    if (pathname === "/health") {
+      return json({ status: "ok" });
+    }
+
+    // --- WebSocket upgrade ---
+    const wsMatch = pathname.match(/^\/ws\/room\/([a-f0-9-]+)$/);
+    if (wsMatch) {
+      const boardId = wsMatch[1]!;
+      const board = await getBoard(boardId);
+      if (!board) {
+        return json({ error: "Board not found" }, 404);
+      }
+      const upgraded = server.upgrade(req, { data: { boardId } });
+      if (!upgraded) {
+        return new Response("WebSocket upgrade failed", { status: 400 });
+      }
+      return undefined as unknown as Response;
+    }
+
+    // --- API routes ---
+    if (pathname === "/api/boards" && req.method === "GET") {
+      const boards = await listBoards();
+      const roomCounts = getAllRoomCounts();
+      const withCounts = boards.map((b) => ({
+        ...b,
+        activeUsers: roomCounts.get(b.id) ?? 0,
+      }));
+      return json(withCounts);
+    }
+
+    if (pathname === "/api/boards" && req.method === "POST") {
+      try {
+        const body = (await req.json()) as { name?: string };
+        const name = body.name?.trim();
+        if (!name) {
+          return json({ error: "Board name is required" }, 400);
+        }
+        const board = await createBoard(name);
+        return json(board, 201);
+      } catch {
+        return json({ error: "Invalid request body" }, 400);
+      }
+    }
+
+    const deleteMatch = pathname.match(/^\/api\/boards\/([a-f0-9-]+)$/);
+    if (deleteMatch && req.method === "DELETE") {
+      const deleted = await deleteBoard(deleteMatch[1]!);
+      if (!deleted) {
+        return json({ error: "Board not found" }, 404);
+      }
+      return json({ ok: true });
+    }
+
+    // --- Board editor page ---
+    const boardMatch = pathname.match(/^\/board\/([a-f0-9-]+)$/);
+    if (boardMatch) {
+      return serveStatic(join(PUBLIC_DIR, "board.html"));
+    }
+
+    // --- Static files ---
+    if (pathname === "/" || pathname === "/index.html") {
+      return serveStatic(join(PUBLIC_DIR, "index.html"));
+    }
+
+    // Serve other static files from public/
+    const safePath = pathname.replace(/\.\./g, "");
+    return serveStatic(join(PUBLIC_DIR, safePath));
+  },
+
+  websocket: {
+    open(ws) {
+      addClient(ws);
+    },
+    message(ws, message) {
+      handleMessage(ws, message);
+    },
+    close(ws) {
+      removeClient(ws);
+    },
+  },
+});
+
+console.log(`Excalidraw Boards running on http://0.0.0.0:${server.port}`);

--- a/plugins/excalidraw/tsconfig.json
+++ b/plugins/excalidraw/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/plugins/excalidraw/uncorded-plugin.json
+++ b/plugins/excalidraw/uncorded-plugin.json
@@ -1,0 +1,21 @@
+{
+  "id": "excalidraw-boards",
+  "name": "Excalidraw Boards",
+  "version": "1.0.0",
+  "description": "Collaborative whiteboard — create boards and draw together in real-time",
+  "author": "UnCorded",
+  "scope": "server",
+  "runtime": {
+    "image": "excalidraw-boards:latest",
+    "port": 3000,
+    "healthCheck": "/health"
+  },
+  "permissions": ["server.read", "members.read"],
+  "resources": {
+    "cpus": 0.5,
+    "memoryMb": 256
+  },
+  "ui": {
+    "type": "page"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the first real server plugin — collaborative whiteboard powered by Excalidraw
- Bun HTTP + WebSocket server with board CRUD API and real-time collab relay
- CDN-loaded Excalidraw editor with dark theme, auto-reconnect, debounced sync
- JSON file persistence at `/app/data/boards/` (Docker volume mount)
- Multi-stage Dockerfile (`oven/bun:1-alpine`) with health check
- Plugin manifest conforming to `PluginManifest` interface (`server` scope)

## What's included

```
plugins/excalidraw/
├── uncorded-plugin.json    ← Server-scope manifest
├── Dockerfile              ← Multi-stage Bun build
├── package.json
├── tsconfig.json
├── src/
│   ├── server.ts           ← HTTP routes + WS upgrade
│   ├── boards.ts           ← Board CRUD + JSON persistence
│   └── room.ts             ← WebSocket room relay
└── public/
    ├── index.html           ← Board picker (dark theme)
    └── board.html           ← Excalidraw editor (CDN-loaded)
```

## Test plan

- [x] `docker build -t excalidraw-boards:latest plugins/excalidraw/` succeeds
- [x] Container starts and `/health` returns `{"status":"ok"}`
- [x] Board picker loads at `/`
- [x] `POST /api/boards` creates a board, `GET /api/boards` lists it
- [x] `DELETE /api/boards/:id` removes a board
- [x] Board editor loads at `/board/:id`
- [ ] Open two browser tabs to same board — verify real-time collab via WebSocket
- [ ] Integration test with plugin platform (install via sidecar, verify tunnel + iframe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Excalidraw Boards plugin: browse, create, delete boards; open collaborative board editor with real-time drawing sync, pointer sharing, live active-user indicators, automatic reconnect and periodic auto-save.

* **Chores**
  * Added plugin packaging, server with healthcheck, container image support, TypeScript build/config, and a client bundling step for production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->