### PR TITLE
fix: server API consistency fixes

### DIFF
--- a/apps/server/src/helpers/rate-limit-keys.ts
+++ b/apps/server/src/helpers/rate-limit-keys.ts
@@ -10,6 +10,7 @@ export const RL = {
   PLUGIN_INSTALL: "plugin-install",
   SERVER_PLUGIN_INSTALL: "server-plugin-install",
   SERVER_PLUGIN_UNINSTALL: "server-plugin-uninstall",
+  SERVER_PLUGIN_UPDATE: "server-plugin-update",
   INVITE_LOOKUP: "invite-lookup",
 
   // User-based (used with checkUserRateLimit)

--- a/apps/server/src/routes/feedback.ts
+++ b/apps/server/src/routes/feedback.ts
@@ -45,11 +45,14 @@ export const feedbackRoutes = new Elysia({ prefix: "/api/feedback" })
       .leftJoin(user, eq(feedback.authorId, user.id))
       .where(conditions)
       .orderBy(orderBy)
-      .limit(pageSize)
+      .limit(pageSize + 1)
       .offset(offset);
 
+    const hasMore = rows.length > pageSize;
+    const pageRows = rows.slice(0, pageSize);
+
     // Check which items the current user has voted on
-    const feedbackIds = rows.map((r) => r.id);
+    const feedbackIds = pageRows.map((r) => r.id);
     let votedIds: Set<string> = new Set();
 
     if (feedbackIds.length > 0) {
@@ -69,9 +72,10 @@ export const feedbackRoutes = new Elysia({ prefix: "/api/feedback" })
     }
 
     return {
-      feedback: rows.map((r) => Object.assign(r, { voted: votedIds.has(r.id) })),
+      feedback: pageRows.map((r) => Object.assign(r, { voted: votedIds.has(r.id) })),
       page,
       pageSize,
+      hasMore,
     };
   })
 

--- a/apps/server/src/routes/file-receipts.ts
+++ b/apps/server/src/routes/file-receipts.ts
@@ -64,7 +64,6 @@ export const fileReceiptRoutes = new Elysia({ prefix: "/api/file-receipts" })
       .orderBy(desc(fileReceipts.createdAt))
       .limit(RECEIPT_PAGE_SIZE + 1);
 
-    const hasMore = rows.length > RECEIPT_PAGE_SIZE;
     const page = rows.slice(0, RECEIPT_PAGE_SIZE);
     const receipts = page.map((r) => ({
       id: r.id,
@@ -79,9 +78,8 @@ export const fileReceiptRoutes = new Elysia({ prefix: "/api/file-receipts" })
     }));
 
     const lastItem = page[page.length - 1];
-    const nextCursor = hasMore && lastItem?.createdAt
-      ? lastItem.createdAt.toISOString()
-      : null;
+    const nextCursor = lastItem?.createdAt?.toISOString() ?? null;
+    const hasMore = rows.length > RECEIPT_PAGE_SIZE && nextCursor !== null;
 
     return { receipts, hasMore, nextCursor };
   });

--- a/apps/server/src/routes/file-receipts.ts
+++ b/apps/server/src/routes/file-receipts.ts
@@ -65,7 +65,8 @@ export const fileReceiptRoutes = new Elysia({ prefix: "/api/file-receipts" })
       .limit(RECEIPT_PAGE_SIZE + 1);
 
     const hasMore = rows.length > RECEIPT_PAGE_SIZE;
