### PR TITLE
feat: Phase 4 — Database-backed plugin registry

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -12,6 +12,7 @@ const Polls = lazy(() => import("./pages/Polls.js"));
 const Admins = lazy(() => import("./pages/Admins.js"));
 const AuditLog = lazy(() => import("./pages/AuditLog.js"));
 const DevEnvironment = lazy(() => import("./pages/DevEnvironment.js"));
+const Plugins = lazy(() => import("./pages/Plugins.js"));
 
 const NotFound = () => (
   <div class="flex min-h-screen items-center justify-center">
@@ -35,6 +36,7 @@ const App = () => {
             <Route path="/polls" component={Polls} />
             <Route path="/admins" component={Admins} />
             <Route path="/audit-log" component={AuditLog} />
+            <Route path="/plugins" component={Plugins} />
             <Route path="/dev" component={DevEnvironment} />
           </Route>
         </Route>

--- a/apps/admin/src/components/AdminLayout.tsx
+++ b/apps/admin/src/components/AdminLayout.tsx
@@ -69,6 +69,15 @@ const NAV_ITEMS = [
     ),
   },
   {
+    href: "/plugins",
+    label: "Plugins",
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 14.5M14.25 3.104c.251.023.501.05.75.082M19.8 14.5l-2.147 2.147a2.25 2.25 0 01-.659.591c-.197.12-.417.207-.649.257l-2.095.349a.75.75 0 01-.867-.867l.349-2.095a2.25 2.25 0 01.848-1.308L19.8 14.5z" />
+      </svg>
+    ),
+  },
+  {
     href: "/dev",
     label: "Dev Environment",
     icon: (
@@ -87,6 +96,7 @@ const PAGE_TITLES: Record<string, string> = {
   "/polls": "Polls",
   "/admins": "Admins",
   "/audit-log": "Audit Log",
+  "/plugins": "Plugins",
   "/dev": "Dev Environment",
 };
 

--- a/apps/admin/src/pages/Plugins.tsx
+++ b/apps/admin/src/pages/Plugins.tsx
@@ -1,0 +1,552 @@
+import { createSignal, onMount, Show, For } from "solid-js";
+import { api, ApiRequestError } from "../lib/api.js";
+import { showToast } from "../components/ui/toast.js";
+import { Button } from "../components/ui/button.js";
+import { Badge } from "../components/ui/badge.js";
+import { Input } from "../components/ui/input.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "../components/ui/dialog.js";
+import { DataTable, type Column } from "../components/DataTable.js";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface PluginRow {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  iconUrl: string | null;
+  category: string;
+  scope: string;
+  tags: string[];
+  image: string;
+  version: string;
+  repository: string | null;
+  verified: boolean;
+  featured: boolean;
+  downloads: number;
+  published: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PluginsResponse {
+  plugins: PluginRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+const CATEGORY_OPTIONS = ["AI", "Collaboration", "Developer Tools", "Automation", "Appearance", "Moderation", "Other"] as const;
+const SCOPE_OPTIONS = ["server", "personal", "both"] as const;
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+const AdminPlugins = () => {
+  const [data, setData] = createSignal<PluginsResponse>({
+    plugins: [],
+    total: 0,
+    page: 1,
+    pageSize: 50,
+  });
+  const [loading, setLoading] = createSignal(true);
+  const [pendingId, setPendingId] = createSignal<string | null>(null);
+
+  // Form modal
+  const [formOpen, setFormOpen] = createSignal(false);
+  const [editTarget, setEditTarget] = createSignal<PluginRow | null>(null);
+  const [formSubmitting, setFormSubmitting] = createSignal(false);
+
+  // Form fields
+  const [formId, setFormId] = createSignal("");
+  const [formName, setFormName] = createSignal("");
+  const [formDescription, setFormDescription] = createSignal("");
+  const [formAuthor, setFormAuthor] = createSignal("");
+  const [formCategory, setFormCategory] = createSignal("Other");
+  const [formScope, setFormScope] = createSignal<string>("server");
+  const [formTags, setFormTags] = createSignal("");
+  const [formImage, setFormImage] = createSignal("");
+  const [formVersion, setFormVersion] = createSignal("1.0.0");
+  const [formManifest, setFormManifest] = createSignal("");
+  const [formRepository, setFormRepository] = createSignal("");
+  const [formScreenshots, setFormScreenshots] = createSignal("");
+
+  let fetchCounter = 0;
+  let searchQuery = "";
+
+  async function fetchPlugins(page: number) {
+    const id = ++fetchCounter;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page) });
+      if (searchQuery) params.set("search", searchQuery);
+      const res = await api<PluginsResponse>(`/api/admin/plugins?${params}`);
+      if (id !== fetchCounter) return;
+      setData(res);
+    } catch {
+      if (id !== fetchCounter) return;
+      showToast("Failed to load plugins", "error");
+    } finally {
+      if (id === fetchCounter) setLoading(false);
+    }
+  }
+
+  onMount(() => fetchPlugins(1));
+
+  function handleSearch(query: string) {
+    searchQuery = query;
+    fetchPlugins(1);
+  }
+
+  function slugify(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+  }
+
+  function openAddForm() {
+    setEditTarget(null);
+    setFormId("");
+    setFormName("");
+    setFormDescription("");
+    setFormAuthor("UnCorded");
+    setFormCategory("Other");
+    setFormScope("server");
+    setFormTags("");
+    setFormImage("");
+    setFormVersion("1.0.0");
+    setFormManifest("");
+    setFormRepository("");
+    setFormScreenshots("");
+    setFormOpen(true);
+  }
+
+  function openEditForm(row: PluginRow) {
+    setEditTarget(row);
+    setFormId(row.id);
+    setFormName(row.name);
+    setFormDescription(row.description);
+    setFormAuthor(row.author);
+    setFormCategory(row.category);
+    setFormScope(row.scope);
+    setFormTags(row.tags.join(", "));
+    setFormImage(row.image);
+    setFormVersion(row.version);
+    setFormManifest(""); // Don't pre-fill manifest JSON — too large
+    setFormRepository(row.repository ?? "");
+    setFormScreenshots("");
+    setFormOpen(true);
+  }
+
+  async function submitForm() {
+    if (formSubmitting()) return;
+    setFormSubmitting(true);
+
+    const tags = formTags()
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    const screenshots = formScreenshots()
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    try {
+      if (editTarget()) {
+        // Update
+        const body: Record<string, unknown> = {
+          name: formName(),
+          description: formDescription(),
+          author: formAuthor(),
+          category: formCategory(),
+          scope: formScope(),
+          tags,
+          image: formImage(),
+          version: formVersion(),
+          repository: formRepository() || null,
+        };
+        if (screenshots.length > 0) body.screenshots = screenshots;
+        if (formManifest().trim()) {
+          body.manifest = JSON.parse(formManifest());
+        }
+
+        await api(`/api/admin/plugins/${editTarget()!.id}`, {
+          method: "PUT",
+          body: JSON.stringify(body),
+        });
+        showToast("Plugin updated", "info");
+      } else {
+        // Create — manifest is required
+        let manifest: Record<string, unknown>;
+        if (formManifest().trim()) {
+          manifest = JSON.parse(formManifest()) as Record<string, unknown>;
+        } else {
+          // Auto-build minimal manifest from form fields
+          manifest = {
+            id: formId() || slugify(formName()),
+            name: formName(),
+            version: formVersion(),
+            description: formDescription(),
+            author: formAuthor(),
+            scope: formScope(),
+            runtime: { image: formImage(), port: 3000, healthCheck: "/health" },
+            permissions: [],
+            ui: { type: "panel" },
+          };
+        }
+
+        await api("/api/admin/plugins", {
+          method: "POST",
+          body: JSON.stringify({
+            id: formId() || slugify(formName()),
+            name: formName(),
+            description: formDescription(),
+            author: formAuthor(),
+            category: formCategory(),
+            scope: formScope(),
+            tags,
+            image: formImage(),
+            version: formVersion(),
+            manifest,
+            repository: formRepository() || null,
+            screenshots,
+          }),
+        });
+        showToast("Plugin created", "info");
+      }
+      setFormOpen(false);
+      await fetchPlugins(data().page);
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        showToast("Invalid JSON in manifest field", "error");
+      } else {
+        const msg = err instanceof ApiRequestError ? err.body.message : "Action failed";
+        showToast(msg, "error");
+      }
+    } finally {
+      setFormSubmitting(false);
+    }
+  }
+
+  async function toggleField(pluginId: string, field: "publish" | "verify" | "feature") {
+    if (pendingId() === pluginId) return;
+    setPendingId(pluginId);
+    try {
+      await api(`/api/admin/plugins/${pluginId}/${field}`, { method: "PATCH" });
+      showToast(`Plugin ${field} toggled`, "info");
+      await fetchPlugins(data().page);
+    } catch (err) {
+      const msg = err instanceof ApiRequestError ? err.body.message : "Action failed";
+      showToast(msg, "error");
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  async function deletePlugin(pluginId: string, name: string) {
+    if (!window.confirm(`Delete "${name}"? This will also remove all installations.`)) return;
+    try {
+      await api(`/api/admin/plugins/${pluginId}`, { method: "DELETE" });
+      showToast("Plugin deleted", "info");
+      await fetchPlugins(data().page);
+    } catch (err) {
+      const msg = err instanceof ApiRequestError ? err.body.message : "Action failed";
+      showToast(msg, "error");
+    }
+  }
+
+  const columns: Column<PluginRow>[] = [
+    {
+      header: "Plugin",
+      accessor: (row) => (
+        <div class="max-w-xs">
+          <p class="truncate text-sm font-medium">{row.name}</p>
+          <p class="text-xs text-muted-foreground">{row.id}</p>
+        </div>
+      ),
+    },
+    {
+      header: "Author",
+      accessor: (row) => <span class="text-sm">{row.author}</span>,
+    },
+    {
+      header: "Category",
+      accessor: (row) => <Badge variant="outline">{row.category}</Badge>,
+    },
+    {
+      header: "Scope",
+      accessor: (row) => <Badge variant="info">{row.scope}</Badge>,
+    },
+    {
+      header: "Version",
+      accessor: (row) => <span class="font-mono text-xs">{row.version}</span>,
+    },
+    {
+      header: "Downloads",
+      accessor: (row) => <span class="tabular-nums text-sm">{row.downloads}</span>,
+    },
+    {
+      header: "Status",
+      accessor: (row) => (
+        <div class="flex gap-1" onClick={(e) => e.stopPropagation()}>
+          <button
+            class={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+              row.published
+                ? "bg-success/15 text-success"
+                : "text-muted-foreground hover:bg-accent"
+            } ${pendingId() === row.id ? "pointer-events-none opacity-50" : ""}`}
+            onClick={() => toggleField(row.id, "publish")}
+            title={row.published ? "Unpublish" : "Publish"}
+          >
+            {row.published ? "Published" : "Draft"}
+          </button>
+          <button
+            class={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+              row.verified
+                ? "bg-primary/15 text-primary"
+                : "text-muted-foreground hover:bg-accent"
+            } ${pendingId() === row.id ? "pointer-events-none opacity-50" : ""}`}
+            onClick={() => toggleField(row.id, "verify")}
+            title={row.verified ? "Unverify" : "Verify"}
+          >
+            {row.verified ? "Verified" : "Unverified"}
+          </button>
+          <button
+            class={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+              row.featured
+                ? "bg-warning/15 text-warning"
+                : "text-muted-foreground hover:bg-accent"
+            } ${pendingId() === row.id ? "pointer-events-none opacity-50" : ""}`}
+            onClick={() => toggleField(row.id, "feature")}
+            title={row.featured ? "Unfeature" : "Feature"}
+          >
+            {row.featured ? "Featured" : "Normal"}
+          </button>
+        </div>
+      ),
+    },
+    {
+      header: "",
+      accessor: (row) => (
+        <div class="flex justify-end gap-2" onClick={(e) => e.stopPropagation()}>
+          <Button variant="outline" size="sm" onClick={() => openEditForm(row)}>
+            Edit
+          </Button>
+          <Button variant="ghost" size="sm" class="text-destructive" onClick={() => deletePlugin(row.id, row.name)}>
+            Delete
+          </Button>
+        </div>
+      ),
+      class: "text-right",
+    },
+  ];
+
+  return (
+    <div>
+      <h1 class="mb-6 text-xl font-semibold">Plugins</h1>
+
+      <DataTable
+        columns={columns}
+        data={data().plugins}
+        total={data().total}
+        page={data().page}
+        pageSize={data().pageSize}
+        onPageChange={(p) => fetchPlugins(p)}
+        onSearch={handleSearch}
+        searchPlaceholder="Search plugins..."
+        loading={loading()}
+        actions={
+          <Button size="sm" onClick={openAddForm}>
+            Add Plugin
+          </Button>
+        }
+        expandRow={(row) => (
+          <div class="space-y-3 text-xs">
+            <div>
+              <p class="text-muted-foreground">Description</p>
+              <p class="mt-1 whitespace-pre-wrap text-sm">{row.description}</p>
+            </div>
+            <div class="flex flex-wrap gap-6 text-muted-foreground">
+              <span>Image: <span class="font-mono text-foreground">{row.image}</span></span>
+              <Show when={row.repository}>
+                <span>Repo: <span class="font-mono text-foreground">{row.repository}</span></span>
+              </Show>
+              <span>Created: {new Date(row.createdAt).toLocaleString()}</span>
+              <span>Updated: {new Date(row.updatedAt).toLocaleString()}</span>
+            </div>
+            <Show when={row.tags.length > 0}>
+              <div class="flex flex-wrap gap-1">
+                <For each={row.tags}>
+                  {(tag) => <Badge variant="outline">{tag}</Badge>}
+                </For>
+              </div>
+            </Show>
+          </div>
+        )}
+      />
+
+      {/* Add/Edit Plugin Modal */}
+      <Dialog open={formOpen()} onOpenChange={setFormOpen}>
+        <DialogContent class="max-w-lg" onClose={() => setFormOpen(false)}>
+          <DialogHeader>
+            <DialogTitle>{editTarget() ? "Edit Plugin" : "Add Plugin"}</DialogTitle>
+            <DialogDescription>
+              {editTarget() ? `Editing ${editTarget()!.name}` : "Register a new plugin in the catalog"}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div class="space-y-3">
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="mb-1 block text-xs font-medium text-muted-foreground">Name</label>
+                <Input
+                  value={formName()}
+                  onInput={(e) => {
+                    setFormName(e.currentTarget.value);
+                    if (!editTarget()) setFormId(slugify(e.currentTarget.value));
+                  }}
+                  placeholder="My Plugin"
+                />
+              </div>
+              <div>
+                <label class="mb-1 block text-xs font-medium text-muted-foreground">ID</label>
+                <Input
+                  value={formId()}
+                  onInput={(e) => setFormId(e.currentTarget.value)}
+                  placeholder="my-plugin"
+                  disabled={!!editTarget()}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label class="mb-1 block text-xs font-medium text-muted-foreground">Description</label>
+              <textarea
+                value={formDescription()}
+                onInput={(e) => setFormDescription(e.currentTarget.value)}
+                placeholder="What does this plugin do?"
+                rows={2}
+                class="w-full resize-none rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="mb-1 block text-xs font-medium text-muted-foreground">Author</label>
+                <Input
+                  value={formAuthor()}
+                  onInput={(e) => setFormAuthor(e.currentTarget.value)}
+                  placeholder="UnCorded"
+                />
+              </div>
+              <div>
+                <label class="mb-1 block text-xs font-medium text-muted-foreground">Docker Image</label>
+                <Input
+                  value={formImage()}
+                  onInput={(e) => setFormImage(e.currentTarget.value)}
+                  placeholder="my-plugin:latest"
+                />
+              </div>
+            </div>
+
+            <div class="grid grid-cols-3 gap-3">
+              <div>
+                <label class="mb-1 block text-xs font-medium text-muted-foreground">Category</label>
+                <select
+                  value={formCategory()}
+                  onChange={(e) => setFormCategory(e.currentTarget.value)}
+                  class="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none"
+                >
+                  <For each={CATEGORY_OPTIONS}>
+                    {(c) => <option value={c}>{c}</option>}
+                  </For>
+                </select>
+              </div>
+              <div>
+                <label class="mb-1 block text-xs font-medium text-muted-foreground">Scope</label>
+                <select
+                  value={formScope()}
+                  onChange={(e) => setFormScope(e.currentTarget.value)}
+                  class="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none"
+                >
+                  <For each={SCOPE_OPTIONS}>
+                    {(s) => <option value={s}>{s}</option>}
+                  </For>
+                </select>
+              </div>
+              <div>
+                <label class="mb-1 block text-xs font-medium text-muted-foreground">Version</label>
+                <Input
+                  value={formVersion()}
+                  onInput={(e) => setFormVersion(e.currentTarget.value)}
+                  placeholder="1.0.0"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label class="mb-1 block text-xs font-medium text-muted-foreground">Tags (comma-separated)</label>
+              <Input
+                value={formTags()}
+                onInput={(e) => setFormTags(e.currentTarget.value)}
+                placeholder="ai, automation, tools"
+              />
+            </div>
+
+            <div>
+              <label class="mb-1 block text-xs font-medium text-muted-foreground">
+                Manifest JSON {editTarget() ? "(leave empty to keep current)" : "(leave empty to auto-generate)"}
+              </label>
+              <textarea
+                value={formManifest()}
+                onInput={(e) => setFormManifest(e.currentTarget.value)}
+                placeholder='{"id": "my-plugin", ...}'
+                rows={4}
+                class="w-full resize-none rounded-lg border border-border bg-input px-3 py-2 font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            <div>
+              <label class="mb-1 block text-xs font-medium text-muted-foreground">Repository URL</label>
+              <Input
+                value={formRepository()}
+                onInput={(e) => setFormRepository(e.currentTarget.value)}
+                placeholder="https://github.com/..."
+              />
+            </div>
+
+            <div>
+              <label class="mb-1 block text-xs font-medium text-muted-foreground">Screenshot URLs (one per line)</label>
+              <textarea
+                value={formScreenshots()}
+                onInput={(e) => setFormScreenshots(e.currentTarget.value)}
+                placeholder="https://..."
+                rows={2}
+                class="w-full resize-none rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setFormOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={submitForm} disabled={formSubmitting()}>
+              {formSubmitting() ? "Saving..." : editTarget() ? "Update" : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default AdminPlugins;

--- a/apps/admin/src/pages/Plugins.tsx
+++ b/apps/admin/src/pages/Plugins.tsx
@@ -46,6 +46,13 @@ interface PluginsResponse {
 const CATEGORY_OPTIONS = ["AI", "Collaboration", "Developer Tools", "Automation", "Appearance", "Moderation", "Other"] as const;
 const SCOPE_OPTIONS = ["server", "personal", "both"] as const;
 
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 // ── Component ──────────────────────────────────────────────────────────────
 
 const AdminPlugins = () => {
@@ -102,13 +109,6 @@ const AdminPlugins = () => {
   function handleSearch(query: string) {
     searchQuery = query;
     fetchPlugins(1);
-  }
-
-  function slugify(name: string): string {
-    return name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "");
   }
 
   function openAddForm() {

--- a/apps/desktop/scripts/dev.ts
+++ b/apps/desktop/scripts/dev.ts
@@ -89,6 +89,7 @@ function spawnElectron(): void {
         ...process.env,
         NODE_ENV: "development",
         UNCORDED_WEB_URL: webUrl,
+        UNCORDED_API_URL: process.env["UNCORDED_API_URL"] ?? webUrl,
       },
       shell: true,
     },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -189,21 +189,18 @@ interface PluginInfo {
 
 let cachedPlugins: PluginInfo[] = [];
 
-// Hardcoded manifests until we have a proper plugin registry
-const PLUGIN_MANIFESTS: Record<string, object> = {
-  "excalidraw-boards": {
-    id: "excalidraw-boards",
-    name: "Excalidraw Boards",
-    version: "1.0.0",
-    description: "Collaborative whiteboard",
-    author: "UnCorded",
-    scope: "server",
-    runtime: { image: "excalidraw-boards:latest", port: 3000, healthCheck: "/health" },
-    permissions: ["server.read", "members.read"],
-    resources: { cpus: 0.5, memoryMb: 256 },
-    ui: { type: "page" },
-  },
-};
+const API_URL = process.env["UNCORDED_API_URL"]
+  ?? (IS_DEV ? "http://localhost:3000" : "https://uncorded.app");
+
+async function fetchPluginManifest(pluginId: string): Promise<object> {
+  const res = await fetch(`${API_URL}/api/plugins/${pluginId}/manifest`);
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Failed to fetch manifest for ${pluginId} (${res.status}): ${body}`);
+  }
+  const data = (await res.json()) as { manifest: object };
+  return data.manifest;
+}
 
 function broadcastPluginState(): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -242,8 +239,7 @@ function setupPluginIpc(): void {
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       if (body.includes("not found") || body.includes("not installed")) {
-        const manifest = PLUGIN_MANIFESTS[pluginId];
-        if (!manifest) throw new Error(`No manifest for plugin: ${pluginId}`);
+        const manifest = await fetchPluginManifest(pluginId);
 
         const installRes = await fetch(`http://localhost:${port}/plugins/install`, {
           method: "POST",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -189,14 +189,30 @@ interface PluginInfo {
 
 let cachedPlugins: PluginInfo[] = [];
 
+// Derive API base URL: explicit env > web URL origin > hardcoded default
 const API_URL = process.env["UNCORDED_API_URL"]
+  ?? process.env["UNCORDED_WEB_URL"]
   ?? (IS_DEV ? "http://localhost:3000" : "https://uncorded.app");
+
+class PluginManifestError extends Error {
+  pluginId: string;
+  status: number;
+  body: string;
+
+  constructor(pluginId: string, status: number, body: string) {
+    super(`Failed to fetch manifest for ${pluginId} (${status}): ${body}`);
+    this.name = "PluginManifestError";
+    this.pluginId = pluginId;
+    this.status = status;
+    this.body = body;
+  }
+}
 
 async function fetchPluginManifest(pluginId: string): Promise<object> {
   const res = await fetch(`${API_URL}/api/plugins/${pluginId}/manifest`);
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`Failed to fetch manifest for ${pluginId} (${res.status}): ${body}`);
+    throw new PluginManifestError(pluginId, res.status, body);
   }
   const data = (await res.json()) as { manifest: object };
   return data.manifest;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -209,13 +209,27 @@ class PluginManifestError extends Error {
 }
 
 async function fetchPluginManifest(pluginId: string): Promise<object> {
-  const res = await fetch(`${API_URL}/api/plugins/${pluginId}/manifest`);
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PluginManifestError(pluginId, res.status, body);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(`${API_URL}/api/plugins/${pluginId}/manifest`, {
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new PluginManifestError(pluginId, res.status, body);
+    }
+    const data = (await res.json()) as { manifest: object };
+    return data.manifest;
+  } catch (err) {
+    if (err instanceof PluginManifestError) throw err;
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new PluginManifestError(pluginId, 0, "Request timed out after 10s");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
   }
-  const data = (await res.json()) as { manifest: object };
-  return data.manifest;
 }
 
 function broadcastPluginState(): void {

--- a/apps/server/drizzle/0017_plugin_registry.sql
+++ b/apps/server/drizzle/0017_plugin_registry.sql
@@ -6,16 +6,16 @@ CREATE TABLE plugin_registry (
   icon_url TEXT,
   category TEXT NOT NULL DEFAULT 'other',
   scope TEXT NOT NULL DEFAULT 'server',
-  tags TEXT[] DEFAULT '{}',
+  tags TEXT[] NOT NULL DEFAULT '{}',
   image TEXT NOT NULL,
   version TEXT NOT NULL DEFAULT '1.0.0',
   manifest JSONB NOT NULL,
   repository TEXT,
-  verified BOOLEAN DEFAULT FALSE,
-  featured BOOLEAN DEFAULT FALSE,
-  downloads INTEGER DEFAULT 0,
-  screenshots JSONB DEFAULT '[]',
-  published BOOLEAN DEFAULT TRUE,
+  verified BOOLEAN NOT NULL DEFAULT FALSE,
+  featured BOOLEAN NOT NULL DEFAULT FALSE,
+  downloads INTEGER NOT NULL DEFAULT 0,
+  screenshots JSONB NOT NULL DEFAULT '[]',
+  published BOOLEAN NOT NULL DEFAULT TRUE,
   created_at TIMESTAMP DEFAULT NOW() NOT NULL,
   updated_at TIMESTAMP DEFAULT NOW() NOT NULL
 );
@@ -27,3 +27,12 @@ CREATE INDEX plugin_registry_scope_idx ON plugin_registry(scope);
 INSERT INTO plugin_registry (id, name, description, author, category, scope, tags, image, version, manifest, verified) VALUES
 ('claude-code', 'Claude Code', 'Connect your Claude Code session to UnCorded. Chat with Claude from any DM or server channel.', 'UnCorded', 'AI', 'both', ARRAY['ai', 'developer-tools', 'automation'], 'claude-code:latest', '1.0.0', '{"id":"claude-code","name":"Claude Code","version":"1.0.0","description":"Connect your Claude Code session to UnCorded.","author":"UnCorded","scope":"both","runtime":{"image":"claude-code:latest","port":3000,"healthCheck":"/health"},"permissions":["server.read","members.read","messages.read","messages.send"],"ui":{"type":"panel"}}', true),
 ('excalidraw-boards', 'Excalidraw Boards', 'Collaborative whiteboard — create boards and draw together in real-time.', 'UnCorded', 'Collaboration', 'server', ARRAY['whiteboard', 'collaboration', 'drawing'], 'excalidraw-boards:latest', '1.0.0', '{"id":"excalidraw-boards","name":"Excalidraw Boards","version":"1.0.0","description":"Collaborative whiteboard","author":"UnCorded","scope":"server","runtime":{"image":"excalidraw-boards:latest","port":3000,"healthCheck":"/health"},"permissions":["server.read","members.read"],"resources":{"cpus":0.5,"memoryMb":256},"ui":{"type":"page"}}', true);
+
+-- Add FK constraints from dependent tables to plugin_registry
+ALTER TABLE plugin_installs
+  ADD CONSTRAINT plugin_installs_plugin_id_fk
+  FOREIGN KEY (plugin_id) REFERENCES plugin_registry(id) ON DELETE CASCADE;
+
+ALTER TABLE server_plugins
+  ADD CONSTRAINT server_plugins_plugin_id_fk
+  FOREIGN KEY (plugin_id) REFERENCES plugin_registry(id) ON DELETE CASCADE;

--- a/apps/server/drizzle/0017_plugin_registry.sql
+++ b/apps/server/drizzle/0017_plugin_registry.sql
@@ -1,0 +1,29 @@
+CREATE TABLE plugin_registry (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  author TEXT NOT NULL,
+  icon_url TEXT,
+  category TEXT NOT NULL DEFAULT 'other',
+  scope TEXT NOT NULL DEFAULT 'server',
+  tags TEXT[] DEFAULT '{}',
+  image TEXT NOT NULL,
+  version TEXT NOT NULL DEFAULT '1.0.0',
+  manifest JSONB NOT NULL,
+  repository TEXT,
+  verified BOOLEAN DEFAULT FALSE,
+  featured BOOLEAN DEFAULT FALSE,
+  downloads INTEGER DEFAULT 0,
+  screenshots JSONB DEFAULT '[]',
+  published BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX plugin_registry_category_idx ON plugin_registry(category);
+CREATE INDEX plugin_registry_scope_idx ON plugin_registry(scope);
+
+-- Seed existing plugins
+INSERT INTO plugin_registry (id, name, description, author, category, scope, tags, image, version, manifest, verified) VALUES
+('claude-code', 'Claude Code', 'Connect your Claude Code session to UnCorded. Chat with Claude from any DM or server channel.', 'UnCorded', 'AI', 'both', ARRAY['ai', 'developer-tools', 'automation'], 'claude-code:latest', '1.0.0', '{"id":"claude-code","name":"Claude Code","version":"1.0.0","description":"Connect your Claude Code session to UnCorded.","author":"UnCorded","scope":"both","runtime":{"image":"claude-code:latest","port":3000,"healthCheck":"/health"},"permissions":["server.read","members.read","messages.read","messages.send"],"ui":{"type":"panel"}}', true),
+('excalidraw-boards', 'Excalidraw Boards', 'Collaborative whiteboard — create boards and draw together in real-time.', 'UnCorded', 'Collaboration', 'server', ARRAY['whiteboard', 'collaboration', 'drawing'], 'excalidraw-boards:latest', '1.0.0', '{"id":"excalidraw-boards","name":"Excalidraw Boards","version":"1.0.0","description":"Collaborative whiteboard","author":"UnCorded","scope":"server","runtime":{"image":"excalidraw-boards:latest","port":3000,"healthCheck":"/health"},"permissions":["server.read","members.read"],"resources":{"cpus":0.5,"memoryMb":256},"ui":{"type":"page"}}', true);

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1743264000000,
       "tag": "0016_add_server_plugins",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1743350400000,
+      "tag": "0017_plugin_registry",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -9,6 +9,7 @@ import {
   index,
   primaryKey,
   unique,
+  jsonb,
 } from "drizzle-orm/pg-core";
 
 import { nanoid } from "nanoid";
@@ -443,6 +444,35 @@ export const pollVotes = pgTable(
 );
 
 // ─── Plugin Tables ──────────────────────────────────────────
+
+export const pluginRegistry = pgTable(
+  "plugin_registry",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    author: text("author").notNull(),
+    iconUrl: text("icon_url"),
+    category: text("category").notNull().default("other"),
+    scope: text("scope").notNull().default("server"),
+    tags: text("tags").array().default([]),
+    image: text("image").notNull(),
+    version: text("version").notNull().default("1.0.0"),
+    manifest: jsonb("manifest").notNull(),
+    repository: text("repository"),
+    verified: boolean("verified").default(false),
+    featured: boolean("featured").default(false),
+    downloads: integer("downloads").default(0),
+    screenshots: jsonb("screenshots").default([]),
+    published: boolean("published").default(true),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (t) => [
+    index("plugin_registry_category_idx").on(t.category),
+    index("plugin_registry_scope_idx").on(t.scope),
+  ],
+);
 
 export const serverPluginStateEnum = pgEnum("server_plugin_state", [
   "active",

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -455,16 +455,16 @@ export const pluginRegistry = pgTable(
     iconUrl: text("icon_url"),
     category: text("category").notNull().default("other"),
     scope: text("scope").notNull().default("server"),
-    tags: text("tags").array().default([]),
+    tags: text("tags").array().notNull().default([]),
     image: text("image").notNull(),
     version: text("version").notNull().default("1.0.0"),
     manifest: jsonb("manifest").notNull(),
     repository: text("repository"),
-    verified: boolean("verified").default(false),
-    featured: boolean("featured").default(false),
-    downloads: integer("downloads").default(0),
-    screenshots: jsonb("screenshots").default([]),
-    published: boolean("published").default(true),
+    verified: boolean("verified").notNull().default(false),
+    featured: boolean("featured").notNull().default(false),
+    downloads: integer("downloads").notNull().default(0),
+    screenshots: jsonb("screenshots").notNull().default([]),
+    published: boolean("published").notNull().default(true),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
   },
@@ -487,7 +487,9 @@ export const serverPlugins = pgTable(
     serverId: text("server_id")
       .notNull()
       .references(() => servers.id, { onDelete: "cascade" }),
-    pluginId: text("plugin_id").notNull(),
+    pluginId: text("plugin_id")
+      .notNull()
+      .references(() => pluginRegistry.id, { onDelete: "cascade" }),
     installedBy: text("installed_by")
       .notNull()
       .references(() => user.id, { onDelete: "restrict" }),
@@ -506,7 +508,9 @@ export const pluginInstalls = pgTable(
   "plugin_installs",
   {
     id: id(),
-    pluginId: text("plugin_id").notNull(),
+    pluginId: text("plugin_id")
+      .notNull()
+      .references(() => pluginRegistry.id, { onDelete: "cascade" }),
     userId: text("user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -23,7 +23,7 @@ import { stripeRoutes } from "./routes/stripe.js";
 import { turnRoutes } from "./routes/turn.js";
 import { fileReceiptRoutes } from "./routes/file-receipts.js";
 import { botRoutes, botAvatarRoutes } from "./routes/bots.js";
-import { pluginRoutes } from "./routes/plugins.js";
+import { pluginRoutes, pluginPublicRoutes } from "./routes/plugins.js";
 import { serverPluginRoutes } from "./routes/server-plugins.js";
 import { gatewayTicketRoutes } from "./routes/gateway.js";
 import { gateway } from "./ws/gateway.js";
@@ -85,6 +85,7 @@ const app = new Elysia()
   .use(fileReceiptRoutes)
   .use(botRoutes)
   .use(botAvatarRoutes)
+  .use(pluginPublicRoutes)
   .use(pluginRoutes)
   .use(serverPluginRoutes)
   .use(gatewayTicketRoutes)

--- a/apps/server/src/routes/__tests__/server-plugins.test.ts
+++ b/apps/server/src/routes/__tests__/server-plugins.test.ts
@@ -13,12 +13,20 @@ const { mockRequireMember, mockRequireOwner, mockComputeEffectiveTier, selectRes
     const deletedRows: unknown[][] = [];
     const insertedRow: unknown[] = [];
 
+    /** Returns a chainable that supports both `await where(...)` and `where(...).limit(n)` */
+    function makeWhereResult() {
+      const resolve = () => selectResults.shift() ?? [];
+      return {
+        limit: vi.fn().mockImplementation(() => Promise.resolve(resolve())),
+        then: (onFulfilled: (v: unknown[]) => unknown, onRejected?: (e: unknown) => unknown) =>
+          Promise.resolve(resolve()).then(onFulfilled, onRejected),
+      };
+    }
+
     const mockDb = {
       select: vi.fn().mockImplementation(() => ({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockImplementation(() =>
-            Promise.resolve(selectResults.shift() ?? []),
-          ),
+          where: vi.fn().mockImplementation(() => makeWhereResult()),
         }),
       })),
       insert: vi.fn().mockImplementation(() => ({
@@ -64,6 +72,10 @@ vi.mock("../../db/schema.js", () => ({
     installedBy: "server_plugins.installed_by",
     tunnelUrl: "server_plugins.tunnel_url",
     state: "server_plugins.state",
+  },
+  pluginRegistry: {
+    id: "plugin_registry.id",
+    published: "plugin_registry.published",
   },
 }));
 vi.mock("../../helpers/permissions.js", () => ({
@@ -160,6 +172,9 @@ describe("server plugin routes", () => {
 
   describe("POST /api/servers/:serverId/plugins", () => {
     it("installs a plugin for server_owner tier users", async () => {
+      // Registry lookup returns a published plugin
+      selectResults.push([{ id: "claude-code" }]);
+
       insertedRow.push({
         id: "sp1",
         pluginId: "claude-code",

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -1059,19 +1059,21 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
   .delete("/plugins/:pluginId", async ({ params, user: sessionUser, adminLevel }) => {
     if (adminLevel !== "owner") throw new ForbiddenError("Owner access required");
 
-    const [plugin] = await db
-      .select({ id: pluginRegistry.id })
-      .from(pluginRegistry)
-      .where(eq(pluginRegistry.id, params.pluginId))
-      .limit(1);
-    if (!plugin) throw new NotFoundError("Plugin");
+    await db.transaction(async (tx) => {
+      const [plugin] = await tx
+        .select({ id: pluginRegistry.id })
+        .from(pluginRegistry)
+        .where(eq(pluginRegistry.id, params.pluginId))
+        .limit(1);
+      if (!plugin) throw new NotFoundError("Plugin");
 
-    // Cascade: remove from server_plugins and plugin_installs first
-    await db.delete(serverPlugins).where(eq(serverPlugins.pluginId, params.pluginId));
-    await db.delete(pluginInstalls).where(eq(pluginInstalls.pluginId, params.pluginId));
-    await db.delete(pluginRegistry).where(eq(pluginRegistry.id, params.pluginId));
+      // Cascade: remove from server_plugins and plugin_installs first
+      await tx.delete(serverPlugins).where(eq(serverPlugins.pluginId, params.pluginId));
+      await tx.delete(pluginInstalls).where(eq(pluginInstalls.pluginId, params.pluginId));
+      await tx.delete(pluginRegistry).where(eq(pluginRegistry.id, params.pluginId));
 
-    await logAudit(sessionUser.id, "delete_plugin", "plugin", params.pluginId);
+      await logAudit(sessionUser.id, "delete_plugin", "plugin", params.pluginId);
+    });
 
     return { success: true };
   })

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -975,29 +975,28 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     }
     const data = parsed.data;
 
-    // Check ID uniqueness
-    const [existing] = await db
-      .select({ id: pluginRegistry.id })
-      .from(pluginRegistry)
-      .where(eq(pluginRegistry.id, data.id))
-      .limit(1);
-    if (existing) throw new ValidationError("Plugin with this ID already exists");
+    // Atomic insert with conflict check
+    const [inserted] = await db
+      .insert(pluginRegistry)
+      .values({
+        id: data.id,
+        name: data.name,
+        description: data.description,
+        author: data.author,
+        iconUrl: data.iconUrl ?? null,
+        category: data.category,
+        scope: data.scope,
+        tags: data.tags ?? [],
+        image: data.image,
+        version: data.version ?? "1.0.0",
+        manifest: data.manifest,
+        repository: data.repository ?? null,
+        screenshots: data.screenshots ?? [],
+      })
+      .onConflictDoNothing()
+      .returning({ id: pluginRegistry.id });
 
-    await db.insert(pluginRegistry).values({
-      id: data.id,
-      name: data.name,
-      description: data.description,
-      author: data.author,
-      iconUrl: data.iconUrl ?? null,
-      category: data.category,
-      scope: data.scope,
-      tags: data.tags ?? [],
-      image: data.image,
-      version: data.version ?? "1.0.0",
-      manifest: data.manifest,
-      repository: data.repository ?? null,
-      screenshots: data.screenshots ?? [],
-    });
+    if (!inserted) throw new ValidationError("Plugin with this ID already exists");
 
     await logAudit(sessionUser.id, "create_plugin", "plugin", data.id);
 

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -22,6 +22,9 @@ import {
   pollVotes,
   giftedSubscriptions,
   bots,
+  pluginRegistry,
+  pluginInstalls,
+  serverPlugins,
 } from "../db/schema.js";
 
 import { readdir } from "node:fs/promises";
@@ -898,4 +901,234 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     ]);
 
     return { entries: rows, total: total?.value ?? 0, page, pageSize: PAGE_SIZE };
+  })
+
+  // ── Plugin Management ────────────────────────────────────────────────────
+  .get("/plugins", async ({ query }) => {
+    const page = Math.max(1, Number(query.page) || 1);
+    const search = typeof query.search === "string" ? query.search.trim() : "";
+    const offset = (page - 1) * PAGE_SIZE;
+
+    const escaped = search.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+    const searchFilter = search
+      ? or(
+          like(pluginRegistry.name, `%${escaped}%`),
+          like(pluginRegistry.author, `%${escaped}%`),
+          like(pluginRegistry.id, `%${escaped}%`),
+        )
+      : undefined;
+
+    const [rows, [total]] = await Promise.all([
+      db
+        .select()
+        .from(pluginRegistry)
+        .where(searchFilter)
+        .orderBy(desc(pluginRegistry.createdAt))
+        .limit(PAGE_SIZE)
+        .offset(offset),
+      db.select({ value: count() }).from(pluginRegistry).where(searchFilter),
+    ]);
+
+    const plugins = rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      description: r.description,
+      author: r.author,
+      iconUrl: r.iconUrl,
+      category: r.category,
+      scope: r.scope,
+      tags: r.tags ?? [],
+      image: r.image,
+      version: r.version,
+      repository: r.repository,
+      verified: r.verified ?? false,
+      featured: r.featured ?? false,
+      downloads: r.downloads ?? 0,
+      published: r.published ?? true,
+      createdAt: r.createdAt.toISOString(),
+      updatedAt: r.updatedAt.toISOString(),
+    }));
+
+    return { plugins, total: total?.value ?? 0, page, pageSize: PAGE_SIZE };
+  })
+
+  .post("/plugins", async ({ body, user: sessionUser }) => {
+    const pluginSchema = z.object({
+      id: z.string().min(1).max(100).regex(/^[a-z0-9-]+$/, "ID must be lowercase alphanumeric with hyphens"),
+      name: z.string().min(1).max(100),
+      description: z.string().min(1).max(2000),
+      author: z.string().min(1).max(100),
+      iconUrl: z.string().max(500).nullable().optional(),
+      category: z.string().min(1).max(50),
+      scope: z.enum(["server", "personal", "both"]),
+      tags: z.array(z.string().max(50)).max(20).optional(),
+      image: z.string().min(1).max(500),
+      version: z.string().min(1).max(20).optional(),
+      manifest: z.record(z.unknown()),
+      repository: z.string().max(500).nullable().optional(),
+      screenshots: z.array(z.string().max(500)).max(10).optional(),
+    });
+
+    const parsed = pluginSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
+    }
+    const data = parsed.data;
+
+    // Check ID uniqueness
+    const [existing] = await db
+      .select({ id: pluginRegistry.id })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, data.id))
+      .limit(1);
+    if (existing) throw new ValidationError("Plugin with this ID already exists");
+
+    await db.insert(pluginRegistry).values({
+      id: data.id,
+      name: data.name,
+      description: data.description,
+      author: data.author,
+      iconUrl: data.iconUrl ?? null,
+      category: data.category,
+      scope: data.scope,
+      tags: data.tags ?? [],
+      image: data.image,
+      version: data.version ?? "1.0.0",
+      manifest: data.manifest,
+      repository: data.repository ?? null,
+      screenshots: data.screenshots ?? [],
+    });
+
+    await logAudit(sessionUser.id, "create_plugin", "plugin", data.id);
+
+    return { success: true };
+  })
+
+  .put("/plugins/:pluginId", async ({ params, body, user: sessionUser }) => {
+    const pluginUpdateSchema = z.object({
+      name: z.string().min(1).max(100).optional(),
+      description: z.string().min(1).max(2000).optional(),
+      author: z.string().min(1).max(100).optional(),
+      iconUrl: z.string().max(500).nullable().optional(),
+      category: z.string().min(1).max(50).optional(),
+      scope: z.enum(["server", "personal", "both"]).optional(),
+      tags: z.array(z.string().max(50)).max(20).optional(),
+      image: z.string().min(1).max(500).optional(),
+      version: z.string().min(1).max(20).optional(),
+      manifest: z.record(z.unknown()).optional(),
+      repository: z.string().max(500).nullable().optional(),
+      screenshots: z.array(z.string().max(500)).max(10).optional(),
+    });
+
+    const parsed = pluginUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new ValidationError(parsed.error.issues[0]?.message ?? "Invalid input");
+    }
+
+    const [plugin] = await db
+      .select({ id: pluginRegistry.id })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+    if (!plugin) throw new NotFoundError("Plugin");
+
+    const updates: Record<string, unknown> = {};
+    const data = parsed.data;
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.description !== undefined) updates.description = data.description;
+    if (data.author !== undefined) updates.author = data.author;
+    if (data.iconUrl !== undefined) updates.iconUrl = data.iconUrl;
+    if (data.category !== undefined) updates.category = data.category;
+    if (data.scope !== undefined) updates.scope = data.scope;
+    if (data.tags !== undefined) updates.tags = data.tags;
+    if (data.image !== undefined) updates.image = data.image;
+    if (data.version !== undefined) updates.version = data.version;
+    if (data.manifest !== undefined) updates.manifest = data.manifest;
+    if (data.repository !== undefined) updates.repository = data.repository;
+    if (data.screenshots !== undefined) updates.screenshots = data.screenshots;
+
+    if (Object.keys(updates).length > 0) {
+      await db.update(pluginRegistry).set(updates).where(eq(pluginRegistry.id, params.pluginId));
+    }
+
+    await logAudit(sessionUser.id, "update_plugin", "plugin", params.pluginId, JSON.stringify(data));
+
+    return { success: true };
+  })
+
+  .delete("/plugins/:pluginId", async ({ params, user: sessionUser, adminLevel }) => {
+    if (adminLevel !== "owner") throw new ForbiddenError("Owner access required");
+
+    const [plugin] = await db
+      .select({ id: pluginRegistry.id })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+    if (!plugin) throw new NotFoundError("Plugin");
+
+    // Cascade: remove from server_plugins and plugin_installs first
+    await db.delete(serverPlugins).where(eq(serverPlugins.pluginId, params.pluginId));
+    await db.delete(pluginInstalls).where(eq(pluginInstalls.pluginId, params.pluginId));
+    await db.delete(pluginRegistry).where(eq(pluginRegistry.id, params.pluginId));
+
+    await logAudit(sessionUser.id, "delete_plugin", "plugin", params.pluginId);
+
+    return { success: true };
+  })
+
+  .patch("/plugins/:pluginId/publish", async ({ params, user: sessionUser }) => {
+    const [plugin] = await db
+      .select({ id: pluginRegistry.id, published: pluginRegistry.published })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+    if (!plugin) throw new NotFoundError("Plugin");
+
+    const newValue = !plugin.published;
+    await db
+      .update(pluginRegistry)
+      .set({ published: newValue })
+      .where(eq(pluginRegistry.id, params.pluginId));
+
+    await logAudit(sessionUser.id, newValue ? "publish_plugin" : "unpublish_plugin", "plugin", params.pluginId);
+
+    return { success: true, published: newValue };
+  })
+
+  .patch("/plugins/:pluginId/verify", async ({ params, user: sessionUser }) => {
+    const [plugin] = await db
+      .select({ id: pluginRegistry.id, verified: pluginRegistry.verified })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+    if (!plugin) throw new NotFoundError("Plugin");
+
+    const newValue = !plugin.verified;
+    await db
+      .update(pluginRegistry)
+      .set({ verified: newValue })
+      .where(eq(pluginRegistry.id, params.pluginId));
+
+    await logAudit(sessionUser.id, newValue ? "verify_plugin" : "unverify_plugin", "plugin", params.pluginId);
+
+    return { success: true, verified: newValue };
+  })
+
+  .patch("/plugins/:pluginId/feature", async ({ params, user: sessionUser }) => {
+    const [plugin] = await db
+      .select({ id: pluginRegistry.id, featured: pluginRegistry.featured })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+    if (!plugin) throw new NotFoundError("Plugin");
+
+    const newValue = !plugin.featured;
+    await db
+      .update(pluginRegistry)
+      .set({ featured: newValue })
+      .where(eq(pluginRegistry.id, params.pluginId));
+
+    await logAudit(sessionUser.id, newValue ? "feature_plugin" : "unfeature_plugin", "plugin", params.pluginId);
+
+    return { success: true, featured: newValue };
   });

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -81,13 +81,13 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
       icon: p.iconUrl,
       category: p.category,
       scope: p.scope as "server" | "personal" | "both",
-      tags: p.tags ?? [],
+      tags: p.tags,
       version: p.version,
-      verified: p.verified ?? false,
-      featured: p.featured ?? false,
-      downloads: p.downloads ?? 0,
+      verified: p.verified,
+      featured: p.featured,
+      downloads: p.downloads,
       repository: p.repository,
-      screenshots: p.screenshots ?? [],
+      screenshots: p.screenshots,
       installCount: countMap.get(p.id) ?? 0,
       installed: userInstallMap.has(p.id),
       installedAt: userInstallMap.get(p.id)?.toISOString() ?? null,
@@ -131,13 +131,13 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
       icon: row.iconUrl,
       category: row.category,
       scope: row.scope as "server" | "personal" | "both",
-      tags: row.tags ?? [],
+      tags: row.tags,
       version: row.version,
-      verified: row.verified ?? false,
-      featured: row.featured ?? false,
-      downloads: row.downloads ?? 0,
+      verified: row.verified,
+      featured: row.featured,
+      downloads: row.downloads,
       repository: row.repository,
-      screenshots: row.screenshots ?? [],
+      screenshots: row.screenshots,
       installCount: countRow?.count ?? 0,
       installed: !!userInstall,
       installedAt: userInstall?.installedAt?.toISOString() ?? null,
@@ -196,19 +196,22 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
     if (!plugin) throw new NotFoundError("Plugin");
 
     // Upsert — ignore if already installed
-    await db
+    const [inserted] = await db
       .insert(pluginInstalls)
       .values({
         pluginId: params.pluginId,
         userId: sessionUser.id,
       })
-      .onConflictDoNothing({ target: [pluginInstalls.pluginId, pluginInstalls.userId] });
+      .onConflictDoNothing({ target: [pluginInstalls.pluginId, pluginInstalls.userId] })
+      .returning({ id: pluginInstalls.id });
 
-    // Increment downloads
-    await db
-      .update(pluginRegistry)
-      .set({ downloads: sql`${pluginRegistry.downloads} + 1` })
-      .where(eq(pluginRegistry.id, params.pluginId));
+    // Only increment downloads when a new install row was created
+    if (inserted) {
+      await db
+        .update(pluginRegistry)
+        .set({ downloads: sql`${pluginRegistry.downloads} + 1` })
+        .where(eq(pluginRegistry.id, params.pluginId));
+    }
 
     const [countRow] = await db
       .select({ count: sql<number>`count(*)::int` })
@@ -225,11 +228,11 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
       throw new RateLimitError("Too many requests, try again later");
     }
 
-    // Validate plugin exists in registry
+    // Validate plugin exists in registry and is published
     const [plugin] = await db
       .select({ id: pluginRegistry.id })
       .from(pluginRegistry)
-      .where(eq(pluginRegistry.id, params.pluginId))
+      .where(and(eq(pluginRegistry.id, params.pluginId), eq(pluginRegistry.published, true)))
       .limit(1);
     if (!plugin) throw new NotFoundError("Plugin");
 

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -2,7 +2,7 @@ import { Elysia } from "elysia";
 import { eq, and, sql, desc } from "drizzle-orm";
 import { NotFoundError, RateLimitError } from "@uncorded/shared";
 import { db } from "../db/index.js";
-import { pluginInstalls, bots, user } from "../db/schema.js";
+import { pluginRegistry, pluginInstalls, bots, user } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
 import { checkIpRateLimit } from "../middleware/ip-rate-limit.js";
 
@@ -14,44 +14,41 @@ function getClientIp(request: Request): string {
   );
 }
 
-// ── Plugin Catalog (hardcoded for now) ──────────────────────────────────────
+// ── Public routes (no auth) ─────────────────────────────────────────────────
 
-const PLUGIN_CATALOG = [
-  {
-    id: "claude-code",
-    name: "Claude Code",
-    description:
-      "Connect your Claude Code session to UnCorded. Chat with Claude from any DM or server channel.",
-    author: "UnCorded",
-    icon: null,
-    category: "AI",
-    scope: "both" as const,
-    tags: ["ai", "developer-tools", "automation"],
-  },
-  {
-    id: "excalidraw-boards",
-    name: "Excalidraw Boards",
-    description:
-      "Collaborative whiteboard — create boards and draw together in real-time.",
-    author: "UnCorded",
-    icon: null,
-    category: "Collaboration",
-    scope: "server" as const,
-    tags: ["whiteboard", "collaboration", "drawing"],
-  },
-] as const;
+export const pluginPublicRoutes = new Elysia({ prefix: "/api/plugins" })
 
-function findPlugin(id: string) {
-  return PLUGIN_CATALOG.find((p) => p.id === id);
-}
+  // ── GET /api/plugins/:pluginId/manifest — public manifest endpoint ────
+  .get("/:pluginId/manifest", async ({ params, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 30, 60_000, "plugin-manifest"))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
 
-// ── Routes ──────────────────────────────────────────────────────────────────
+    const [row] = await db
+      .select({ manifest: pluginRegistry.manifest, published: pluginRegistry.published })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+
+    if (!row || !row.published) throw new NotFoundError("Plugin");
+
+    return { manifest: row.manifest };
+  });
+
+// ── Authenticated routes ────────────────────────────────────────────────────
 
 export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
   .resolve(authResolve())
 
-  // ── GET /api/plugins — list catalog with install counts + user status ──
+  // ── GET /api/plugins — list published plugins with install counts + user status ──
   .get("/", async ({ user: sessionUser }) => {
+    const rows = await db
+      .select()
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.published, true))
+      .orderBy(desc(pluginRegistry.featured), pluginRegistry.name);
+
     // Get install counts per plugin
     const countRows = await db
       .select({
@@ -76,21 +73,38 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
       userInstalls.map((r) => [r.pluginId, r.installedAt]),
     );
 
-    const plugins = PLUGIN_CATALOG.map((p) =>
-      Object.assign({}, p, {
-        installCount: countMap.get(p.id) ?? 0,
-        installed: userInstallMap.has(p.id),
-        installedAt: userInstallMap.get(p.id)?.toISOString() ?? null,
-      }),
-    );
+    const plugins = rows.map((p) => ({
+      id: p.id,
+      name: p.name,
+      description: p.description,
+      author: p.author,
+      icon: p.iconUrl,
+      category: p.category,
+      scope: p.scope as "server" | "personal" | "both",
+      tags: p.tags ?? [],
+      version: p.version,
+      verified: p.verified ?? false,
+      featured: p.featured ?? false,
+      downloads: p.downloads ?? 0,
+      repository: p.repository,
+      screenshots: p.screenshots ?? [],
+      installCount: countMap.get(p.id) ?? 0,
+      installed: userInstallMap.has(p.id),
+      installedAt: userInstallMap.get(p.id)?.toISOString() ?? null,
+    }));
 
     return { plugins };
   })
 
   // ── GET /api/plugins/:pluginId — detail with setup status ─────────────
   .get("/:pluginId", async ({ user: sessionUser, params }) => {
-    const catalog = findPlugin(params.pluginId);
-    if (!catalog) throw new NotFoundError("Plugin");
+    const [row] = await db
+      .select()
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+
+    if (!row || !row.published) throw new NotFoundError("Plugin");
 
     // Install count
     const [countRow] = await db
@@ -110,7 +124,20 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
       );
 
     const plugin = {
-      ...catalog,
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      author: row.author,
+      icon: row.iconUrl,
+      category: row.category,
+      scope: row.scope as "server" | "personal" | "both",
+      tags: row.tags ?? [],
+      version: row.version,
+      verified: row.verified ?? false,
+      featured: row.featured ?? false,
+      downloads: row.downloads ?? 0,
+      repository: row.repository,
+      screenshots: row.screenshots ?? [],
       installCount: countRow?.count ?? 0,
       installed: !!userInstall,
       installedAt: userInstall?.installedAt?.toISOString() ?? null,
@@ -159,8 +186,14 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
     if (!(await checkIpRateLimit(ip, 10, 60_000, "plugin-install"))) {
       throw new RateLimitError("Too many requests, try again later");
     }
-    const catalog = findPlugin(params.pluginId);
-    if (!catalog) throw new NotFoundError("Plugin");
+
+    // Validate plugin exists in registry
+    const [plugin] = await db
+      .select({ id: pluginRegistry.id })
+      .from(pluginRegistry)
+      .where(and(eq(pluginRegistry.id, params.pluginId), eq(pluginRegistry.published, true)))
+      .limit(1);
+    if (!plugin) throw new NotFoundError("Plugin");
 
     // Upsert — ignore if already installed
     await db
@@ -170,6 +203,12 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
         userId: sessionUser.id,
       })
       .onConflictDoNothing({ target: [pluginInstalls.pluginId, pluginInstalls.userId] });
+
+    // Increment downloads
+    await db
+      .update(pluginRegistry)
+      .set({ downloads: sql`${pluginRegistry.downloads} + 1` })
+      .where(eq(pluginRegistry.id, params.pluginId));
 
     const [countRow] = await db
       .select({ count: sql<number>`count(*)::int` })
@@ -185,8 +224,14 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
     if (!(await checkIpRateLimit(ip, 10, 60_000, "plugin-install"))) {
       throw new RateLimitError("Too many requests, try again later");
     }
-    const catalog = findPlugin(params.pluginId);
-    if (!catalog) throw new NotFoundError("Plugin");
+
+    // Validate plugin exists in registry
+    const [plugin] = await db
+      .select({ id: pluginRegistry.id })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+    if (!plugin) throw new NotFoundError("Plugin");
 
     await db
       .delete(pluginInstalls)

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -2,7 +2,7 @@ import { Elysia } from "elysia";
 import { eq, and } from "drizzle-orm";
 import { ForbiddenError, NotFoundError, ValidationError, RateLimitError } from "@uncorded/shared";
 import { db } from "../db/index.js";
-import { serverPlugins } from "../db/schema.js";
+import { serverPlugins, pluginRegistry } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
 import { requireMember, requireOwner } from "../helpers/permissions.js";
 import { computeEffectiveTier } from "../helpers/resolve-tier.js";
@@ -74,6 +74,14 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
     if (!pluginId || typeof pluginId !== "string") {
       throw new ForbiddenError("pluginId is required");
     }
+
+    // Validate plugin exists in registry
+    const [registryPlugin] = await db
+      .select({ id: pluginRegistry.id })
+      .from(pluginRegistry)
+      .where(and(eq(pluginRegistry.id, pluginId), eq(pluginRegistry.published, true)))
+      .limit(1);
+    if (!registryPlugin) throw new NotFoundError("Plugin");
 
     // Upsert — ignore if already installed
     const [row] = await db

--- a/apps/web/src/pages/settings/PluginsSettings.tsx
+++ b/apps/web/src/pages/settings/PluginsSettings.tsx
@@ -16,6 +16,12 @@ interface Plugin {
   category: string;
   scope: "server" | "personal" | "both";
   tags: string[];
+  version: string;
+  verified: boolean;
+  featured: boolean;
+  downloads: number;
+  repository: string | null;
+  screenshots: string[];
   installCount: number;
   installed: boolean;
   installedAt: string | null;
@@ -48,6 +54,8 @@ const COMING_SOON_PLUGINS = [
 
 const PluginsSettings = () => {
   const [search, setSearch] = createSignal("");
+  const [categoryFilter, setCategoryFilter] = createSignal("all");
+  const [scopeFilter, setScopeFilter] = createSignal("all");
   const [installing, setInstalling] = createSignal<PluginId | null>(null);
 
   const [plugins, { refetch, mutate }] = createResource(async () => {
@@ -55,18 +63,47 @@ const PluginsSettings = () => {
     return res.plugins;
   });
 
+  // Extract unique categories from plugins for filter dropdown
+  const categories = () => {
+    const cats = new Set((plugins() ?? []).map((p) => p.category));
+    return [...cats].sort();
+  };
+
   // Only show personal/both scope plugins in user settings
   const personalPlugins = () =>
     (plugins() ?? []).filter((p) => p.scope === "personal" || p.scope === "both");
 
   const filteredPlugins = () => {
+    let list = personalPlugins();
+
+    // Category filter
+    const cat = categoryFilter();
+    if (cat !== "all") {
+      list = list.filter((p) => p.category === cat);
+    }
+
+    // Scope filter
+    const scope = scopeFilter();
+    if (scope !== "all") {
+      list = list.filter((p) => p.scope === scope);
+    }
+
+    // Search by name, description, and tags
     const q = search().toLowerCase();
-    if (!q) return personalPlugins();
-    return personalPlugins().filter(
-      (p) =>
-        p.name.toLowerCase().includes(q) ||
-        p.description.toLowerCase().includes(q),
-    );
+    if (q) {
+      list = list.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          p.description.toLowerCase().includes(q) ||
+          p.tags.some((t) => t.toLowerCase().includes(q)),
+      );
+    }
+
+    // Featured plugins first
+    return list.sort((a, b) => {
+      if (a.featured !== b.featured) return a.featured ? -1 : 1;
+      return 0;
+    });
   };
 
   const filteredComingSoon = () => {
@@ -113,29 +150,52 @@ const PluginsSettings = () => {
         </p>
       </div>
 
-      {/* Search */}
-      <div class="relative">
-        <svg
-          class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="2"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+      {/* Search + Filters */}
+      <div class="flex flex-wrap items-center gap-3">
+        <div class="relative flex-1">
+          <svg
+            class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search plugins by name, description, or tags..."
+            value={search()}
+            onInput={(e) => setSearch(e.currentTarget.value)}
+            class="w-full rounded-lg border border-border bg-input py-2 pl-10 pr-3 text-sm text-foreground outline-none placeholder:text-muted-foreground transition-shadow duration-200 focus:ring-2 focus:ring-ring/50"
           />
-        </svg>
-        <input
-          type="text"
-          placeholder="Search plugins..."
-          value={search()}
-          onInput={(e) => setSearch(e.currentTarget.value)}
-          class="w-full rounded-lg border border-border bg-input py-2 pl-10 pr-3 text-sm text-foreground outline-none placeholder:text-muted-foreground transition-shadow duration-200 focus:ring-2 focus:ring-ring/50"
-        />
+        </div>
+
+        <select
+          value={categoryFilter()}
+          onChange={(e) => setCategoryFilter(e.currentTarget.value)}
+          class="rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none"
+        >
+          <option value="all">All Categories</option>
+          <For each={categories()}>
+            {(cat) => <option value={cat}>{cat}</option>}
+          </For>
+        </select>
+
+        <select
+          value={scopeFilter()}
+          onChange={(e) => setScopeFilter(e.currentTarget.value)}
+          class="rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none"
+        >
+          <option value="all">All Scopes</option>
+          <option value="personal">Personal</option>
+          <option value="both">Personal + Server</option>
+        </select>
       </div>
 
       {/* Plugin cards from API */}
@@ -212,7 +272,9 @@ function PluginCard(props: {
   const p = () => props.plugin;
 
   return (
-    <div class="rounded-xl border border-border bg-card p-4 transition-colors hover:border-border/80">
+    <div class={`rounded-xl border p-4 transition-colors hover:border-border/80 ${
+      p().featured ? "border-warning/30 bg-warning/5" : "border-border bg-card"
+    }`}>
       <div class="flex items-start gap-3">
         {/* Icon */}
         <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -236,16 +298,44 @@ function PluginCard(props: {
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">
             <span class="font-semibold text-foreground">{p().name}</span>
-            <span class="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
-              Official
-            </span>
+            {/* Verified badge */}
+            <Show when={p().verified}>
+              <span class="inline-flex items-center gap-0.5 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary" title="Verified">
+                <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                  <path fill-rule="evenodd" d="M8.603 3.799A4.49 4.49 0 0112 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 013.498 1.307 4.491 4.491 0 011.307 3.497A4.49 4.49 0 0121.75 12a4.49 4.49 0 01-1.549 3.397 4.491 4.491 0 01-1.307 3.497 4.491 4.491 0 01-3.497 1.307A4.49 4.49 0 0112 21.75a4.49 4.49 0 01-3.397-1.549 4.49 4.49 0 01-3.498-1.306 4.491 4.491 0 01-1.307-3.498A4.49 4.49 0 012.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 011.307-3.497 4.49 4.49 0 013.497-1.307zm7.007 6.387a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z" clip-rule="evenodd" />
+                </svg>
+                Verified
+              </span>
+            </Show>
+            {/* Featured badge */}
+            <Show when={p().featured}>
+              <span class="rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-semibold text-warning">
+                Featured
+              </span>
+            </Show>
           </div>
           <p class="mt-1 text-sm text-muted-foreground">{p().description}</p>
           <div class="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
             <span>By {p().author}</span>
             <span class="rounded bg-muted px-1.5 py-0.5">{p().category}</span>
             <span>{p().installCount} {p().installCount === 1 ? "install" : "installs"}</span>
+            <Show when={p().downloads > 0}>
+              <span>{p().downloads.toLocaleString()} {p().downloads === 1 ? "download" : "downloads"}</span>
+            </Show>
+            <span class="font-mono">v{p().version}</span>
           </div>
+          {/* Tags */}
+          <Show when={p().tags.length > 0}>
+            <div class="mt-2 flex flex-wrap gap-1">
+              <For each={p().tags}>
+                {(tag) => (
+                  <span class="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                    {tag}
+                  </span>
+                )}
+              </For>
+            </div>
+          </Show>
         </div>
 
         {/* Action */}


### PR DESCRIPTION
## Summary

- **Database**: New `plugin_registry` table with migration + seed data for existing plugins (claude-code, excalidraw-boards)
- **Backend**: Rewrote `/api/plugins` routes to query DB instead of hardcoded catalog, added public `/manifest` endpoint (rate-limited, no auth), added full admin CRUD (list/create/update/delete + toggle publish/verify/feature), added registry validation on server plugin installs
- **Desktop**: Replaced hardcoded `PLUGIN_MANIFESTS` with `fetchPluginManifest()` that queries the registry API at runtime
- **Admin panel**: New Plugins page with DataTable, search, inline status toggles (published/verified/featured), add/edit modal with manifest JSON editor, delete with cascade warning
- **Frontend**: Enhanced plugin store with verified/featured badges, category and scope filter dropdowns, tag-based search, download counts, and featured-first sorting

## Test plan

- [ ] Run migration `0017_plugin_registry.sql` — verify table created and 2 plugins seeded
- [ ] `GET /api/plugins` returns plugins from DB with correct shape (installCount, installed, verified, featured, etc.)
- [ ] `GET /api/plugins/:id/manifest` returns manifest JSON without auth
- [ ] `POST /api/plugins/:id/install` increments downloads counter
- [ ] Admin panel `/plugins` page loads, shows all plugins (including unpublished)
- [ ] Admin: create a new plugin via the form, verify it appears in the list and in the public API
- [ ] Admin: toggle publish/verify/feature, verify changes persist
- [ ] Admin: delete a plugin, verify cascade removes from `server_plugins` and `plugin_installs`
- [ ] Desktop app: start a plugin that isn't on the sidecar — verify it fetches manifest from API
- [ ] Frontend: verify verified badge, featured badge, category filter, scope filter, and tag search all work
- [ ] Server plugin install (`POST /api/servers/:id/plugins`) rejects unknown plugin IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin: New Plugins page in the dashboard for creating, editing, deleting, and managing plugin state (publish/verify/feature).
  * Public API: Unauthenticated manifest endpoint so clients can fetch plugin manifests.
  * Desktop: Plugin manifests fetched dynamically; dev build injects API URL.
  * Web: Plugin discovery UI adds category/scope filters and richer plugin cards (version, badges, downloads, tags).

* **Backend**
  * Introduced a persistent plugin registry (DB) powering CRUD and listing endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->