### PR TITLE
feat: CI/CD release pipeline for desktop app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           - os: macos-14
             platform: mac-arm64
             artifact: "*.dmg"
-          - os: macos-13
+          - os: macos-15
             platform: mac-x64
             artifact: "*.dmg"
           - os: ubuntu-latest
@@ -60,20 +60,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - name: Set version
         run: |
           cd apps/desktop
           bun -e "const pkg = require('./package.json'); pkg.version = '${{ needs.preflight.outputs.version }}'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
-      - name: Build desktop app
+      - name: Build and package
         run: |
           cd apps/desktop
-          bun run build
-          bun run build:sidecar:compile
-      - name: Package with electron-builder
-        run: |
-          cd apps/desktop
-          npx electron-builder --publish never
+          bun run dist -- --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release Desktop App
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (semver, e.g., 0.1.0 or 0.1.0-alpha.1)"
+        required: true
+        type: string
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      tag: ${{ steps.validate.outputs.tag }}
+      is_prerelease: ${{ steps.validate.outputs.is_prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun run lint
+      - run: bun run test
+      - name: Validate version
+        id: validate
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Invalid semver: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" == *-* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win
+            artifact: "*.exe"
+          - os: macos-14
+            platform: mac-arm64
+            artifact: "*.dmg"
+          - os: macos-13
+            platform: mac-x64
+            artifact: "*.dmg"
+          - os: ubuntu-latest
+            platform: linux
+            artifact: "*.AppImage"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - name: Set version
+        run: |
+          cd apps/desktop
+          bun -e "const pkg = require('./package.json'); pkg.version = '${{ needs.preflight.outputs.version }}'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
+      - name: Build desktop app
+        run: |
+          cd apps/desktop
+          bun run build
+          bun run build:sidecar:compile
+      - name: Package with electron-builder
+        run: |
+          cd apps/desktop
+          npx electron-builder --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.platform }}
+          path: |
+            apps/desktop/release/*.exe
+            apps/desktop/release/*.dmg
+            apps/desktop/release/*.zip
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.yml
+          if-no-files-found: error
+
+  release:
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.preflight.outputs.tag }}
+          name: "UnCorded ${{ needs.preflight.outputs.version }}"
+          prerelease: ${{ needs.preflight.outputs.is_prerelease == 'true' }}
+          generate_release_notes: true
+          files: artifacts/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -2,6 +2,8 @@ appId: com.uncorded.app
 productName: UnCorded
 artifactName: "UnCorded-${version}-${os}-${arch}.${ext}"
 
+npmRebuild: false
+
 directories:
   output: release
   buildResources: resources

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,27 +1,31 @@
 appId: com.uncorded.app
 productName: UnCorded
-artifactName: UnCorded-${version}-${arch}.${ext}
+artifactName: "UnCorded-${version}-${os}-${arch}.${ext}"
 
 directories:
-  buildResources: resources
   output: release
+  buildResources: resources
 
 files:
-  - dist-electron/**/*
-  - src/renderer/**/*
+  - "dist-electron/main/**/*"
+  - "node_modules/**/*"
+  - "!node_modules/**/*.{md,txt,map}"
 
 extraResources:
-  - from: sidecar/
-    to: sidecar/
+  - from: "dist-electron/sidecar"
+    to: "sidecar"
     filter:
       - "**/*"
-      - "!node_modules"
 
-publish:
-  - provider: github
-    owner: ItzDevoo
-    repo: UnCorded
-    releaseType: release
+win:
+  target: nsis
+  icon: resources/icon.ico
+
+nsis:
+  oneClick: true
+  perMachine: false
+  allowToChangeInstallationDirectory: false
+  deleteAppDataOnUninstall: false
 
 mac:
   target:
@@ -30,17 +34,16 @@ mac:
   icon: resources/icon.icns
   category: public.app-category.social-networking
 
+dmg:
+  writeUpdateInfo: true
+
 linux:
-  target:
-    - AppImage
+  target: AppImage
   icon: resources/icon.png
   category: Network
 
-win:
-  target:
-    - nsis
-  icon: resources/icon.ico
-
-nsis:
-  oneClick: false
-  allowToChangeInstallationDirectory: true
+publish:
+  provider: github
+  owner: ItzDevoo
+  repo: UnCorded
+  releaseType: release

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,8 +11,8 @@
     "build:sidecar:compile": "bun build --compile sidecar/index.ts --outfile dist-electron/sidecar/sidecar",
     "build": "bun run build:main && bun run build:sidecar",
     "typecheck": "tsc --noEmit",
