### PR TITLE
feat: Plugin SDK & Developer Experience (Phase 3)

### DIFF
--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -228,7 +228,7 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
                       >
                         {toggling() === plugin.pluginId
                           ? "..."
-                          : plugin.state === "active" || plugin.state === "running"
+                          : plugin.state === "active"
                             ? "Stop"
                             : "Start"}
                       </Button>

--- a/apps/web/src/pages/ServerView.tsx
+++ b/apps/web/src/pages/ServerView.tsx
@@ -142,7 +142,7 @@ const ServerView = () => {
               breadcrumbs={[{ label: "Servers" }]}
             />
             <div class="flex-1 overflow-hidden">
-              <PluginFrame plugin={plugin()} tunnelUrl={activeServerPlugin()?.tunnelUrl} />
+              <PluginFrame plugin={plugin()} tunnelUrl={activeServerPlugin()?.tunnelUrl ?? null} />
             </div>
           </>
         )}

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,37 @@
         "vite-plugin-solid": "^2",
       },
     },
+    "packages/create-uncorded-plugin": {
+      "name": "create-uncorded-plugin",
+      "version": "0.0.0",
+      "bin": {
+        "create-uncorded-plugin": "./src/index.ts",
+      },
+    },
+    "packages/mock-bridge": {
+      "name": "@uncorded/mock-bridge",
+      "version": "0.0.0",
+      "bin": {
+        "mock-bridge": "./src/index.ts",
+      },
+      "dependencies": {
+        "elysia": "^1",
+      },
+    },
+    "packages/plugin-client": {
+      "name": "@uncorded/plugin-client",
+      "version": "0.0.0",
+      "dependencies": {
+        "@uncorded/protocol": "*",
+      },
+    },
+    "packages/plugin-server": {
+      "name": "@uncorded/plugin-server",
+      "version": "0.0.0",
+      "dependencies": {
+        "@uncorded/protocol": "*",
+      },
+    },
     "packages/protocol": {
       "name": "@uncorded/protocol",
       "version": "0.0.0",
@@ -959,6 +990,12 @@
 
     "@uncorded/desktop": ["@uncorded/desktop@workspace:apps/desktop"],
 
+    "@uncorded/mock-bridge": ["@uncorded/mock-bridge@workspace:packages/mock-bridge"],
+
+    "@uncorded/plugin-client": ["@uncorded/plugin-client@workspace:packages/plugin-client"],
+
+    "@uncorded/plugin-server": ["@uncorded/plugin-server@workspace:packages/plugin-server"],
+
     "@uncorded/protocol": ["@uncorded/protocol@workspace:packages/protocol"],
 
     "@uncorded/server": ["@uncorded/server@workspace:apps/server"],
@@ -1284,6 +1321,8 @@
     "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
 
     "create-torrent": ["create-torrent@6.1.0", "", { "dependencies": { "bencode": "^4.0.0", "block-iterator": "^1.1.1", "fast-readable-async-iterator": "^2.0.0", "is-file": "^1.0.0", "join-async-iterator": "^1.1.1", "junk": "^4.0.1", "minimist": "^1.2.8", "once": "^1.4.0", "piece-length": "^2.0.1", "queue-microtask": "^1.2.3", "run-parallel": "^1.2.0", "uint8-util": "^2.2.5" }, "bin": { "create-torrent": "bin/cmd.js" } }, "sha512-War593HCsg4TotHgMGWTJqnDHN0pmEU2RM13xUzzSZ78TpRNOC2bbcsC5yMO3pqIkedHEWFzYNqH1yhwuuBYTg=="],
+
+    "create-uncorded-plugin": ["create-uncorded-plugin@workspace:packages/create-uncorded-plugin"],
 
     "cross-fetch-ponyfill": ["cross-fetch-ponyfill@1.0.3", "", { "dependencies": { "abort-controller": "^3.0.0", "node-fetch": "^3.3.0" } }, "sha512-uOBkDhUAGAbx/FEzNKkOfx3w57H8xReBBXoZvUnOKTI0FW0Xvrj3GrYv2iZXUqlffC1LMGfQzhmBM/ke+6eTDA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -128,6 +128,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@uncorded/protocol": "*",
+        "@uncorded/shared": "*",
       },
     },
     "packages/plugin-server": {
@@ -135,6 +136,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@uncorded/protocol": "*",
+        "@uncorded/shared": "*",
       },
     },
     "packages/protocol": {

--- a/packages/create-uncorded-plugin/package.json
+++ b/packages/create-uncorded-plugin/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "create-uncorded-plugin",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "create-uncorded-plugin": "./src/index.ts"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/create-uncorded-plugin/src/index.ts
+++ b/packages/create-uncorded-plugin/src/index.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env bun
+import { resolve } from "node:path";
+import { runPrompts } from "./prompts.js";
+import { scaffold } from "./scaffold.js";
+import { sideload } from "./sideload.js";
+
+const args = process.argv.slice(2);
+
+const pluginName = args.find((a) => !a.startsWith("-"));
+const shouldSideload = args.includes("--sideload");
+
+const answers = await runPrompts(pluginName);
+const targetDir = resolve(process.cwd(), answers.name);
+
+scaffold(targetDir, answers);
+
+if (shouldSideload) {
+  await sideload(targetDir);
+}

--- a/packages/create-uncorded-plugin/src/index.ts
+++ b/packages/create-uncorded-plugin/src/index.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
-import { resolve } from "node:path";
+import { basename, relative, resolve } from "node:path";
 import { runPrompts } from "./prompts.js";
 import { scaffold } from "./scaffold.js";
 import { sideload } from "./sideload.js";
+
+const VALID_NAME = /^[a-zA-Z0-9_-]+$/;
 
 const args = process.argv.slice(2);
 
@@ -10,10 +12,33 @@ const pluginName = args.find((a) => !a.startsWith("-"));
 const shouldSideload = args.includes("--sideload");
 
 const answers = await runPrompts(pluginName);
-const targetDir = resolve(process.cwd(), answers.name);
+
+// Validate plugin name
+const safeName = basename(answers.name);
+if (!safeName || !VALID_NAME.test(safeName)) {
+  console.error(`Invalid plugin name: "${answers.name}". Use alphanumeric characters, hyphens, or underscores only.`);
+  process.exit(1);
+}
+
+const targetDir = resolve(process.cwd(), safeName);
+
+// Ensure targetDir is inside cwd (prevent path traversal)
+const rel = relative(process.cwd(), targetDir);
+if (rel.startsWith("..") || resolve(targetDir) !== targetDir) {
+  console.error(`Invalid target directory: "${targetDir}" is outside the current working directory.`);
+  process.exit(1);
+}
+
+// Use the sanitized name
+answers.name = safeName;
 
 scaffold(targetDir, answers);
 
 if (shouldSideload) {
-  await sideload(targetDir);
+  try {
+    await sideload(targetDir);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
 }

--- a/packages/create-uncorded-plugin/src/prompts.ts
+++ b/packages/create-uncorded-plugin/src/prompts.ts
@@ -53,20 +53,50 @@ function askChoice(rl: readline.Interface, question: string, options: string[]):
 function askMultiChoice(rl: readline.Interface, question: string, options: string[]): Promise<string[]> {
   const optionsStr = options.map((o, i) => `  ${i + 1}) ${o}`).join("\n");
   return new Promise((resolve) => {
-    rl.question(
-      `${question} (comma-separated numbers, or "all")\n${optionsStr}\n> `,
-      (answer) => {
-        if (answer.trim().toLowerCase() === "all") {
-          resolve([...options]);
+    const prompt = (): void => {
+      rl.question(
+        `${question} (comma-separated numbers, or "all")\n${optionsStr}\n> `,
+        (answer) => {
+          if (answer.trim().toLowerCase() === "all") {
+            resolve([...options]);
+            return;
+          }
+          const indices = answer.split(",").map((s) => Number(s.trim()) - 1);
+          const selected = indices
+            .filter((i) => i >= 0 && i < options.length)
+            .map((i) => options[i]!);
+          if (selected.length > 0) {
+            resolve(selected);
+          } else {
+            console.log("No valid permissions selected, try again.");
+            prompt();
+          }
+        },
+      );
+    };
+    prompt();
+  });
+}
+
+function askPort(rl: readline.Interface): Promise<number> {
+  return new Promise((resolve) => {
+    const prompt = (): void => {
+      rl.question("Container port (default 3000): ", (answer) => {
+        const trimmed = answer.trim();
+        if (trimmed === "") {
+          resolve(3000);
           return;
         }
-        const indices = answer.split(",").map((s) => Number(s.trim()) - 1);
-        const selected = indices
-          .filter((i) => i >= 0 && i < options.length)
-          .map((i) => options[i]!);
-        resolve(selected.length > 0 ? selected : ["server.read"]);
-      },
-    );
+        const parsed = parseInt(trimmed, 10);
+        if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535) {
+          resolve(parsed);
+        } else {
+          console.log("Invalid port. Enter a number between 1 and 65535.");
+          prompt();
+        }
+      });
+    };
+    prompt();
   });
 }
 
@@ -82,8 +112,7 @@ export async function runPrompts(defaultName?: string): Promise<PluginAnswers> {
     const author = await ask(rl, "Author: ");
     const scope = (await askChoice(rl, "Scope:", ["server", "personal", "both"])) as PluginAnswers["scope"];
     const permissions = await askMultiChoice(rl, "Permissions:", [...KNOWN_PERMISSIONS]);
-    const portStr = await ask(rl, "Container port (default 3000): ");
-    const port = portStr ? Number(portStr) : 3000;
+    const port = await askPort(rl);
     const uiType = (await askChoice(rl, "UI type:", ["panel", "page", "both", "none"])) as PluginAnswers["uiType"];
 
     return { name, description, author, scope, permissions, port, uiType };

--- a/packages/create-uncorded-plugin/src/prompts.ts
+++ b/packages/create-uncorded-plugin/src/prompts.ts
@@ -1,0 +1,93 @@
+import * as readline from "node:readline";
+
+const KNOWN_PERMISSIONS = [
+  "server.read",
+  "members.read",
+  "channels.read",
+  "messages.read",
+  "messages.send",
+  "users.read",
+  "presence.read",
+  "notifications.send",
+  "config.read",
+  "storage.read",
+  "storage.write",
+] as const;
+
+export interface PluginAnswers {
+  name: string;
+  description: string;
+  author: string;
+  scope: "server" | "personal" | "both";
+  permissions: string[];
+  port: number;
+  uiType: "panel" | "page" | "both" | "none";
+}
+
+function ask(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, resolve);
+  });
+}
+
+function askChoice(rl: readline.Interface, question: string, options: string[]): Promise<string> {
+  const optionsStr = options.map((o, i) => `  ${i + 1}) ${o}`).join("\n");
+  return new Promise((resolve) => {
+    const prompt = (): void => {
+      rl.question(`${question}\n${optionsStr}\n> `, (answer) => {
+        const idx = Number(answer) - 1;
+        if (idx >= 0 && idx < options.length) {
+          resolve(options[idx]!);
+        } else if (options.includes(answer)) {
+          resolve(answer);
+        } else {
+          console.log("Invalid choice, try again.");
+          prompt();
+        }
+      });
+    };
+    prompt();
+  });
+}
+
+function askMultiChoice(rl: readline.Interface, question: string, options: string[]): Promise<string[]> {
+  const optionsStr = options.map((o, i) => `  ${i + 1}) ${o}`).join("\n");
+  return new Promise((resolve) => {
+    rl.question(
+      `${question} (comma-separated numbers, or "all")\n${optionsStr}\n> `,
+      (answer) => {
+        if (answer.trim().toLowerCase() === "all") {
+          resolve([...options]);
+          return;
+        }
+        const indices = answer.split(",").map((s) => Number(s.trim()) - 1);
+        const selected = indices
+          .filter((i) => i >= 0 && i < options.length)
+          .map((i) => options[i]!);
+        resolve(selected.length > 0 ? selected : ["server.read"]);
+      },
+    );
+  });
+}
+
+export async function runPrompts(defaultName?: string): Promise<PluginAnswers> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const name = defaultName ?? (await ask(rl, "Plugin name: "));
+    const description = await ask(rl, "Description: ");
+    const author = await ask(rl, "Author: ");
+    const scope = (await askChoice(rl, "Scope:", ["server", "personal", "both"])) as PluginAnswers["scope"];
+    const permissions = await askMultiChoice(rl, "Permissions:", [...KNOWN_PERMISSIONS]);
+    const portStr = await ask(rl, "Container port (default 3000): ");
+    const port = portStr ? Number(portStr) : 3000;
+    const uiType = (await askChoice(rl, "UI type:", ["panel", "page", "both", "none"])) as PluginAnswers["uiType"];
+
+    return { name, description, author, scope, permissions, port, uiType };
+  } finally {
+    rl.close();
+  }
+}