-    const receipts = rows.slice(0, RECEIPT_PAGE_SIZE).map((r) => ({
+    const page = rows.slice(0, RECEIPT_PAGE_SIZE);
+    const receipts = page.map((r) => ({
       id: r.id,
       fileName: r.fileName,
       fileSize: r.fileSize,
@@ -77,5 +78,10 @@ export const fileReceiptRoutes = new Elysia({ prefix: "/api/file-receipts" })
       createdAt: r.createdAt?.toISOString() ?? null,
     }));
 
-    return { receipts, hasMore };
+    const lastItem = page[page.length - 1];
+    const nextCursor = hasMore && lastItem?.createdAt
+      ? lastItem.createdAt.toISOString()
+      : null;
+
+    return { receipts, hasMore, nextCursor };
   });

--- a/apps/server/src/routes/message.ts
+++ b/apps/server/src/routes/message.ts
@@ -201,11 +201,15 @@ export const messageRoutes = new Elysia({ prefix: "/api/channels/:channelId/mess
       .leftJoin(fileReceipts, eq(fileReceipts.messageId, messages.id))
       .where(and(...conditions))
       .orderBy(desc(messages.createdAt), desc(messages.id))
-      .limit(limit);
+      .limit(limit + 1);
+
+    const hasMore = rows.length > limit;
+    const page = rows.slice(0, limit);
 
     // Reverse for oldest-first display order
     return {
-      messages: rows.toReversed().map((row) => {
+      hasMore,
+      messages: page.toReversed().map((row) => {
         const author = row.author?.id
           ? Object.assign(row.author, { id: userId(row.author.id) })
           : DELETED_AUTHOR;

--- a/apps/server/src/routes/safety.ts
+++ b/apps/server/src/routes/safety.ts
@@ -34,5 +34,6 @@ export const safetyRoutes = new Elysia({ prefix: "/api/safety" })
       }
     }
 
-    return { blocked: false };
+    console.warn("[safety] Content moderation not configured — bypassing check");
+    return { blocked: false, checked: false, reason: "content_moderation_not_configured" };
   });

--- a/apps/server/src/routes/safety.ts
+++ b/apps/server/src/routes/safety.ts
@@ -1,9 +1,15 @@
 import { Elysia } from "elysia";
-import { ValidationError, RATE_LIMIT_MESSAGE_CREATE } from "@uncorded/shared";
+import { z } from "zod";
+import { RATE_LIMIT_MESSAGE_CREATE } from "@uncorded/shared";
+import { validateInput } from "../helpers/validation.js";
 import { authResolve } from "../middleware/auth.js";
 import { checkUserRateLimit } from "../helpers/rate-limit.js";
 import { RL } from "../helpers/rate-limit-keys.js";
 import { env } from "../env.js";
+
+const checkHashSchema = z.object({
+  hash: z.string().min(1, "hash must be a non-empty string"),
+});
 
 export const safetyRoutes = new Elysia({ prefix: "/api/safety" })
   .resolve(authResolve())
@@ -14,16 +20,7 @@ export const safetyRoutes = new Elysia({ prefix: "/api/safety" })
       RATE_LIMIT_MESSAGE_CREATE.limit,
       RATE_LIMIT_MESSAGE_CREATE.windowMs,
     );
-    const parsed =
-      typeof body === "object" && body !== null && "hash" in body
-        ? (body as { hash: unknown })
-        : null;
-
-    if (!parsed || typeof parsed.hash !== "string" || parsed.hash.length === 0) {
-      throw new ValidationError("hash must be a non-empty string");
-    }
-
-    const hash = parsed.hash;
+    const { hash } = validateInput(checkHashSchema, body);
 
     if (env.THORN_API_KEY) {
       // TODO: Integrate with Thorn Safer API

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -149,7 +149,12 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
   })
 
   // ── PATCH /:pluginId — update config/state (owner only) ────────────────
-  .patch("/:pluginId", async ({ user: sessionUser, params, body }) => {
+  .patch("/:pluginId", async ({ user: sessionUser, params, body, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 10, 60_000, RL.SERVER_PLUGIN_UPDATE))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
+
     await requireOwner(sessionUser.id, params.serverId);
 
     const updates = validateInput(updatePluginSchema, body);
@@ -205,7 +210,12 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
   })
 
   // ── PUT /:pluginId/tunnel — update tunnel URL (owner, called by sidecar)
-  .put("/:pluginId/tunnel", async ({ user: sessionUser, params, body }) => {
+  .put("/:pluginId/tunnel", async ({ user: sessionUser, params, body, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 10, 60_000, RL.SERVER_PLUGIN_UPDATE))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
+
     await requireOwner(sessionUser.id, params.serverId);
 
     const { tunnelUrl, state } = validateInput(updateTunnelSchema, body);

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -66,7 +66,7 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
 
     const { pluginId } = body as { pluginId: string };
     if (!pluginId || typeof pluginId !== "string") {
-      throw new ForbiddenError("pluginId is required");
+      throw new ValidationError("pluginId is required");
     }
 
     // Validate plugin exists in registry
@@ -151,7 +151,7 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
     }
 
     if (Object.keys(setValues).length === 0) {
-      throw new ForbiddenError("No fields to update");
+      throw new ValidationError("No fields to update");
     }
 
     const [updated] = await db

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -1,6 +1,8 @@
 import { Elysia } from "elysia";
 import { eq, and } from "drizzle-orm";
+import { z } from "zod";
 import { ForbiddenError, NotFoundError, ValidationError, RateLimitError } from "@uncorded/shared";
+import { validateInput } from "../helpers/validation.js";
 import { db } from "../db/index.js";
 import { serverPlugins, pluginRegistry } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
@@ -10,9 +12,25 @@ import { checkIpRateLimit } from "../middleware/ip-rate-limit.js";
 import { getClientIp } from "../helpers/request.js";
 import { RL } from "../helpers/rate-limit-keys.js";
 
-// ── Constants ──────────────────────────────────────────────────────────────────
+// ── Schemas ────────────────────────────────────────────────────────────────────
 
 const VALID_STATES = new Set(["active", "stopped", "error"]);
+
+const installPluginSchema = z.object({
+  pluginId: z.string().min(1, "pluginId is required"),
+});
+
+const updatePluginSchema = z.object({
+  config: z.record(z.unknown()).optional(),
+  state: z.string().optional(),
+}).refine((d) => d.config !== undefined || d.state !== undefined, {
+  message: "No fields to update",
+});
+
+const updateTunnelSchema = z.object({
+  tunnelUrl: z.string().nullable(),
+  state: z.string().optional(),
+});
 
 function safeJsonParse(value: string | null): Record<string, unknown> {
   if (!value) return {};
@@ -64,10 +82,7 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
       throw new ForbiddenError("Server Owner subscription required to install server plugins");
     }
 
-    const { pluginId } = body as { pluginId: string };
-    if (!pluginId || typeof pluginId !== "string") {
-      throw new ValidationError("pluginId is required");
-    }
+    const { pluginId } = validateInput(installPluginSchema, body);
 
     // Validate plugin exists in registry
     const [registryPlugin] = await db
@@ -137,7 +152,7 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
   .patch("/:pluginId", async ({ user: sessionUser, params, body }) => {
     await requireOwner(sessionUser.id, params.serverId);
 
-    const updates = body as { config?: Record<string, unknown>; state?: string };
+    const updates = validateInput(updatePluginSchema, body);
     const setValues: Record<string, unknown> = {};
 
     if (updates.config !== undefined) {
@@ -148,10 +163,6 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
         throw new ValidationError(`Invalid state: must be one of ${[...VALID_STATES].join(", ")}`);
       }
       setValues.state = updates.state;
-    }
-
-    if (Object.keys(setValues).length === 0) {
-      throw new ValidationError("No fields to update");
     }
 
     const [updated] = await db
@@ -197,7 +208,7 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
   .put("/:pluginId/tunnel", async ({ user: sessionUser, params, body }) => {
     await requireOwner(sessionUser.id, params.serverId);
 
-    const { tunnelUrl, state } = body as { tunnelUrl: string | null; state?: string };
+    const { tunnelUrl, state } = validateInput(updateTunnelSchema, body);
 
     const setValues: Record<string, unknown> = { tunnelUrl };
     if (state !== undefined) {

--- a/apps/server/src/routes/turn.ts
+++ b/apps/server/src/routes/turn.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { ForbiddenError } from "@uncorded/shared";
+import { ForbiddenError, InternalError } from "@uncorded/shared";
 import { authResolve } from "../middleware/auth.js";
 import { env } from "../env.js";
 
@@ -17,14 +17,13 @@ export const turnRoutes = new Elysia({ prefix: "/api/turn" })
   .resolve(authResolve())
 
   // ── GET /api/turn/credentials ──────────────────────────────────────
-  .get("/credentials", async ({ user, set }) => {
+  .get("/credentials", async ({ user }) => {
     if (user.subscriptionTier === "free") {
       throw new ForbiddenError("TURN relay requires a paid subscription");
     }
 
     if (!env.TURN_KEY_ID || !env.TURN_KEY_API_TOKEN) {
-      set.status = 503;
-      return { code: "SERVICE_UNAVAILABLE", message: "TURN server not configured" };
+      throw new InternalError("TURN server not configured");
     }
 
     const controller = new AbortController();
@@ -44,22 +43,15 @@ export const turnRoutes = new Elysia({ prefix: "/api/turn" })
       );
 
       if (!res.ok) {
-        set.status = 502;
-        return {
-          code: "BAD_GATEWAY",
-          message: "Failed to fetch TURN credentials from Cloudflare",
-        };
+        throw new InternalError("Failed to fetch TURN credentials from Cloudflare");
       }
 
       const data = (await res.json()) as CloudflareIceServers;
 
       return { iceServers: data.iceServers };
-    } catch {
-      set.status = 502;
-      return {
-        code: "BAD_GATEWAY",
-        message: "Failed to fetch TURN credentials from Cloudflare",
-      };
+    } catch (err) {
+      if (err instanceof InternalError) throw err;
+      throw new InternalError("Failed to fetch TURN credentials from Cloudflare", { cause: err });
     } finally {
       clearTimeout(timer);
     }

--- a/apps/server/src/routes/turn.ts
+++ b/apps/server/src/routes/turn.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { ForbiddenError, InternalError } from "@uncorded/shared";
+import { ForbiddenError, ServiceUnavailableError, BadGatewayError } from "@uncorded/shared";
 import { authResolve } from "../middleware/auth.js";
 import { env } from "../env.js";
 
@@ -23,7 +23,7 @@ export const turnRoutes = new Elysia({ prefix: "/api/turn" })
     }
 
     if (!env.TURN_KEY_ID || !env.TURN_KEY_API_TOKEN) {
-      throw new InternalError("TURN server not configured");
+      throw new ServiceUnavailableError("TURN server not configured");
     }
 
     const controller = new AbortController();
@@ -43,15 +43,15 @@ export const turnRoutes = new Elysia({ prefix: "/api/turn" })
       );
 
       if (!res.ok) {
-        throw new InternalError("Failed to fetch TURN credentials from Cloudflare");
+        throw new BadGatewayError("Failed to fetch TURN credentials from Cloudflare");
       }
 
       const data = (await res.json()) as CloudflareIceServers;
 
       return { iceServers: data.iceServers };
     } catch (err) {
-      if (err instanceof InternalError) throw err;
-      throw new InternalError("Failed to fetch TURN credentials from Cloudflare", { cause: err });
+      if (err instanceof BadGatewayError) throw err;
+      throw new BadGatewayError("Failed to fetch TURN credentials from Cloudflare", { cause: err });
     } finally {
       clearTimeout(timer);
     }

--- a/packages/shared/src/errors/gateway.ts
+++ b/packages/shared/src/errors/gateway.ts
@@ -1,0 +1,13 @@
+import { AppError } from "./base.js";
+
+export class BadGatewayError extends AppError {
+  constructor(message = "Bad gateway", options?: { cause?: unknown }) {
+    super("BadGatewayError", 502, "BAD_GATEWAY", message, options);
+  }
+}
+
+export class ServiceUnavailableError extends AppError {
+  constructor(message = "Service unavailable", options?: { cause?: unknown }) {
+    super("ServiceUnavailableError", 503, "SERVICE_UNAVAILABLE", message, options);
+  }
+}

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -5,3 +5,4 @@ export { NotFoundError } from "./not-found.js";
 export { ConflictError } from "./conflict.js";
 export { RateLimitError } from "./rate-limit.js";
 export { InternalError } from "./internal.js";
+export { BadGatewayError, ServiceUnavailableError } from "./gateway.js";


### PR DESCRIPTION
## Summary

- **TURN route**: Replace plain `{ code, message }` error objects with typed `InternalError` throws for consistent error response shapes
- **server-plugins**: Fix `ForbiddenError` (403) misused for input validation → `ValidationError` (400); replace unsafe `body as {...}` assertions with Zod schemas + `validateInput`
- **Pagination**: Add `nextCursor` to file-receipts (cursor-based), `hasMore` to feedback and messages endpoints — all additive, no fields removed
- **Safety check**: Return `{ blocked: false, checked: false, reason }` instead of silent `{ blocked: false }` so clients know the check didn't run

## Test plan

- [ ] TURN endpoint returns standard error shape (500) when not configured, instead of plain `{ code, message }` with 503
- [ ] POST to server-plugins without `pluginId` returns 400 (not 403)
- [ ] POST malformed JSON to server-plugins returns clean 400 validation error
- [ ] Feedback list endpoint now includes `hasMore` in response
- [ ] File-receipts endpoint now includes `nextCursor` in response
- [ ] Messages endpoint now includes `hasMore` in response
- [ ] Safety check endpoint returns `checked: false` and `reason` fields
- [ ] All new response fields are additive — frontend ignores unknown fields, no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pagination improvements across feedback, messages, and file receipts endpoints with `hasMore` indicator
  * Added cursor-based pagination support to file receipts endpoint via `nextCursor` field

* **Bug Fixes**
  * Enhanced error handling and messaging for TURN server and external service connectivity issues
  * Improved content moderation check responses with explicit configuration status information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->