-    "pack": "electron-builder --dir",
-    "dist": "electron-builder"
+    "pack": "bun run build && bun run build:sidecar:compile && electron-builder --dir",
+    "dist": "bun run build && bun run build:sidecar:compile && electron-builder"
   },
   "dependencies": {
     "@uncorded/shared": "workspace:*",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,7 +27,7 @@
     "@types/dockerode": "^3.3.34",
     "@types/ws": "^8.5.14",
     "@types/webtorrent": "^0.109.8",
-    "electron": "^33.3.1",
+    "electron": "33.4.11",
     "electron-builder": "^25.1.8",
     "tsdown": "^0.9.2",
     "typescript": "^5.7.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,7 @@
     "dev": "bun run scripts/dev.ts",
     "build:main": "tsdown src/main/index.ts --out-dir dist-electron/main --format cjs --external electron && tsdown src/main/preload.ts --out-dir dist-electron/main --format cjs --external electron",
     "build:sidecar": "bun build sidecar/index.ts --outdir dist-electron/sidecar --target bun",
+    "build:sidecar:compile": "bun build --compile sidecar/index.ts --outfile dist-electron/sidecar/sidecar",
     "build": "bun run build:main && bun run build:sidecar",
     "typecheck": "tsc --noEmit",
     "pack": "electron-builder --dir",

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -34,10 +34,14 @@ export class SidecarManager {
     this.intentionalStop = false;
     this.stdoutBuffer = "";
 
-    const sidecarEntry = this.getSidecarEntryPath();
+    const sidecarPath = this.getSidecarPath();
 
     try {
-      this.process = spawn("bun", ["run", sidecarEntry], {
+      const spawnArgs = app.isPackaged
+        ? { command: sidecarPath, args: [] as string[] }
+        : { command: "bun", args: ["run", sidecarPath] };
+
+      this.process = spawn(spawnArgs.command, spawnArgs.args, {
         stdio: ["pipe", "pipe", "pipe"],
         env: {
           ...process.env,
@@ -178,12 +182,12 @@ export class SidecarManager {
     }
   }
 
-  private getSidecarEntryPath(): string {
+  private getSidecarPath(): string {
     if (app.isPackaged) {
-      // In packaged app, use the compiled sidecar artifact
-      return path.join(process.resourcesPath, "sidecar", "index.js");
+      const ext = process.platform === "win32" ? ".exe" : "";
+      return path.join(process.resourcesPath, "sidecar", `sidecar${ext}`);
     }
-    // Dev: run directly from source
+    // Dev: run directly from source via bun
     return path.join(__dirname, "..", "..", "sidecar", "index.ts");
   }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "lint": "oxlint",
     "test": "turbo test",
     "fmt": "oxfmt .",
-    "db:migrate": "bun run --filter @uncorded/server db:migrate"
+    "db:migrate": "bun run --filter @uncorded/server db:migrate",
+    "build:desktop": "bun run --filter @uncorded/desktop build",
+    "pack:desktop": "bun run --filter @uncorded/desktop pack",
+    "dist:desktop": "bun run --filter @uncorded/desktop dist"
   },
   "devDependencies": {
     "oxfmt": "^0.36.0",


### PR DESCRIPTION
## Summary

- **Sidecar standalone compilation**: Added `build:sidecar:compile` script using `bun build --compile` to embed the Bun runtime into a single executable. Updated `SidecarManager` to spawn the compiled binary directly when packaged (with `.exe` on Windows), falling back to `bun run` in dev mode.
- **electron-builder config**: Updated `electron-builder.yml` with correct file patterns (`dist-electron/main`), compiled sidecar as `extraResources`, OS-specific artifact naming (`UnCorded-${version}-${os}-${arch}.${ext}`), oneClick NSIS installer, and GitHub publish config for auto-update detection.
- **Build scripts**: Added `pack` and `dist` scripts that chain build + sidecar compilation + electron-builder. Added `build:desktop`, `pack:desktop`, `dist:desktop` to root package.json.
- **Release workflow**: Manual `workflow_dispatch` trigger with semver version input. Preflight job runs typecheck/lint/test. Matrix build across Windows, macOS (arm64 + x64), and Linux. Creates GitHub Release with all platform artifacts.
- **Bun monorepo fixes**: Pinned electron version (33.4.11) for electron-builder resolution. Disabled `npmRebuild` for bun workspace compatibility.

## Test plan

- [x] `bun run build` compiles main + sidecar bundle
- [x] `bun run build:sidecar:compile` produces standalone `sidecar.exe` (112MB)
- [x] Compiled sidecar runs standalone and reports ready on a port
- [x] `bun run pack` produces `release/win-unpacked/UnCorded.exe` with sidecar in `resources/sidecar/`
- [x] Packaged app launches successfully
- [ ] Trigger release workflow on GitHub Actions to verify cross-platform builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual Release workflow to produce and publish desktop release artifacts across Windows, macOS (arm64/x64), and Linux.
  * Updated desktop build and packaging to produce platform-specific installers and include update metadata for macOS.

* **New Features**
  * Desktop app now bundles a compiled native sidecar executable for packaged installs, improving runtime reliability.
  * Electron version bumped and new convenient desktop build/dist scripts added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->