--- a/packages/create-uncorded-plugin/src/scaffold.ts
+++ b/packages/create-uncorded-plugin/src/scaffold.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { PluginAnswers } from "./prompts.js";
 
@@ -17,6 +17,16 @@ function replaceVars(template: string, vars: Record<string, string>): string {
 }
 
 export function scaffold(targetDir: string, answers: PluginAnswers): void {
+  // Preflight: abort if target directory already exists and is non-empty
+  if (existsSync(targetDir)) {
+    const entries = readdirSync(targetDir);
+    if (entries.length > 0) {
+      throw new Error(
+        `Directory "${targetDir}" already exists and is not empty. Remove it or choose a different name.`,
+      );
+    }
+  }
+
   mkdirSync(targetDir, { recursive: true });
   mkdirSync(join(targetDir, "src"), { recursive: true });
 

--- a/packages/create-uncorded-plugin/src/scaffold.ts
+++ b/packages/create-uncorded-plugin/src/scaffold.ts
@@ -1,0 +1,82 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { PluginAnswers } from "./prompts.js";
+
+const TEMPLATES_DIR = resolve(import.meta.dirname, "../templates");
+
+function readTemplate(name: string): string {
+  return readFileSync(join(TEMPLATES_DIR, name), "utf-8");
+}
+
+function replaceVars(template: string, vars: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
+
+export function scaffold(targetDir: string, answers: PluginAnswers): void {
+  mkdirSync(targetDir, { recursive: true });
+  mkdirSync(join(targetDir, "src"), { recursive: true });
+
+  const vars: Record<string, string> = {
+    name: answers.name,
+    description: answers.description,
+    author: answers.author,
+    scope: answers.scope,
+    port: String(answers.port),
+    permissions: JSON.stringify(answers.permissions),
+    uiType: answers.uiType === "none" ? "" : `"type": "${answers.uiType}"`,
+  };
+
+  // uncorded-plugin.json (manifest)
+  const manifest = {
+    id: answers.name,
+    name: answers.name,
+    version: "0.1.0",
+    description: answers.description,
+    author: answers.author,
+    scope: answers.scope,
+    permissions: answers.permissions,
+    runtime: {
+      image: `${answers.name}:latest`,
+      port: answers.port,
+      healthCheck: "/health",
+    },
+    ...(answers.uiType !== "none" ? { ui: { type: answers.uiType } } : {}),
+  };
+  writeFileSync(join(targetDir, "uncorded-plugin.json"), JSON.stringify(manifest, null, 2) + "\n");
+
+  // package.json
+  const pkgJson = readTemplate("package.json.tmpl");
+  writeFileSync(join(targetDir, "package.json"), replaceVars(pkgJson, vars));
+
+  // tsconfig.json
+  const tsconfig = readTemplate("tsconfig.json.tmpl");
+  writeFileSync(join(targetDir, "tsconfig.json"), tsconfig);
+
+  // Dockerfile
+  const dockerfile = readTemplate("Dockerfile.tmpl");
+  writeFileSync(join(targetDir, "Dockerfile"), replaceVars(dockerfile, vars));
+
+  // src/server.ts
+  const serverTs = readTemplate("server.ts.tmpl");
+  writeFileSync(join(targetDir, "src/server.ts"), replaceVars(serverTs, vars));
+
+  // src/index.html (if UI)
+  if (answers.uiType !== "none") {
+    const indexHtml = readTemplate("index.html.tmpl");
+    writeFileSync(join(targetDir, "src/index.html"), replaceVars(indexHtml, vars));
+  }
+
+  // .gitignore
+  const gitignore = readTemplate("gitignore.tmpl");
+  writeFileSync(join(targetDir, ".gitignore"), gitignore);
+
+  console.log(`\nPlugin scaffolded at ${targetDir}/`);
+  console.log(`\nNext steps:`);
+  console.log(`  cd ${answers.name}`);
+  console.log(`  bun install`);
+  console.log(`  bun run dev`);
+}

--- a/packages/create-uncorded-plugin/src/sideload.ts
+++ b/packages/create-uncorded-plugin/src/sideload.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -15,9 +15,9 @@ export async function sideload(pluginDir: string): Promise<void> {
 
   const imageName = manifest.runtime.image;
 
-  // Build Docker image
+  // Build Docker image (use execFileSync to avoid shell injection via imageName)
   console.log(`\nBuilding Docker image: ${imageName}`);
-  execSync(`docker build -t ${imageName} .`, {
+  execFileSync("docker", ["build", "-t", imageName, "."], {
     cwd: pluginDir,
     stdio: "inherit",
   });
@@ -36,8 +36,7 @@ export async function sideload(pluginDir: string): Promise<void> {
 
   if (!res.ok) {
     const text = await res.text();
-    console.error(`Sideload failed (${res.status}): ${text}`);
-    process.exit(1);
+    throw new Error(`Sideload failed (${res.status}): ${text}`);
   }
 
   const result = await res.json();

--- a/packages/create-uncorded-plugin/src/sideload.ts
+++ b/packages/create-uncorded-plugin/src/sideload.ts
@@ -1,0 +1,45 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DEFAULT_SIDECAR_PORT = 7070;
+
+export async function sideload(pluginDir: string): Promise<void> {
+  // Read manifest
+  const manifestPath = join(pluginDir, "uncorded-plugin.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+    id: string;
+    name: string;
+    runtime: { image: string };
+  };
+
+  const imageName = manifest.runtime.image;
+
+  // Build Docker image
+  console.log(`\nBuilding Docker image: ${imageName}`);
+  execSync(`docker build -t ${imageName} .`, {
+    cwd: pluginDir,
+    stdio: "inherit",
+  });
+
+  // POST to sidecar install endpoint
+  const sidecarPort = process.env["UNCORDED_SIDECAR_PORT"] ?? String(DEFAULT_SIDECAR_PORT);
+  const sidecarUrl = `http://localhost:${sidecarPort}/plugins/install`;
+
+  console.log(`\nInstalling plugin via sidecar at ${sidecarUrl}...`);
+
+  const res = await fetch(sidecarUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: readFileSync(manifestPath, "utf-8"),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`Sideload failed (${res.status}): ${text}`);
+    process.exit(1);
+  }
+
+  const result = await res.json();
+  console.log("Plugin installed:", result);
+}

--- a/packages/create-uncorded-plugin/templates/Dockerfile.tmpl
+++ b/packages/create-uncorded-plugin/templates/Dockerfile.tmpl
@@ -1,0 +1,10 @@
+FROM oven/bun:1 AS base
+WORKDIR /app
+
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile || bun install
+
+COPY . .
+
+EXPOSE {{port}}
+CMD ["bun", "run", "src/server.ts"]

--- a/packages/create-uncorded-plugin/templates/gitignore.tmpl
+++ b/packages/create-uncorded-plugin/templates/gitignore.tmpl
@@ -2,3 +2,19 @@ node_modules/
 dist/
 .mock-data/
 *.log
+
+# Environment and secrets
+.env
+.env.*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.envrc
+.secrets
+.secret
+
+# Private keys and certificates
+*.key
+*.pem
+*.p12

--- a/packages/create-uncorded-plugin/templates/gitignore.tmpl
+++ b/packages/create-uncorded-plugin/templates/gitignore.tmpl
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.mock-data/
+*.log

--- a/packages/create-uncorded-plugin/templates/index.html.tmpl
+++ b/packages/create-uncorded-plugin/templates/index.html.tmpl
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{name}}</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; padding: 1rem; color: #e1e1e6; background: transparent; }
+    h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    p { color: #a1a1aa; }
+  </style>
+</head>
+<body>
+  <h1>{{name}}</h1>
+  <p>{{description}}</p>
+
+  <script type="module">
+    // Import from CDN or bundled — adjust as needed
+    // import { UnCordedPlugin } from '@uncorded/plugin-client';
+    // const plugin = new UnCordedPlugin();
+    // const user = await plugin.getUser();
+    // console.log('Current user:', user);
+  </script>
+</body>
+</html>

--- a/packages/create-uncorded-plugin/templates/package.json.tmpl
+++ b/packages/create-uncorded-plugin/templates/package.json.tmpl
@@ -9,9 +9,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@uncorded/plugin-server": "*"
+    "@uncorded/plugin-server": "0.0.0"
   },
   "devDependencies": {
+    "bun-types": "latest",
     "typescript": "^5"
   }
 }

--- a/packages/create-uncorded-plugin/templates/package.json.tmpl
+++ b/packages/create-uncorded-plugin/templates/package.json.tmpl
@@ -1,0 +1,17 @@
+{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/server.ts",
+    "start": "bun run src/server.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@uncorded/plugin-server": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/create-uncorded-plugin/templates/server.ts.tmpl
+++ b/packages/create-uncorded-plugin/templates/server.ts.tmpl
@@ -1,0 +1,29 @@
+import { UnCordedBridge } from "@uncorded/plugin-server";
+
+const bridge = new UnCordedBridge();
+
+const server = Bun.serve({
+  port: {{port}},
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/health") {
+      return new Response("ok");
+    }
+
+    // Serve the UI
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      return new Response(Bun.file("src/index.html"));
+    }
+
+    // Example: fetch server info from the bridge
+    if (url.pathname === "/api/server") {
+      const info = await bridge.getServer();
+      return Response.json(info);
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+});
+
+console.log(`{{name}} running on http://localhost:${server.port}`);

--- a/packages/create-uncorded-plugin/templates/tsconfig.json.tmpl
+++ b/packages/create-uncorded-plugin/templates/tsconfig.json.tmpl
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/create-uncorded-plugin/tsconfig.json
+++ b/packages/create-uncorded-plugin/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/mock-bridge/package.json
+++ b/packages/mock-bridge/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@uncorded/mock-bridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "mock-bridge": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "start": "bun run src/index.ts"
+  },
+  "dependencies": {
+    "elysia": "^1"
+  }
+}

--- a/packages/mock-bridge/src/index.ts
+++ b/packages/mock-bridge/src/index.ts
@@ -6,7 +6,12 @@ let port = 7070;
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "--port" && args[i + 1]) {
-    port = Number(args[i + 1]);
+    const parsed = parseInt(args[i + 1]!, 10);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+      console.error(`Invalid port "${args[i + 1]}". Must be an integer between 1 and 65535.`);
+      process.exit(1);
+    }
+    port = parsed;
     i++;
   }
 }

--- a/packages/mock-bridge/src/index.ts
+++ b/packages/mock-bridge/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env bun
+import { createMockBridge } from "./server.js";
+
+const args = process.argv.slice(2);
+let port = 7070;
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--port" && args[i + 1]) {
+    port = Number(args[i + 1]);
+    i++;
+  }
+}
+
+const app = createMockBridge();
+app.listen(port);
+
+console.log(`[mock-bridge] UnCorded mock bridge running on http://localhost:${port}`);
+console.log(`[mock-bridge] Use UNCORDED_BRIDGE_URL=http://localhost:${port}`);
+console.log(`[mock-bridge] Use any value for UNCORDED_BRIDGE_TOKEN`);
+
+export { createMockBridge };

--- a/packages/mock-bridge/src/mock-data.ts
+++ b/packages/mock-bridge/src/mock-data.ts
@@ -1,0 +1,100 @@
+/** Mock server info. */
+export const mockServer = {
+  id: "mock-server-001",
+  name: "Mock Server",
+  iconUrl: null,
+  memberCount: 3,
+  channelCount: 2,
+};
+
+/** Mock members list. */
+export const mockMembers = [
+  {
+    id: "user-001",
+    username: "alice",
+    displayName: "Alice",
+    avatarUrl: null,
+    roles: ["admin"],
+    joinedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "user-002",
+    username: "bob",
+    displayName: "Bob",
+    avatarUrl: null,
+    roles: ["member"],
+    joinedAt: "2025-01-02T00:00:00Z",
+  },
+  {
+    id: "user-003",
+    username: "charlie",
+    displayName: "Charlie",
+    avatarUrl: null,
+    roles: ["member"],
+    joinedAt: "2025-01-03T00:00:00Z",
+  },
+];
+
+/** Mock channels list. */
+export const mockChannels = [
+  { id: "channel-001", name: "general", type: "text", position: 0 },
+  { id: "channel-002", name: "random", type: "text", position: 1 },
+];
+
+/** Mock messages per channel. */
+export const mockMessages: Record<
+  string,
+  Array<{
+    id: string;
+    channelId: string;
+    authorId: string;
+    content: string;
+    createdAt: string;
+    editedAt: string | null;
+  }>
+> = {
+  "channel-001": [
+    {
+      id: "msg-001",
+      channelId: "channel-001",
+      authorId: "user-001",
+      content: "Hello from the mock bridge!",
+      createdAt: "2025-01-01T12:00:00Z",
+      editedAt: null,
+    },
+    {
+      id: "msg-002",
+      channelId: "channel-001",
+      authorId: "user-002",
+      content: "Hey Alice!",
+      createdAt: "2025-01-01T12:01:00Z",
+      editedAt: null,
+    },
+  ],
+  "channel-002": [
+    {
+      id: "msg-003",
+      channelId: "channel-002",
+      authorId: "user-003",
+      content: "Anyone here?",
+      createdAt: "2025-01-01T12:05:00Z",
+      editedAt: null,
+    },
+  ],
+};
+
+/** Mock user lookup. */
+export const mockUsers: Record<
+  string,
+  { id: string; username: string; displayName: string; avatarUrl: string | null }
+> = {
+  "user-001": { id: "user-001", username: "alice", displayName: "Alice", avatarUrl: null },
+  "user-002": { id: "user-002", username: "bob", displayName: "Bob", avatarUrl: null },
+  "user-003": { id: "user-003", username: "charlie", displayName: "Charlie", avatarUrl: null },
+};
+
+/** Mock config. */
+export const mockConfig: Record<string, unknown> = {
+  greeting: "Welcome to the mock plugin!",
+  maxItems: 100,
+};

--- a/packages/mock-bridge/src/server.ts
+++ b/packages/mock-bridge/src/server.ts
@@ -9,24 +9,36 @@ import {
 } from "./mock-data.js";
 import { MockStorage } from "./storage.js";
 
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
 /** Create the mock bridge Elysia server. */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createMockBridge() {
   const storage = new MockStorage();
 
   const app = new Elysia()
     // ── Auth middleware (accepts any Bearer token) ──────────
-    .derive(({ headers }) => {
+    .derive(({ headers, set }) => {
       const auth = headers["authorization"];
       if (!auth?.startsWith("Bearer ")) {
-        throw new Error("Unauthorized");
+        set.status = 401;
+        return { pluginId: "", serverId: "", scope: "server" as const, permissions: [] as string[], authError: true as const };
       }
       return {
         pluginId: "mock-plugin",
         serverId: mockServer.id,
         scope: "server" as const,
         permissions: ["*"],
+        authError: false as const,
       };
+    })
+
+    // ── Reject unauthorized requests ───────────────────────
+    .onBeforeHandle(({ authError, set }) => {
+      if (authError) {
+        set.status = 401;
+        return { error: "Unauthorized: Bearer token required" };
+      }
     })
 
     // ── Server ─────────────────────────────────────────────
@@ -43,7 +55,13 @@ export function createMockBridge() {
       "/bridge/channels/:channelId/messages",
       ({ params, query }) => {
         const channelId = params.channelId;
-        const limit = query.limit ? Number(query.limit) : 50;
+        let limit = DEFAULT_LIMIT;
+        if (query.limit !== undefined) {
+          const parsed = parseInt(query.limit, 10);
+          limit = Number.isFinite(parsed) && parsed >= 0
+            ? Math.min(parsed, MAX_LIMIT)
+            : DEFAULT_LIMIT;
+        }
         const messages = mockMessages[channelId] ?? [];
         return {
           channelId,
@@ -86,10 +104,11 @@ export function createMockBridge() {
     )
 
     // ── Users ──────────────────────────────────────────────
-    .get("/bridge/users/:userId", ({ params }) => {
+    .get("/bridge/users/:userId", ({ params, set }) => {
       const user = mockUsers[params.userId];
       if (!user) {
-        throw new Error("User not found");
+        set.status = 404;
+        return { error: "User not found" };
       }
       return user;
     })

--- a/packages/mock-bridge/src/server.ts
+++ b/packages/mock-bridge/src/server.ts
@@ -1,0 +1,148 @@
+import { Elysia, t } from "elysia";
+import {
+  mockChannels,
+  mockConfig,
+  mockMembers,
+  mockMessages,
+  mockServer,
+  mockUsers,
+} from "./mock-data.js";
+import { MockStorage } from "./storage.js";
+
+/** Create the mock bridge Elysia server. */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function createMockBridge() {
+  const storage = new MockStorage();
+
+  const app = new Elysia()
+    // ── Auth middleware (accepts any Bearer token) ──────────
+    .derive(({ headers }) => {
+      const auth = headers["authorization"];
+      if (!auth?.startsWith("Bearer ")) {
+        throw new Error("Unauthorized");
+      }
+      return {
+        pluginId: "mock-plugin",
+        serverId: mockServer.id,
+        scope: "server" as const,
+        permissions: ["*"],
+      };
+    })
+
+    // ── Server ─────────────────────────────────────────────
+    .get("/bridge/server", () => mockServer)
+
+    // ── Members ────────────────────────────────────────────
+    .get("/bridge/members", () => ({ members: mockMembers }))
+
+    // ── Channels ───────────────────────────────────────────
+    .get("/bridge/channels", () => ({ channels: mockChannels }))
+
+    // ── Messages ───────────────────────────────────────────
+    .get(
+      "/bridge/channels/:channelId/messages",
+      ({ params, query }) => {
+        const channelId = params.channelId;
+        const limit = query.limit ? Number(query.limit) : 50;
+        const messages = mockMessages[channelId] ?? [];
+        return {
+          channelId,
+          messages: messages.slice(0, limit),
+          limit,
+        };
+      },
+      {
+        query: t.Object({
+          limit: t.Optional(t.String()),
+        }),
+      },
+    )
+
+    .post(
+      "/bridge/channels/:channelId/messages",
+      ({ params, body }) => {
+        const channelId = params.channelId;
+        const newMsg = {
+          id: `msg-${Date.now()}`,
+          channelId,
+          authorId: "mock-plugin",
+          content: (body as { content: string }).content,
+          createdAt: new Date().toISOString(),
+          editedAt: null,
+        };
+        const channelMsgs = mockMessages[channelId];
+        if (channelMsgs) {
+          channelMsgs.push(newMsg);
+        } else {
+          mockMessages[channelId] = [newMsg];
+        }
+        return { channelId, sent: true };
+      },
+      {
+        body: t.Object({
+          content: t.String(),
+        }),
+      },
+    )
+
+    // ── Users ──────────────────────────────────────────────
+    .get("/bridge/users/:userId", ({ params }) => {
+      const user = mockUsers[params.userId];
+      if (!user) {
+        throw new Error("User not found");
+      }
+      return user;
+    })
+
+    // ── Presence ───────────────────────────────────────────
+    .get("/bridge/presence", () => ({ presence: [] }))
+
+    // ── Notify ─────────────────────────────────────────────
+    .post(
+      "/bridge/notify",
+      ({ body }) => {
+        const { title, body: notifBody } = body as { title: string; body: string };
+        console.log(`[mock-bridge] Notification: ${title} — ${notifBody}`);
+        return { sent: true };
+      },
+      {
+        body: t.Object({
+          title: t.String(),
+          body: t.String(),
+        }),
+      },
+    )
+
+    // ── Config ─────────────────────────────────────────────
+    .get("/bridge/config", () => ({ config: mockConfig }))
+
+    // ── Storage ────────────────────────────────────────────
+    .get("/bridge/storage/:key", ({ params }) => {
+      const value = storage.get(params.key);
+      return { key: params.key, value };
+    })
+
+    .put(
+      "/bridge/storage/:key",
+      ({ params, body, query }) => {
+        const encrypt = query.encrypt === "true";
+        storage.set(params.key, (body as { value: unknown }).value, encrypt);
+        return { key: params.key, stored: true };
+      },
+      {
+        body: t.Object({
+          value: t.Unknown(),
+        }),
+        query: t.Object({
+          encrypt: t.Optional(t.String()),
+        }),
+      },
+    )
+
+    .delete("/bridge/storage/:key", ({ params }) => {
+      const deleted = storage.delete(params.key);
+      return { key: params.key, deleted };
+    });
+
+  return app;
+}

--- a/packages/mock-bridge/src/storage.ts
+++ b/packages/mock-bridge/src/storage.ts
@@ -22,14 +22,19 @@ export class MockStorage {
   get(key: string): unknown {
     const path = this.#keyPath(key);
     if (!existsSync(path)) return null;
-    const raw = readFileSync(path, "utf-8");
-    const parsed = JSON.parse(raw) as { value: unknown };
-    return parsed.value;
+    try {
+      const raw = readFileSync(path, "utf-8");
+      const parsed = JSON.parse(raw) as { value: unknown };
+      return parsed.value;
+    } catch {
+      console.error(`[mock-bridge] Corrupted storage file: ${path}`);
+      return null;
+    }
   }
 
-  set(key: string, value: unknown, _encrypt?: boolean): void {
+  set(key: string, value: unknown, encrypt?: boolean): void {
     const path = this.#keyPath(key);
-    writeFileSync(path, JSON.stringify({ encrypted: false, value }), "utf-8");
+    writeFileSync(path, JSON.stringify({ encrypted: Boolean(encrypt), value }), "utf-8");
   }
 
   delete(key: string): boolean {

--- a/packages/mock-bridge/src/storage.ts
+++ b/packages/mock-bridge/src/storage.ts
@@ -1,0 +1,41 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const STORAGE_DIR = ".mock-data";
+
+/** File-based KV store for the mock bridge. */
+export class MockStorage {
+  readonly #dir: string;
+
+  constructor(baseDir: string = process.cwd()) {
+    this.#dir = join(baseDir, STORAGE_DIR);
+    if (!existsSync(this.#dir)) {
+      mkdirSync(this.#dir, { recursive: true });
+    }
+  }
+
+  #keyPath(key: string): string {
+    const safe = key.replace(/[^a-zA-Z0-9_-]/g, "_");
+    return join(this.#dir, `${safe}.json`);
+  }
+
+  get(key: string): unknown {
+    const path = this.#keyPath(key);
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as { value: unknown };
+    return parsed.value;
+  }
+
+  set(key: string, value: unknown, _encrypt?: boolean): void {
+    const path = this.#keyPath(key);
+    writeFileSync(path, JSON.stringify({ encrypted: false, value }), "utf-8");
+  }
+
+  delete(key: string): boolean {
+    const path = this.#keyPath(key);
+    if (!existsSync(path)) return false;
+    rmSync(path);
+    return true;
+  }
+}

--- a/packages/mock-bridge/tsconfig.json
+++ b/packages/mock-bridge/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["bun-types"],
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-client/package.json
+++ b/packages/plugin-client/package.json
@@ -8,5 +8,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@uncorded/protocol": "*"
   }
 }

--- a/packages/plugin-client/package.json
+++ b/packages/plugin-client/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@uncorded/plugin-client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/plugin-client/package.json
+++ b/packages/plugin-client/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@uncorded/protocol": "*"
+    "@uncorded/protocol": "*",
+    "@uncorded/shared": "*"
   }
 }

--- a/packages/plugin-client/src/errors.ts
+++ b/packages/plugin-client/src/errors.ts
@@ -1,0 +1,31 @@
+/** Base error for all plugin bridge errors. */
+export class BridgeError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "BridgeError";
+    this.code = code;
+  }
+}
+
+/** Thrown when a bridge request times out. */
+export class RequestTimeoutError extends BridgeError {
+  readonly method: string;
+  readonly requestId: string;
+
+  constructor(method: string, requestId: string, timeoutMs: number) {
+    super("REQUEST_TIMEOUT", `Request "${method}" (${requestId}) timed out after ${timeoutMs}ms`);
+    this.name = "RequestTimeoutError";
+    this.method = method;
+    this.requestId = requestId;
+  }
+}
+
+/** Thrown when the plugin is destroyed while requests are pending. */
+export class PluginDestroyedError extends BridgeError {
+  constructor() {
+    super("PLUGIN_DESTROYED", "Plugin was destroyed while requests were pending");
+    this.name = "PluginDestroyedError";
+  }
+}

--- a/packages/plugin-client/src/errors.ts
+++ b/packages/plugin-client/src/errors.ts
@@ -1,11 +1,9 @@
-/** Base error for all plugin bridge errors. */
-export class BridgeError extends Error {
-  readonly code: string;
+import { AppError } from "@uncorded/shared";
 
+/** Base error for all plugin bridge errors. */
+export class BridgeError extends AppError {
   constructor(code: string, message: string) {
-    super(message);
-    this.name = "BridgeError";
-    this.code = code;
+    super("BridgeError", 0, code, message);
   }
 }
 
@@ -16,7 +14,6 @@ export class RequestTimeoutError extends BridgeError {
 
   constructor(method: string, requestId: string, timeoutMs: number) {
     super("REQUEST_TIMEOUT", `Request "${method}" (${requestId}) timed out after ${timeoutMs}ms`);
-    this.name = "RequestTimeoutError";
     this.method = method;
     this.requestId = requestId;
   }
@@ -26,6 +23,5 @@ export class RequestTimeoutError extends BridgeError {
 export class PluginDestroyedError extends BridgeError {
   constructor() {
     super("PLUGIN_DESTROYED", "Plugin was destroyed while requests were pending");
-    this.name = "PluginDestroyedError";
   }
 }

--- a/packages/plugin-client/src/index.ts
+++ b/packages/plugin-client/src/index.ts
@@ -1,10 +1,12 @@
 export { UnCordedPlugin } from "./plugin.js";
+export { BridgeError, PluginDestroyedError, RequestTimeoutError } from "./errors.js";
 export type {
   Channel,
   EventHandler,
   Member,
   NavigateParams,
   PluginEvent,
+  PluginOptions,
   PluginRequest,
   PluginResponse,
   Server,

--- a/packages/plugin-client/src/index.ts
+++ b/packages/plugin-client/src/index.ts
@@ -1,0 +1,13 @@
+export { UnCordedPlugin } from "./plugin.js";
+export type {
+  Channel,
+  EventHandler,
+  Member,
+  NavigateParams,
+  PluginEvent,
+  PluginRequest,
+  PluginResponse,
+  Server,
+  ToastType,
+  User,
+} from "./types.js";

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -1,0 +1,157 @@
+import type {
+  Channel,
+  EventHandler,
+  Member,
+  NavigateParams,
+  PluginEvent,
+  PluginResponse,
+  Server,
+  ToastType,
+  User,
+} from "./types.js";
+
+/**
+ * PostMessage client for plugin UIs running inside iframes.
+ * Communicates with the UnCorded shell via the postMessage bridge protocol.
+ */
+export class UnCordedPlugin {
+  readonly #pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  readonly #listeners = new Map<string, Set<EventHandler>>();
+  #idCounter = 0;
+
+  constructor() {
+    window.addEventListener("message", this.#onMessage);
+  }
+
+  /** Remove the message listener. Call when the plugin is unmounting. */
+  destroy(): void {
+    window.removeEventListener("message", this.#onMessage);
+    for (const [, { reject }] of this.#pending) {
+      reject(new Error("Plugin destroyed"));
+    }
+    this.#pending.clear();
+    this.#listeners.clear();
+  }
+
+  // ── Request/Response ─────────────────────────────────────
+
+  #nextId(): string {
+    return `plugin-${++this.#idCounter}-${Date.now()}`;
+  }
+
+  #request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const id = this.#nextId();
+      this.#pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject,
+      });
+
+      window.parent.postMessage(
+        {
+          type: "uncorded:request" as const,
+          id,
+          method,
+          ...(params !== undefined ? { params } : {}),
+        },
+        "*",
+      );
+    });
+  }
+
+  readonly #onMessage = (event: MessageEvent): void => {
+    const data: unknown = event.data;
+    if (typeof data !== "object" || data === null) return;
+
+    const msg = data as Record<string, unknown>;
+
+    if (msg["type"] === "uncorded:response") {
+      const response = msg as unknown as PluginResponse;
+      const pending = this.#pending.get(response.id);
+      if (!pending) return;
+      this.#pending.delete(response.id);
+
+      if (response.error) {
+        pending.reject(new Error(`${response.error.code}: ${response.error.message}`));
+      } else {
+        pending.resolve(response.result);
+      }
+      return;
+    }
+
+    if (msg["type"] === "uncorded:event") {
+      const pluginEvent = msg as unknown as PluginEvent;
+      const handlers = this.#listeners.get(pluginEvent.event);
+      if (handlers) {
+        for (const handler of handlers) {
+          handler(pluginEvent.data);
+        }
+      }
+    }
+  };
+
+  // ── Data Methods ─────────────────────────────────────────
+
+  /** Get the current user. */
+  async getUser(): Promise<User> {
+    return this.#request<User>("getUser");
+  }
+
+  /** Get the current server. */
+  async getServer(): Promise<Server> {
+    return this.#request<Server>("getServer");
+  }
+
+  /** Get channels in the server. */
+  async getChannels(): Promise<Channel[]> {
+    return this.#request<Channel[]>("getChannels");
+  }
+
+  /** Get members of the server. */
+  async getMembers(): Promise<Member[]> {
+    return this.#request<Member[]>("getMembers");
+  }
+
+  /** Get presence data. */
+  async getPresence(): Promise<unknown[]> {
+    return this.#request<unknown[]>("getPresence");
+  }
+
+  // ── Actions ──────────────────────────────────────────────
+
+  /** Send a message to a channel. */
+  async sendMessage(channelId: string, content: string): Promise<{ sent: boolean }> {
+    return this.#request<{ sent: boolean }>("sendMessage", { channelId, content });
+  }
+
+  /** Show a toast notification. */
+  showToast(message: string, type: ToastType = "info"): void {
+    void this.#request("showToast", { message, type });
+  }
+
+  /** Navigate within the app. */
+  navigate(to: NavigateParams["to"], channelId: string): void {
+    void this.#request("navigate", { to, channelId } satisfies NavigateParams);
+  }
+
+  // ── Events ───────────────────────────────────────────────
+
+  /** Subscribe to a bridge event. */
+  on<T = unknown>(event: string, handler: EventHandler<T>): void {
+    let set = this.#listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.#listeners.set(event, set);
+    }
+    set.add(handler as EventHandler);
+  }
+
+  /** Unsubscribe from a bridge event. */
+  off<T = unknown>(event: string, handler: EventHandler<T>): void {
+    const set = this.#listeners.get(event);
+    if (set) {
+      set.delete(handler as EventHandler);
+      if (set.size === 0) this.#listeners.delete(event);
+    }
+  }
+}

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -131,14 +131,14 @@ export class UnCordedPlugin {
 
   // ── Data Methods ─────────────────────────────────────────
 
-  /** Get the current user. */
-  async getUser(): Promise<User> {
-    return this.#request<User>("getUser");
+  /** Get the current user. Returns `null` if user data is not yet available. */
+  async getUser(): Promise<User | null> {
+    return this.#request<User | null>("getUser");
   }
 
-  /** Get the current server. */
-  async getServer(): Promise<Server> {
-    return this.#request<Server>("getServer");
+  /** Get the current server. Returns `null` if no server is selected. */
+  async getServer(): Promise<Server | null> {
+    return this.#request<Server | null>("getServer");
   }
 
   /** Get channels in the server. */

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -1,33 +1,60 @@
+import type { ChannelId } from "@uncorded/protocol";
+import { BridgeError, PluginDestroyedError, RequestTimeoutError } from "./errors.js";
 import type {
   Channel,
   EventHandler,
   Member,
   NavigateParams,
   PluginEvent,
+  PluginOptions,
   PluginResponse,
   Server,
   ToastType,
   User,
 } from "./types.js";
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface PendingRequest {
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 /**
  * PostMessage client for plugin UIs running inside iframes.
  * Communicates with the UnCorded shell via the postMessage bridge protocol.
  */
 export class UnCordedPlugin {
-  readonly #pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  readonly #pending = new Map<string, PendingRequest>();
   readonly #listeners = new Map<string, Set<EventHandler>>();
+  readonly #shellOrigin: string;
+  readonly #timeoutMs: number;
   #idCounter = 0;
 
-  constructor() {
+  constructor(options?: PluginOptions) {
+    this.#timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    // Derive shell origin from document.referrer if not provided
+    if (options?.shellOrigin) {
+      this.#shellOrigin = options.shellOrigin;
+    } else {
+      try {
+        this.#shellOrigin = new URL(document.referrer).origin;
+      } catch {
+        this.#shellOrigin = "*";
+      }
+    }
+
     window.addEventListener("message", this.#onMessage);
   }
 
   /** Remove the message listener. Call when the plugin is unmounting. */
   destroy(): void {
     window.removeEventListener("message", this.#onMessage);
-    for (const [, { reject }] of this.#pending) {
-      reject(new Error("Plugin destroyed"));
+    for (const [, pending] of this.#pending) {
+      clearTimeout(pending.timer);
+      pending.reject(new PluginDestroyedError());
     }
     this.#pending.clear();
     this.#listeners.clear();
@@ -42,9 +69,16 @@ export class UnCordedPlugin {
   #request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const id = this.#nextId();
+
+      const timer = setTimeout(() => {
+        this.#pending.delete(id);
+        reject(new RequestTimeoutError(method, id, this.#timeoutMs));
+      }, this.#timeoutMs);
+
       this.#pending.set(id, {
         resolve: resolve as (v: unknown) => void,
         reject,
+        timer,
       });
 
       window.parent.postMessage(
@@ -54,12 +88,16 @@ export class UnCordedPlugin {
           method,
           ...(params !== undefined ? { params } : {}),
         },
-        "*",
+        this.#shellOrigin,
       );
     });
   }
 
   readonly #onMessage = (event: MessageEvent): void => {
+    // Validate message source is our parent window
+    if (event.source !== window.parent) return;
+    if (this.#shellOrigin !== "*" && event.origin !== this.#shellOrigin) return;
+
     const data: unknown = event.data;
     if (typeof data !== "object" || data === null) return;
 
@@ -69,10 +107,11 @@ export class UnCordedPlugin {
       const response = msg as unknown as PluginResponse;
       const pending = this.#pending.get(response.id);
       if (!pending) return;
+      clearTimeout(pending.timer);
       this.#pending.delete(response.id);
 
       if (response.error) {
-        pending.reject(new Error(`${response.error.code}: ${response.error.message}`));
+        pending.reject(new BridgeError(response.error.code, response.error.message));
       } else {
         pending.resolve(response.result);
       }
@@ -120,18 +159,18 @@ export class UnCordedPlugin {
   // ── Actions ──────────────────────────────────────────────
 
   /** Send a message to a channel. */
-  async sendMessage(channelId: string, content: string): Promise<{ sent: boolean }> {
+  async sendMessage(channelId: ChannelId, content: string): Promise<{ sent: boolean }> {
     return this.#request<{ sent: boolean }>("sendMessage", { channelId, content });
   }
 
   /** Show a toast notification. */
-  showToast(message: string, type: ToastType = "info"): void {
-    void this.#request("showToast", { message, type });
+  async showToast(message: string, type: ToastType = "info"): Promise<void> {
+    await this.#request("showToast", { message, type });
   }
 
   /** Navigate within the app. */
-  navigate(to: NavigateParams["to"], channelId: string): void {
-    void this.#request("navigate", { to, channelId } satisfies NavigateParams);
+  async navigate(to: NavigateParams["to"], channelId: ChannelId): Promise<void> {
+    await this.#request("navigate", { to, channelId } satisfies NavigateParams);
   }
 
   // ── Events ───────────────────────────────────────────────

--- a/packages/plugin-client/src/types.ts
+++ b/packages/plugin-client/src/types.ts
@@ -1,0 +1,68 @@
+/** Current user info. */
+export interface User {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+/** Server info. */
+export interface Server {
+  id: string;
+  name: string;
+  iconUrl: string | null;
+  ownerId: string;
+}
+
+/** A channel. */
+export interface Channel {
+  id: string;
+  name: string;
+  type: string;
+  position: number;
+}
+
+/** A server member. */
+export interface Member {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  roles: string[];
+  joinedAt: string;
+}
+
+/** Toast notification type. */
+export type ToastType = "info" | "success" | "warning" | "error";
+
+/** Navigate target. */
+export interface NavigateParams {
+  to: "channel";
+  channelId: string;
+}
+
+/** postMessage request (plugin → shell). */
+export interface PluginRequest {
+  type: "uncorded:request";
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** postMessage response (shell → plugin). */
+export interface PluginResponse {
+  type: "uncorded:response";
+  id: string;
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+/** postMessage event (shell → plugin). */
+export interface PluginEvent {
+  type: "uncorded:event";
+  event: string;
+  data: unknown;
+}
+
+/** Event handler function. */
+export type EventHandler<T = unknown> = (data: T) => void;

--- a/packages/plugin-client/src/types.ts
+++ b/packages/plugin-client/src/types.ts
@@ -1,6 +1,8 @@
+import type { ChannelId, ServerId, UserId } from "@uncorded/protocol";
+
 /** Current user info. */
 export interface User {
-  id: string;
+  id: UserId;
   username: string;
   displayName: string;
   avatarUrl: string | null;
@@ -8,15 +10,15 @@ export interface User {
 
 /** Server info. */
 export interface Server {
-  id: string;
+  id: ServerId;
   name: string;
   iconUrl: string | null;
-  ownerId: string;
+  ownerId: UserId;
 }
 
 /** A channel. */
 export interface Channel {
-  id: string;
+  id: ChannelId;
   name: string;
   type: string;
   position: number;
@@ -24,7 +26,7 @@ export interface Channel {
 
 /** A server member. */
 export interface Member {
-  id: string;
+  id: UserId;
   username: string;
   displayName: string;
   avatarUrl: string | null;
@@ -38,7 +40,7 @@ export type ToastType = "info" | "success" | "warning" | "error";
 /** Navigate target. */
 export interface NavigateParams {
   to: "channel";
-  channelId: string;
+  channelId: ChannelId;
 }
 
 /** postMessage request (plugin → shell). */
@@ -66,3 +68,11 @@ export interface PluginEvent {
 
 /** Event handler function. */
 export type EventHandler<T = unknown> = (data: T) => void;
+
+/** Plugin constructor options. */
+export interface PluginOptions {
+  /** Origin of the shell window. Defaults to `document.referrer` origin. */
+  shellOrigin?: string;
+  /** Request timeout in ms. Defaults to 30000. */
+  timeoutMs?: number;
+}

--- a/packages/plugin-client/tsconfig.json
+++ b/packages/plugin-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ES2023", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-server/package.json
+++ b/packages/plugin-server/package.json
@@ -8,5 +8,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@uncorded/protocol": "*"
   }
 }

--- a/packages/plugin-server/package.json
+++ b/packages/plugin-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@uncorded/plugin-server",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/plugin-server/package.json
+++ b/packages/plugin-server/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@uncorded/protocol": "*"
+    "@uncorded/protocol": "*",
+    "@uncorded/shared": "*"
   }
 }

--- a/packages/plugin-server/src/bridge.ts
+++ b/packages/plugin-server/src/bridge.ts
@@ -1,5 +1,5 @@
 import type { ChannelId, UserId } from "@uncorded/protocol";
-import { BridgeConfigError, BridgeHttpError, BridgeNetworkError } from "./errors.js";
+import { BridgeConfigError, BridgeHttpError, BridgeNetworkError, BridgeNotFoundError } from "./errors.js";
 import { BridgeStorage } from "./storage.js";
 import type {
   BridgeOptions,
@@ -39,7 +39,11 @@ export class UnCordedBridge {
 
     this.#baseUrl = baseUrl.replace(/\/+$/, "");
     this.#token = token;
-    this.#timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const rawTimeout = options?.timeoutMs;
+    this.#timeoutMs =
+      rawTimeout !== undefined && Number.isFinite(rawTimeout) && rawTimeout > 0
+        ? rawTimeout
+        : DEFAULT_TIMEOUT_MS;
     this.storage = new BridgeStorage((path, init) => this.#fetch(path, init));
   }
 
@@ -73,6 +77,7 @@ export class UnCordedBridge {
   async #get<T>(path: string): Promise<T> {
     const res = await this.#fetch(path);
     if (!res.ok) {
+      if (res.status === 404) throw new BridgeNotFoundError(path);
       const text = await res.text();
       throw new BridgeHttpError("GET", path, res.status, text);
     }
@@ -86,6 +91,7 @@ export class UnCordedBridge {
       body: body !== undefined ? JSON.stringify(body) : null,
     });
     if (!res.ok) {
+      if (res.status === 404) throw new BridgeNotFoundError(path);
       const text = await res.text();
       throw new BridgeHttpError("POST", path, res.status, text);
     }

--- a/packages/plugin-server/src/bridge.ts
+++ b/packages/plugin-server/src/bridge.ts
@@ -1,0 +1,144 @@
+import { BridgeStorage } from "./storage.js";
+import type {
+  BridgeOptions,
+  Channel,
+  GetMessagesOptions,
+  Member,
+  Message,
+  Server,
+  User,
+} from "./types.js";
+
+/** Typed HTTP client for Docker plugins to talk to the UnCorded sidecar bridge. */
+export class UnCordedBridge {
+  readonly #baseUrl: string;
+  readonly #token: string;
+
+  /** KV storage API. */
+  readonly storage: BridgeStorage;
+
+  constructor(options?: BridgeOptions) {
+    const baseUrl = options?.baseUrl ?? process.env["UNCORDED_BRIDGE_URL"];
+    const token = options?.token ?? process.env["UNCORDED_BRIDGE_TOKEN"];
+
+    if (!baseUrl) {
+      throw new Error(
+        "UnCordedBridge: No base URL provided. Set UNCORDED_BRIDGE_URL or pass baseUrl option.",
+      );
+    }
+    if (!token) {
+      throw new Error(
+        "UnCordedBridge: No token provided. Set UNCORDED_BRIDGE_TOKEN or pass token option.",
+      );
+    }
+
+    this.#baseUrl = baseUrl.replace(/\/+$/, "");
+    this.#token = token;
+    this.storage = new BridgeStorage((path, init) => this.#fetch(path, init));
+  }
+
+  // ── Helpers ──────────────────────────────────────────────
+
+  async #fetch(path: string, init?: RequestInit): Promise<Response> {
+    const url = `${this.#baseUrl}${path}`;
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.#token}`,
+        ...init?.headers,
+      },
+    });
+    return res;
+  }
+
+  async #get<T>(path: string): Promise<T> {
+    const res = await this.#fetch(path);
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Bridge GET ${path} failed (${res.status}): ${text}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  async #post<T>(path: string, body?: unknown): Promise<T> {
+    const res = await this.#fetch(path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: body !== undefined ? JSON.stringify(body) : null,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Bridge POST ${path} failed (${res.status}): ${text}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  // ── Server ───────────────────────────────────────────────
+
+  /** Get info about the server (or DM context) this plugin is installed in. */
+  async getServer(): Promise<Server> {
+    return this.#get<Server>("/bridge/server");
+  }
+
+  // ── Members ──────────────────────────────────────────────
+
+  /** List members of the server (or friends in personal scope). */
+  async getMembers(): Promise<Member[]> {
+    const body = await this.#get<{ members: Member[] }>("/bridge/members");
+    return body.members;
+  }
+
+  // ── Channels ─────────────────────────────────────────────
+
+  /** List channels in the server. */
+  async getChannels(): Promise<Channel[]> {
+    const body = await this.#get<{ channels: Channel[] }>("/bridge/channels");
+    return body.channels;
+  }
+
+  // ── Messages ─────────────────────────────────────────────
+
+  /** Get messages from a channel. */
+  async getMessages(channelId: string, options?: GetMessagesOptions): Promise<Message[]> {
+    const params = options?.limit ? `?limit=${options.limit}` : "";
+    const body = await this.#get<{ channelId: string; messages: Message[]; limit: number }>(
+      `/bridge/channels/${encodeURIComponent(channelId)}/messages${params}`,
+    );
+    return body.messages;
+  }
+
+  /** Send a message to a channel. */
+  async sendMessage(channelId: string, content: string): Promise<{ sent: boolean; error?: string }> {
+    return this.#post(`/bridge/channels/${encodeURIComponent(channelId)}/messages`, { content });
+  }
+
+  // ── Users ────────────────────────────────────────────────
+
+  /** Get a user by ID. */
+  async getUser(userId: string): Promise<User> {
+    return this.#get<User>(`/bridge/users/${encodeURIComponent(userId)}`);
+  }
+
+  // ── Presence ─────────────────────────────────────────────
+
+  /** Get presence data for server members. */
+  async getPresence(): Promise<unknown[]> {
+    const body = await this.#get<{ presence: unknown[] }>("/bridge/presence");
+    return body.presence;
+  }
+
+  // ── Notifications ────────────────────────────────────────
+
+  /** Send a notification. */
+  async notify(options: { title: string; body: string }): Promise<{ sent: boolean; error?: string }> {
+    return this.#post("/bridge/notify", options);
+  }
+
+  // ── Config ───────────────────────────────────────────────
+
+  /** Get the plugin's configuration. */
+  async getConfig(): Promise<Record<string, unknown>> {
+    const body = await this.#get<{ config: Record<string, unknown> }>("/bridge/config");
+    return body.config;
+  }
+}

--- a/packages/plugin-server/src/bridge.ts
+++ b/packages/plugin-server/src/bridge.ts
@@ -1,3 +1,5 @@
+import type { ChannelId, UserId } from "@uncorded/protocol";
+import { BridgeConfigError, BridgeHttpError, BridgeNetworkError } from "./errors.js";
 import { BridgeStorage } from "./storage.js";
 import type {
   BridgeOptions,
@@ -9,10 +11,13 @@ import type {
   User,
 } from "./types.js";
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 /** Typed HTTP client for Docker plugins to talk to the UnCorded sidecar bridge. */
 export class UnCordedBridge {
   readonly #baseUrl: string;
   readonly #token: string;
+  readonly #timeoutMs: number;
 
   /** KV storage API. */
   readonly storage: BridgeStorage;
@@ -22,18 +27,19 @@ export class UnCordedBridge {
     const token = options?.token ?? process.env["UNCORDED_BRIDGE_TOKEN"];
 
     if (!baseUrl) {
-      throw new Error(
-        "UnCordedBridge: No base URL provided. Set UNCORDED_BRIDGE_URL or pass baseUrl option.",
+      throw new BridgeConfigError(
+        "No base URL provided. Set UNCORDED_BRIDGE_URL or pass baseUrl option.",
       );
     }
     if (!token) {
-      throw new Error(
-        "UnCordedBridge: No token provided. Set UNCORDED_BRIDGE_TOKEN or pass token option.",
+      throw new BridgeConfigError(
+        "No token provided. Set UNCORDED_BRIDGE_TOKEN or pass token option.",
       );
     }
 
     this.#baseUrl = baseUrl.replace(/\/+$/, "");
     this.#token = token;
+    this.#timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.storage = new BridgeStorage((path, init) => this.#fetch(path, init));
   }
 
@@ -41,21 +47,34 @@ export class UnCordedBridge {
 
   async #fetch(path: string, init?: RequestInit): Promise<Response> {
     const url = `${this.#baseUrl}${path}`;
-    const res = await fetch(url, {
-      ...init,
-      headers: {
-        Authorization: `Bearer ${this.#token}`,
-        ...init?.headers,
-      },
-    });
-    return res;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
+
+    try {
+      const res = await fetch(url, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${this.#token}`,
+          ...init?.headers,
+        },
+      });
+      return res;
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        throw new BridgeNetworkError(`Request to ${path} timed out after ${this.#timeoutMs}ms`);
+      }
+      throw new BridgeNetworkError(`Network error on ${path}`, { cause: err });
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   async #get<T>(path: string): Promise<T> {
     const res = await this.#fetch(path);
     if (!res.ok) {
       const text = await res.text();
-      throw new Error(`Bridge GET ${path} failed (${res.status}): ${text}`);
+      throw new BridgeHttpError("GET", path, res.status, text);
     }
     return (await res.json()) as T;
   }
@@ -68,7 +87,7 @@ export class UnCordedBridge {
     });
     if (!res.ok) {
       const text = await res.text();
-      throw new Error(`Bridge POST ${path} failed (${res.status}): ${text}`);
+      throw new BridgeHttpError("POST", path, res.status, text);
     }
     return (await res.json()) as T;
   }
@@ -99,8 +118,8 @@ export class UnCordedBridge {
   // ── Messages ─────────────────────────────────────────────
 
   /** Get messages from a channel. */
-  async getMessages(channelId: string, options?: GetMessagesOptions): Promise<Message[]> {
-    const params = options?.limit ? `?limit=${options.limit}` : "";
+  async getMessages(channelId: ChannelId, options?: GetMessagesOptions): Promise<Message[]> {
+    const params = options?.limit !== undefined ? `?limit=${options.limit}` : "";
     const body = await this.#get<{ channelId: string; messages: Message[]; limit: number }>(
       `/bridge/channels/${encodeURIComponent(channelId)}/messages${params}`,
     );
@@ -108,14 +127,14 @@ export class UnCordedBridge {
   }
 
   /** Send a message to a channel. */
-  async sendMessage(channelId: string, content: string): Promise<{ sent: boolean; error?: string }> {
+  async sendMessage(channelId: ChannelId, content: string): Promise<{ sent: boolean; error?: string }> {
     return this.#post(`/bridge/channels/${encodeURIComponent(channelId)}/messages`, { content });
   }
 
   // ── Users ────────────────────────────────────────────────
 
   /** Get a user by ID. */
-  async getUser(userId: string): Promise<User> {
+  async getUser(userId: UserId): Promise<User> {
     return this.#get<User>(`/bridge/users/${encodeURIComponent(userId)}`);
   }
 

--- a/packages/plugin-server/src/errors.ts
+++ b/packages/plugin-server/src/errors.ts
@@ -1,13 +1,9 @@
-/** Base error for all bridge HTTP errors. */
-export class BridgeError extends Error {
-  readonly statusCode: number;
-  readonly code: string;
+import { AppError } from "@uncorded/shared";
 
+/** Base error for all bridge HTTP errors. */
+export class BridgeError extends AppError {
   constructor(statusCode: number, code: string, message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.name = "BridgeError";
-    this.statusCode = statusCode;
-    this.code = code;
+    super("BridgeError", statusCode, code, message, options);
   }
 }
 
@@ -15,7 +11,6 @@ export class BridgeError extends Error {
 export class BridgeConfigError extends BridgeError {
   constructor(message: string) {
     super(0, "CONFIG_ERROR", message);
-    this.name = "BridgeConfigError";
   }
 }
 
@@ -27,7 +22,6 @@ export class BridgeHttpError extends BridgeError {
 
   constructor(httpMethod: string, path: string, statusCode: number, body: string) {
     super(statusCode, "BRIDGE_HTTP_ERROR", `Bridge ${httpMethod} ${path} failed (${statusCode}): ${body}`);
-    this.name = "BridgeHttpError";
     this.path = path;
     this.method = httpMethod;
     this.body = body;
@@ -36,9 +30,11 @@ export class BridgeHttpError extends BridgeError {
 
 /** Thrown when the bridge returns 404. */
 export class BridgeNotFoundError extends BridgeError {
+  readonly path: string;
+
   constructor(path: string) {
     super(404, "NOT_FOUND", `Bridge resource not found: ${path}`);
-    this.name = "BridgeNotFoundError";
+    this.path = path;
   }
 }
 
@@ -46,6 +42,5 @@ export class BridgeNotFoundError extends BridgeError {
 export class BridgeNetworkError extends BridgeError {
   constructor(message: string, options?: { cause?: unknown }) {
     super(0, "NETWORK_ERROR", message, options);
-    this.name = "BridgeNetworkError";
   }
 }

--- a/packages/plugin-server/src/errors.ts
+++ b/packages/plugin-server/src/errors.ts
@@ -1,0 +1,51 @@
+/** Base error for all bridge HTTP errors. */
+export class BridgeError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+
+  constructor(statusCode: number, code: string, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "BridgeError";
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
+/** Thrown when required configuration is missing. */
+export class BridgeConfigError extends BridgeError {
+  constructor(message: string) {
+    super(0, "CONFIG_ERROR", message);
+    this.name = "BridgeConfigError";
+  }
+}
+
+/** Thrown when the bridge returns a non-OK response. */
+export class BridgeHttpError extends BridgeError {
+  readonly path: string;
+  readonly method: string;
+  readonly body: string;
+
+  constructor(httpMethod: string, path: string, statusCode: number, body: string) {
+    super(statusCode, "BRIDGE_HTTP_ERROR", `Bridge ${httpMethod} ${path} failed (${statusCode}): ${body}`);
+    this.name = "BridgeHttpError";
+    this.path = path;
+    this.method = httpMethod;
+    this.body = body;
+  }
+}
+
+/** Thrown when the bridge returns 404. */
+export class BridgeNotFoundError extends BridgeError {
+  constructor(path: string) {
+    super(404, "NOT_FOUND", `Bridge resource not found: ${path}`);
+    this.name = "BridgeNotFoundError";
+  }
+}
+
+/** Thrown when a bridge request times out or network fails. */
+export class BridgeNetworkError extends BridgeError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(0, "NETWORK_ERROR", message, options);
+    this.name = "BridgeNetworkError";
+  }
+}

--- a/packages/plugin-server/src/index.ts
+++ b/packages/plugin-server/src/index.ts
@@ -1,0 +1,12 @@
+export { UnCordedBridge } from "./bridge.js";
+export { BridgeStorage } from "./storage.js";
+export type {
+  BridgeOptions,
+  Channel,
+  GetMessagesOptions,
+  Member,
+  Message,
+  Server,
+  SetStorageOptions,
+  User,
+} from "./types.js";

--- a/packages/plugin-server/src/index.ts
+++ b/packages/plugin-server/src/index.ts
@@ -1,5 +1,12 @@
 export { UnCordedBridge } from "./bridge.js";
 export { BridgeStorage } from "./storage.js";
+export {
+  BridgeConfigError,
+  BridgeError,
+  BridgeHttpError,
+  BridgeNetworkError,
+  BridgeNotFoundError,
+} from "./errors.js";
 export type {
   BridgeOptions,
   Channel,

--- a/packages/plugin-server/src/storage.ts
+++ b/packages/plugin-server/src/storage.ts
@@ -1,3 +1,4 @@
+import { BridgeHttpError } from "./errors.js";
 import type { SetStorageOptions } from "./types.js";
 
 type Fetcher = (path: string, init?: RequestInit) => Promise<Response>;
@@ -13,7 +14,11 @@ export class BridgeStorage {
   /** Get a value by key. Returns `null` if not found. */
   async get<T = unknown>(key: string): Promise<T | null> {
     const res = await this.#fetch(`/bridge/storage/${encodeURIComponent(key)}`);
-    if (!res.ok) return null;
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text();
+      throw new BridgeHttpError("GET", `/bridge/storage/${key}`, res.status, text);
+    }
     const body = (await res.json()) as { key: string; value: T };
     return body.value;
   }
@@ -28,7 +33,7 @@ export class BridgeStorage {
     });
     if (!res.ok) {
       const text = await res.text();
-      throw new Error(`storage.set failed (${res.status}): ${text}`);
+      throw new BridgeHttpError("PUT", `/bridge/storage/${key}`, res.status, text);
     }
   }
 
@@ -37,7 +42,11 @@ export class BridgeStorage {
     const res = await this.#fetch(`/bridge/storage/${encodeURIComponent(key)}`, {
       method: "DELETE",
     });
-    if (!res.ok) return false;
+    if (res.status === 404) return false;
+    if (!res.ok) {
+      const text = await res.text();
+      throw new BridgeHttpError("DELETE", `/bridge/storage/${key}`, res.status, text);
+    }
     const body = (await res.json()) as { key: string; deleted: boolean };
     return body.deleted;
   }

--- a/packages/plugin-server/src/storage.ts
+++ b/packages/plugin-server/src/storage.ts
@@ -1,0 +1,44 @@
+import type { SetStorageOptions } from "./types.js";
+
+type Fetcher = (path: string, init?: RequestInit) => Promise<Response>;
+
+/** KV storage wrapper around the bridge /storage endpoints. */
+export class BridgeStorage {
+  readonly #fetch: Fetcher;
+
+  constructor(fetcher: Fetcher) {
+    this.#fetch = fetcher;
+  }
+
+  /** Get a value by key. Returns `null` if not found. */
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const res = await this.#fetch(`/bridge/storage/${encodeURIComponent(key)}`);
+    if (!res.ok) return null;
+    const body = (await res.json()) as { key: string; value: T };
+    return body.value;
+  }
+
+  /** Set a value. Optionally encrypt it at rest. */
+  async set(key: string, value: unknown, options?: SetStorageOptions): Promise<void> {
+    const params = options?.encrypt ? "?encrypt=true" : "";
+    const res = await this.#fetch(`/bridge/storage/${encodeURIComponent(key)}${params}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`storage.set failed (${res.status}): ${text}`);
+    }
+  }
+
+  /** Delete a key. Returns whether it existed. */
+  async delete(key: string): Promise<boolean> {
+    const res = await this.#fetch(`/bridge/storage/${encodeURIComponent(key)}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { key: string; deleted: boolean };
+    return body.deleted;
+  }
+}

--- a/packages/plugin-server/src/types.ts
+++ b/packages/plugin-server/src/types.ts
@@ -1,6 +1,8 @@
+import type { ChannelId, MessageId, ServerId, UserId } from "@uncorded/protocol";
+
 /** Server information returned by the bridge. */
 export interface Server {
-  id: string;
+  id: ServerId;
   name: string;
   iconUrl: string | null;
   memberCount: number;
@@ -9,7 +11,7 @@ export interface Server {
 
 /** A server member. */
 export interface Member {
-  id: string;
+  id: UserId;
   username: string;
   displayName: string;
   avatarUrl: string | null;
@@ -19,7 +21,7 @@ export interface Member {
 
 /** A channel. */
 export interface Channel {
-  id: string;
+  id: ChannelId;
   name: string;
   type: string;
   position: number;
@@ -27,9 +29,9 @@ export interface Channel {
 
 /** A chat message. */
 export interface Message {
-  id: string;
-  channelId: string;
-  authorId: string;
+  id: MessageId;
+  channelId: ChannelId;
+  authorId: UserId;
   content: string;
   createdAt: string;
   editedAt: string | null;
@@ -37,7 +39,7 @@ export interface Message {
 
 /** A user profile. */
 export interface User {
-  id: string;
+  id: UserId;
   username: string;
   displayName: string;
   avatarUrl: string | null;
@@ -59,4 +61,6 @@ export interface BridgeOptions {
   baseUrl?: string;
   /** Bearer token for auth (default: UNCORDED_BRIDGE_TOKEN env var). */
   token?: string;
+  /** Request timeout in ms. Defaults to 30000. */
+  timeoutMs?: number;
 }

--- a/packages/plugin-server/src/types.ts
+++ b/packages/plugin-server/src/types.ts
@@ -1,0 +1,62 @@
+/** Server information returned by the bridge. */
+export interface Server {
+  id: string;
+  name: string;
+  iconUrl: string | null;
+  memberCount: number;
+  channelCount: number;
+}
+
+/** A server member. */
+export interface Member {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  roles: string[];
+  joinedAt: string;
+}
+
+/** A channel. */
+export interface Channel {
+  id: string;
+  name: string;
+  type: string;
+  position: number;
+}
+
+/** A chat message. */
+export interface Message {
+  id: string;
+  channelId: string;
+  authorId: string;
+  content: string;
+  createdAt: string;
+  editedAt: string | null;
+}
+
+/** A user profile. */
+export interface User {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+/** Options for fetching messages. */
+export interface GetMessagesOptions {
+  limit?: number;
+}
+
+/** Options for setting a storage value. */
+export interface SetStorageOptions {
+  encrypt?: boolean;
+}
+
+/** Bridge constructor options. */
+export interface BridgeOptions {
+  /** Base URL of the sidecar bridge (default: UNCORDED_BRIDGE_URL env var). */
+  baseUrl?: string;
+  /** Bearer token for auth (default: UNCORDED_BRIDGE_TOKEN env var). */
+  token?: string;
+}

--- a/packages/plugin-server/tsconfig.json
+++ b/packages/plugin-server/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- **`@uncorded/plugin-server`** — Typed HTTP client for Docker plugins to talk to the sidecar bridge. Wraps all `/bridge/*` endpoints with async methods + `BridgeStorage` KV wrapper with optional encryption.
- **`@uncorded/plugin-client`** — PostMessage wrapper for plugin UIs in iframes. Typed request/response protocol, event subscriptions (`on`/`off`), and action methods (sendMessage, showToast, navigate).
- **`@uncorded/mock-bridge`** — Standalone Bun/Elysia server simulating the sidecar bridge for local dev. All `/bridge/*` routes with mock data + file-based KV store.
- **`create-uncorded-plugin`** — Interactive CLI that scaffolds a new plugin project (manifest, Dockerfile, server.ts, UI). `--sideload` flag builds Docker image and installs via sidecar.

## Test plan

- [x] `bun install` at root resolves all new packages
- [x] `bun run typecheck` passes for all 4 new packages
- [ ] Start mock bridge (`bun run packages/mock-bridge/src/index.ts`), use plugin-server SDK to fetch data
- [ ] Run `bunx create-uncorded-plugin test-plugin` and verify generated project structure
- [ ] Generated project builds and runs against mock bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New plugin creation CLI with interactive prompts, scaffolding, and optional Docker sideloading
  * Plugin client library for iframe UIs with bridge messaging, events, and error types
  * Plugin server library with a typed bridge client and storage wrapper
  * Mock bridge server and file-backed mock storage for local development/testing
* **Templates**
  * Project templates (Dockerfile, gitignore, server, package/tsconfig, HTML) for scaffolded plugins
* **Bug Fixes**
  * Fix: server plugins toggle label and explicit null prop handling for plugin frames
<!-- end of auto-generated comment: release notes by coderabbit.ai -->