### PR TITLE
feat: developer settings tab + plugin submission flow

### DIFF
--- a/apps/server/drizzle/0018_plugin_submissions.sql
+++ b/apps/server/drizzle/0018_plugin_submissions.sql
@@ -16,4 +16,5 @@ ALTER TABLE "plugin_submissions" ADD CONSTRAINT "plugin_submissions_plugin_id_pl
 ALTER TABLE "plugin_submissions" ADD CONSTRAINT "plugin_submissions_author_user_id_user_id_fk" FOREIGN KEY ("author_user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "plugin_submissions" ADD CONSTRAINT "plugin_submissions_reviewed_by_user_id_fk" FOREIGN KEY ("reviewed_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "plugin_submissions_author_idx" ON "plugin_submissions" USING btree ("author_user_id");--> statement-breakpoint
-CREATE INDEX "plugin_submissions_status_idx" ON "plugin_submissions" USING btree ("status");
+CREATE INDEX "plugin_submissions_status_idx" ON "plugin_submissions" USING btree ("status");--> statement-breakpoint
+CREATE UNIQUE INDEX "plugin_submissions_pending_unique_idx" ON "plugin_submissions" ("plugin_id") WHERE "status" = 'pending';

--- a/apps/server/drizzle/0018_plugin_submissions.sql
+++ b/apps/server/drizzle/0018_plugin_submissions.sql
@@ -1,0 +1,19 @@
+CREATE TYPE "public"."plugin_submission_status" AS ENUM('pending', 'approved', 'rejected');--> statement-breakpoint
+ALTER TABLE "plugin_registry" ADD COLUMN "author_user_id" text;--> statement-breakpoint
+CREATE TABLE "plugin_submissions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"plugin_id" text NOT NULL,
+	"author_user_id" text NOT NULL,
+	"status" "plugin_submission_status" DEFAULT 'pending' NOT NULL,
+	"submitted_at" timestamp DEFAULT now() NOT NULL,
+	"reviewed_by" text,
+	"reviewed_at" timestamp,
+	"rejection_reason" text
+);
+--> statement-breakpoint
+ALTER TABLE "plugin_registry" ADD CONSTRAINT "plugin_registry_author_user_id_user_id_fk" FOREIGN KEY ("author_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plugin_submissions" ADD CONSTRAINT "plugin_submissions_plugin_id_plugin_registry_id_fk" FOREIGN KEY ("plugin_id") REFERENCES "public"."plugin_registry"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plugin_submissions" ADD CONSTRAINT "plugin_submissions_author_user_id_user_id_fk" FOREIGN KEY ("author_user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plugin_submissions" ADD CONSTRAINT "plugin_submissions_reviewed_by_user_id_fk" FOREIGN KEY ("reviewed_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "plugin_submissions_author_idx" ON "plugin_submissions" USING btree ("author_user_id");--> statement-breakpoint
+CREATE INDEX "plugin_submissions_status_idx" ON "plugin_submissions" USING btree ("status");

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1743350400000,
       "tag": "0017_plugin_registry",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1743436800000,
+      "tag": "0018_plugin_submissions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -465,6 +465,7 @@ export const pluginRegistry = pgTable(
     downloads: integer("downloads").notNull().default(0),
     screenshots: jsonb("screenshots").notNull().default([]),
     published: boolean("published").notNull().default(true),
+    authorUserId: text("author_user_id").references(() => user.id, { onDelete: "set null" }),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
   },
@@ -519,6 +520,34 @@ export const pluginInstalls = pgTable(
   (t) => [
     index("plugin_installs_user_id_idx").on(t.userId),
     unique("plugin_installs_plugin_user").on(t.pluginId, t.userId),
+  ],
+);
+
+export const pluginSubmissionStatusEnum = pgEnum("plugin_submission_status", [
+  "pending",
+  "approved",
+  "rejected",
+]);
+
+export const pluginSubmissions = pgTable(
+  "plugin_submissions",
+  {
+    id: id(),
+    pluginId: text("plugin_id")
+      .notNull()
+      .references(() => pluginRegistry.id, { onDelete: "cascade" }),
+    authorUserId: text("author_user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    status: pluginSubmissionStatusEnum("status").default("pending").notNull(),
+    submittedAt: timestamp("submitted_at", { mode: "date" }).defaultNow().notNull(),
+    reviewedBy: text("reviewed_by").references(() => user.id, { onDelete: "set null" }),
+    reviewedAt: timestamp("reviewed_at", { mode: "date" }),
+    rejectionReason: text("rejection_reason"),
+  },
+  (t) => [
+    index("plugin_submissions_author_idx").on(t.authorUserId),
+    index("plugin_submissions_status_idx").on(t.status),
   ],
 );
 

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -7,10 +7,12 @@ import {
   integer,
   bigint,
   index,
+  uniqueIndex,
   primaryKey,
   unique,
   jsonb,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 
 import { nanoid } from "nanoid";
 
@@ -548,6 +550,9 @@ export const pluginSubmissions = pgTable(
   (t) => [
     index("plugin_submissions_author_idx").on(t.authorUserId),
     index("plugin_submissions_status_idx").on(t.status),
+    uniqueIndex("plugin_submissions_pending_unique_idx")
+      .on(t.pluginId)
+      .where(sql`${t.status} = 'pending'`),
   ],
 );
 

--- a/apps/server/src/helpers/rate-limit-keys.ts
+++ b/apps/server/src/helpers/rate-limit-keys.ts
@@ -23,4 +23,6 @@ export const RL = {
   REPORT_CREATE: "report:create",
   SAFETY_CHECK_HASH: "safety:check-hash",
   USER_SEARCH: "users:search",
+  DEVELOPER_PLUGIN_SUBMIT: "developer:plugin-submit",
+  DEVELOPER_PLUGIN_UPDATE: "developer:plugin-update",
 } as const;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -24,6 +24,7 @@ import { turnRoutes } from "./routes/turn.js";
 import { fileReceiptRoutes } from "./routes/file-receipts.js";
 import { botRoutes, botAvatarRoutes } from "./routes/bots.js";
 import { pluginRoutes, pluginPublicRoutes } from "./routes/plugins.js";
+import { developerRoutes } from "./routes/developer.js";
 import { serverPluginRoutes } from "./routes/server-plugins.js";
 import { gatewayTicketRoutes } from "./routes/gateway.js";
 import { gateway } from "./ws/gateway.js";
@@ -87,6 +88,7 @@ const app = new Elysia()
   .use(botAvatarRoutes)
   .use(pluginPublicRoutes)
   .use(pluginRoutes)
+  .use(developerRoutes)
   .use(serverPluginRoutes)
   .use(gatewayTicketRoutes)
   .use(gateway)

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -1145,21 +1145,29 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     if (!submission) throw new NotFoundError("Submission");
     if (submission.status !== "pending") throw new ValidationError("Submission is not pending");
 
-    await db
-      .update(pluginSubmissions)
-      .set({
-        status: "approved",
-        reviewedBy: sessionUser.id,
-        reviewedAt: new Date(),
-      })
-      .where(eq(pluginSubmissions.id, params.id));
+    await db.transaction(async (tx) => {
+      await tx
+        .update(pluginSubmissions)
+        .set({
+          status: "approved",
+          reviewedBy: sessionUser.id,
+          reviewedAt: new Date(),
+        })
+        .where(eq(pluginSubmissions.id, params.id));
 
-    await db
-      .update(pluginRegistry)
-      .set({ published: true })
-      .where(eq(pluginRegistry.id, submission.pluginId));
+      await tx
+        .update(pluginRegistry)
+        .set({ published: true })
+        .where(eq(pluginRegistry.id, submission.pluginId));
 
-    await logAudit(sessionUser.id, "approve_plugin_submission", "plugin_submission", params.id);
+      await tx.insert(adminAuditLog).values({
+        adminId: sessionUser.id,
+        action: "approve_plugin_submission",
+        targetType: "plugin_submission",
+        targetId: params.id,
+        details: null,
+      });
+    });
 
     return { success: true };
   })

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -26,6 +26,7 @@ import {
   pluginRegistry,
   pluginInstalls,
   serverPlugins,
+  pluginSubmissions,
 } from "../db/schema.js";
 
 import { readdir } from "node:fs/promises";
@@ -1073,4 +1074,122 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
     await logAudit(sessionUser.id, newValue ? "feature_plugin" : "unfeature_plugin", "plugin", params.pluginId);
 
     return { success: true, featured: newValue };
+  })
+
+  // ── Plugin Submission Review ─────────────────────────────────────────────
+
+  .get("/plugins/submissions", async ({ query }) => {
+    const { page, pageSize, offset } = flexPageQuerySchema({ pageSize: 20, maxPageSize: 50 }).parse(query);
+
+    const author = alias(user, "author");
+
+    const rows = await db
+      .select({
+        id: pluginSubmissions.id,
+        pluginId: pluginSubmissions.pluginId,
+        status: pluginSubmissions.status,
+        submittedAt: pluginSubmissions.submittedAt,
+        rejectionReason: pluginSubmissions.rejectionReason,
+        reviewedAt: pluginSubmissions.reviewedAt,
+        pluginName: pluginRegistry.name,
+        pluginDescription: pluginRegistry.description,
+        pluginVersion: pluginRegistry.version,
+        pluginImage: pluginRegistry.image,
+        authorId: author.id,
+        authorUsername: author.username,
+        authorDisplayName: author.displayName,
+      })
+      .from(pluginSubmissions)
+      .innerJoin(pluginRegistry, eq(pluginSubmissions.pluginId, pluginRegistry.id))
+      .innerJoin(author, eq(pluginSubmissions.authorUserId, author.id))
+      .where(eq(pluginSubmissions.status, "pending"))
+      .orderBy(pluginSubmissions.submittedAt)
+      .limit(pageSize)
+      .offset(offset);
+
+    const [totalRow] = await db
+      .select({ value: count() })
+      .from(pluginSubmissions)
+      .where(eq(pluginSubmissions.status, "pending"));
+
+    const submissions = rows.map((r) => ({
+      id: r.id,
+      pluginId: r.pluginId,
+      status: r.status,
+      submittedAt: r.submittedAt.toISOString(),
+      rejectionReason: r.rejectionReason,
+      reviewedAt: r.reviewedAt?.toISOString() ?? null,
+      plugin: {
+        name: r.pluginName,
+        description: r.pluginDescription,
+        version: r.pluginVersion,
+        image: r.pluginImage,
+      },
+      author: {
+        id: r.authorId,
+        username: r.authorUsername,
+        displayName: r.authorDisplayName,
+      },
+    }));
+
+    return { submissions, total: totalRow?.value ?? 0, page, pageSize };
+  })
+
+  .patch("/plugins/submissions/:id/approve", async ({ params, user: sessionUser }) => {
+    const [submission] = await db
+      .select({ id: pluginSubmissions.id, status: pluginSubmissions.status, pluginId: pluginSubmissions.pluginId })
+      .from(pluginSubmissions)
+      .where(eq(pluginSubmissions.id, params.id))
+      .limit(1);
+
+    if (!submission) throw new NotFoundError("Submission");
+    if (submission.status !== "pending") throw new ValidationError("Submission is not pending");
+
+    await db
+      .update(pluginSubmissions)
+      .set({
+        status: "approved",
+        reviewedBy: sessionUser.id,
+        reviewedAt: new Date(),
+      })
+      .where(eq(pluginSubmissions.id, params.id));
+
+    await db
+      .update(pluginRegistry)
+      .set({ published: true })
+      .where(eq(pluginRegistry.id, submission.pluginId));
+
+    await logAudit(sessionUser.id, "approve_plugin_submission", "plugin_submission", params.id);
+
+    return { success: true };
+  })
+
+  .patch("/plugins/submissions/:id/reject", async ({ params, body, user: sessionUser }) => {
+    const rejectSchema = z.object({
+      reason: z.string().min(1).max(500),
+    });
+    const data = validateInput(rejectSchema, body);
+
+    const [submission] = await db
+      .select({ id: pluginSubmissions.id, status: pluginSubmissions.status })
+      .from(pluginSubmissions)
+      .where(eq(pluginSubmissions.id, params.id))
+      .limit(1);
+
+    if (!submission) throw new NotFoundError("Submission");
+    if (submission.status !== "pending") throw new ValidationError("Submission is not pending");
+
+    await db
+      .update(pluginSubmissions)
+      .set({
+        status: "rejected",
+        rejectionReason: data.reason,
+        reviewedBy: sessionUser.id,
+        reviewedAt: new Date(),
+      })
+      .where(eq(pluginSubmissions.id, params.id));
+
+    await logAudit(sessionUser.id, "reject_plugin_submission", "plugin_submission", params.id);
+
+    return { success: true };
   });

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -6,6 +6,33 @@ import { db } from "../db/index.js";
 import { pluginRegistry, pluginSubmissions } from "../db/schema.js";
 import { authResolve } from "../middleware/auth.js";
 import { validateInput } from "../helpers/validation.js";
+import { checkUserRateLimit } from "../helpers/rate-limit.js";
+import { RL } from "../helpers/rate-limit-keys.js";
+
+const PLUGIN_PERMISSIONS = [
+  "server.read",
+  "members.read",
+  "channels.read",
+  "messages.read",
+  "messages.send",
+  "users.read",
+  "presence.read",
+  "notifications.send",
+  "config.read",
+  "storage.read",
+  "storage.write",
+] as const;
+
+const permissionEnum = z.enum(PLUGIN_PERMISSIONS);
+
+const manifestSchema = z.object({
+  runtime: z.object({
+    image: z.string().min(1),
+    port: z.number().int().min(1).max(65535),
+    healthCheck: z.string().min(1),
+  }),
+  permissions: z.array(permissionEnum).min(1),
+});
 
 const pluginSubmitSchema = z.object({
   id: z
@@ -23,14 +50,7 @@ const pluginSubmitSchema = z.object({
   scope: z.enum(["server", "personal", "both"]),
   image: z.string().min(1),
   version: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be semver format (e.g. 1.0.0)"),
-  manifest: z.object({
-    runtime: z.object({
-      image: z.string().min(1),
-      port: z.number().int().min(1).max(65535),
-      healthCheck: z.string().min(1),
-    }),
-    permissions: z.array(z.string()).min(1),
-  }).passthrough(),
+  manifest: manifestSchema,
   tags: z.array(z.string().min(1).max(30)).max(10).optional(),
   repository: z.string().url().optional(),
   screenshots: z.array(z.string().url()).max(5).optional(),
@@ -41,14 +61,7 @@ const pluginUpdateSchema = z.object({
   description: z.string().min(10).max(500).optional(),
   version: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be semver format").optional(),
   image: z.string().min(1).optional(),
-  manifest: z.object({
-    runtime: z.object({
-      image: z.string().min(1),
-      port: z.number().int().min(1).max(65535),
-      healthCheck: z.string().min(1),
-    }),
-    permissions: z.array(z.string()).min(1),
-  }).passthrough().optional(),
+  manifest: manifestSchema.optional(),
   tags: z.array(z.string().min(1).max(30)).max(10).optional(),
   repository: z.string().url().nullable().optional(),
   screenshots: z.array(z.string().url()).max(5).optional(),
@@ -59,45 +72,54 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
 
   // ── POST /api/developer/plugins — Submit a new plugin ───────────────────
   .post("/plugins", async ({ body, user: sessionUser }) => {
+    await checkUserRateLimit(sessionUser.id, RL.DEVELOPER_PLUGIN_SUBMIT, 5, 3_600_000);
     const data = validateInput(pluginSubmitSchema, body);
 
-    // Check no existing plugin with same id
-    const [existing] = await db
-      .select({ id: pluginRegistry.id })
-      .from(pluginRegistry)
-      .where(eq(pluginRegistry.id, data.id))
-      .limit(1);
+    try {
+      const result = await db.transaction(async (tx) => {
+        const [inserted] = await tx
+          .insert(pluginRegistry)
+          .values({
+            id: data.id,
+            name: data.name,
+            description: data.description,
+            author: data.author,
+            category: data.category,
+            scope: data.scope,
+            image: data.image,
+            version: data.version,
+            manifest: data.manifest,
+            tags: data.tags ?? [],
+            repository: data.repository ?? null,
+            screenshots: data.screenshots ?? [],
+            published: false,
+            authorUserId: sessionUser.id,
+          })
+          .onConflictDoNothing()
+          .returning({ id: pluginRegistry.id });
 
-    if (existing) throw new ValidationError("Plugin with this ID already exists");
+        if (!inserted) throw new ValidationError("Plugin with this ID already exists");
 
-    // Insert into pluginRegistry with published: false
-    await db.insert(pluginRegistry).values({
-      id: data.id,
-      name: data.name,
-      description: data.description,
-      author: data.author,
-      category: data.category,
-      scope: data.scope,
-      image: data.image,
-      version: data.version,
-      manifest: data.manifest,
-      tags: data.tags ?? [],
-      repository: data.repository ?? null,
-      screenshots: data.screenshots ?? [],
-      published: false,
-      authorUserId: sessionUser.id,
-    });
+        const [submission] = await tx
+          .insert(pluginSubmissions)
+          .values({
+            pluginId: data.id,
+            authorUserId: sessionUser.id,
+          })
+          .returning({ id: pluginSubmissions.id });
 
-    // Insert submission record
-    const [submission] = await db
-      .insert(pluginSubmissions)
-      .values({
-        pluginId: data.id,
-        authorUserId: sessionUser.id,
-      })
-      .returning({ id: pluginSubmissions.id });
+        return { pluginId: data.id, submissionId: submission!.id, status: "pending" as const };
+      });
 
-    return { pluginId: data.id, submissionId: submission!.id, status: "pending" as const };
+      return result;
+    } catch (err) {
+      if (err instanceof ValidationError) throw err;
+      // Postgres unique constraint violation (23505)
+      if (typeof err === "object" && err !== null && "code" in err && (err as { code: string }).code === "23505") {
+        throw new ValidationError("Plugin with this ID already exists");
+      }
+      throw err;
+    }
   })
 
   // ── GET /api/developer/plugins — List user's submitted plugins ──────────
@@ -154,6 +176,7 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
 
   // ── PUT /api/developer/plugins/:pluginId — Update unpublished plugin ────
   .put("/plugins/:pluginId", async ({ params, body, user: sessionUser }) => {
+    await checkUserRateLimit(sessionUser.id, RL.DEVELOPER_PLUGIN_UPDATE, 10, 3_600_000);
     const data = validateInput(pluginUpdateSchema, body);
 
     // Verify ownership

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -1,0 +1,242 @@
+import { Elysia } from "elysia";
+import { eq, desc } from "drizzle-orm";
+import { z } from "zod";
+import { NotFoundError, ForbiddenError, ValidationError } from "@uncorded/shared";
+import { db } from "../db/index.js";
+import { pluginRegistry, pluginSubmissions } from "../db/schema.js";
+import { authResolve } from "../middleware/auth.js";
+import { validateInput } from "../helpers/validation.js";
+
+const pluginSubmitSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(
+      /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+      "ID must be lowercase alphanumeric with hyphens, min 2 chars",
+    ),
+  name: z.string().min(1).max(100),
+  description: z.string().min(10).max(500),
+  author: z.string().min(1).max(100),
+  category: z.enum(["ai", "productivity", "developer", "media", "social", "utility", "other"]),
+  scope: z.enum(["server", "personal", "both"]),
+  image: z.string().min(1),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be semver format (e.g. 1.0.0)"),
+  manifest: z.object({
+    runtime: z.object({
+      image: z.string().min(1),
+      port: z.number().int().min(1).max(65535),
+      healthCheck: z.string().min(1),
+    }),
+    permissions: z.array(z.string()).min(1),
+  }).passthrough(),
+  tags: z.array(z.string().min(1).max(30)).max(10).optional(),
+  repository: z.string().url().optional(),
+  screenshots: z.array(z.string().url()).max(5).optional(),
+});
+
+const pluginUpdateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().min(10).max(500).optional(),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be semver format").optional(),
+  image: z.string().min(1).optional(),
+  manifest: z.object({
+    runtime: z.object({
+      image: z.string().min(1),
+      port: z.number().int().min(1).max(65535),
+      healthCheck: z.string().min(1),
+    }),
+    permissions: z.array(z.string()).min(1),
+  }).passthrough().optional(),
+  tags: z.array(z.string().min(1).max(30)).max(10).optional(),
+  repository: z.string().url().nullable().optional(),
+  screenshots: z.array(z.string().url()).max(5).optional(),
+});
+
+export const developerRoutes = new Elysia({ prefix: "/api/developer" })
+  .resolve(authResolve())
+
+  // ── POST /api/developer/plugins — Submit a new plugin ───────────────────
+  .post("/plugins", async ({ body, user: sessionUser }) => {
+    const data = validateInput(pluginSubmitSchema, body);
+
+    // Check no existing plugin with same id
+    const [existing] = await db
+      .select({ id: pluginRegistry.id })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, data.id))
+      .limit(1);
+
+    if (existing) throw new ValidationError("Plugin with this ID already exists");
+
+    // Insert into pluginRegistry with published: false
+    await db.insert(pluginRegistry).values({
+      id: data.id,
+      name: data.name,
+      description: data.description,
+      author: data.author,
+      category: data.category,
+      scope: data.scope,
+      image: data.image,
+      version: data.version,
+      manifest: data.manifest,
+      tags: data.tags ?? [],
+      repository: data.repository ?? null,
+      screenshots: data.screenshots ?? [],
+      published: false,
+      authorUserId: sessionUser.id,
+    });
+
+    // Insert submission record
+    const [submission] = await db
+      .insert(pluginSubmissions)
+      .values({
+        pluginId: data.id,
+        authorUserId: sessionUser.id,
+      })
+      .returning({ id: pluginSubmissions.id });
+
+    return { pluginId: data.id, submissionId: submission!.id, status: "pending" as const };
+  })
+
+  // ── GET /api/developer/plugins — List user's submitted plugins ──────────
+  .get("/plugins", async ({ user: sessionUser }) => {
+    const rows = await db
+      .select({
+        id: pluginRegistry.id,
+        name: pluginRegistry.name,
+        description: pluginRegistry.description,
+        version: pluginRegistry.version,
+        category: pluginRegistry.category,
+        scope: pluginRegistry.scope,
+        image: pluginRegistry.image,
+        published: pluginRegistry.published,
+        createdAt: pluginRegistry.createdAt,
+      })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.authorUserId, sessionUser.id))
+      .orderBy(desc(pluginRegistry.createdAt));
+
+    // Get latest submission for each plugin
+    const plugins = await Promise.all(
+      rows.map(async (plugin) => {
+        const [latestSubmission] = await db
+          .select({
+            id: pluginSubmissions.id,
+            status: pluginSubmissions.status,
+            submittedAt: pluginSubmissions.submittedAt,
+            rejectionReason: pluginSubmissions.rejectionReason,
+            reviewedAt: pluginSubmissions.reviewedAt,
+          })
+          .from(pluginSubmissions)
+          .where(eq(pluginSubmissions.pluginId, plugin.id))
+          .orderBy(desc(pluginSubmissions.submittedAt))
+          .limit(1);
+
+        return Object.assign(plugin, {
+          createdAt: plugin.createdAt.toISOString(),
+          submission: latestSubmission
+            ? {
+                id: latestSubmission.id,
+                status: latestSubmission.status,
+                submittedAt: latestSubmission.submittedAt.toISOString(),
+                rejectionReason: latestSubmission.rejectionReason,
+                reviewedAt: latestSubmission.reviewedAt?.toISOString() ?? null,
+              }
+            : null,
+        });
+      }),
+    );
+
+    return { plugins };
+  })
+
+  // ── PUT /api/developer/plugins/:pluginId — Update unpublished plugin ────
+  .put("/plugins/:pluginId", async ({ params, body, user: sessionUser }) => {
+    const data = validateInput(pluginUpdateSchema, body);
+
+    // Verify ownership
+    const [plugin] = await db
+      .select({
+        id: pluginRegistry.id,
+        authorUserId: pluginRegistry.authorUserId,
+        published: pluginRegistry.published,
+      })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+
+    if (!plugin) throw new NotFoundError("Plugin");
+    if (plugin.authorUserId !== sessionUser.id) throw new ForbiddenError("Not your plugin");
+    if (plugin.published) throw new ForbiddenError("Cannot edit a published plugin");
+
+    const updates: Record<string, unknown> = {};
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.description !== undefined) updates.description = data.description;
+    if (data.version !== undefined) updates.version = data.version;
+    if (data.image !== undefined) updates.image = data.image;
+    if (data.manifest !== undefined) updates.manifest = data.manifest;
+    if (data.tags !== undefined) updates.tags = data.tags;
+    if (data.repository !== undefined) updates.repository = data.repository;
+    if (data.screenshots !== undefined) updates.screenshots = data.screenshots;
+
+    if (Object.keys(updates).length > 0) {
+      await db.update(pluginRegistry).set(updates).where(eq(pluginRegistry.id, params.pluginId));
+    }
+
+    // If previous submission was rejected, create a new pending submission (resubmission)
+    const [latestSubmission] = await db
+      .select({ status: pluginSubmissions.status })
+      .from(pluginSubmissions)
+      .where(eq(pluginSubmissions.pluginId, params.pluginId))
+      .orderBy(desc(pluginSubmissions.submittedAt))
+      .limit(1);
+
+    if (latestSubmission?.status === "rejected") {
+      await db.insert(pluginSubmissions).values({
+        pluginId: params.pluginId,
+        authorUserId: sessionUser.id,
+      });
+    }
+
+    return { success: true };
+  })
+
+  // ── GET /api/developer/plugins/:pluginId/status — Check submission status
+  .get("/plugins/:pluginId/status", async ({ params, user: sessionUser }) => {
+    // Verify ownership
+    const [plugin] = await db
+      .select({ authorUserId: pluginRegistry.authorUserId })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+
+    if (!plugin) throw new NotFoundError("Plugin");
+    if (plugin.authorUserId !== sessionUser.id) throw new ForbiddenError("Not your plugin");
+
+    const [submission] = await db
+      .select({
+        id: pluginSubmissions.id,
+        status: pluginSubmissions.status,
+        submittedAt: pluginSubmissions.submittedAt,
+        reviewedBy: pluginSubmissions.reviewedBy,
+        reviewedAt: pluginSubmissions.reviewedAt,
+        rejectionReason: pluginSubmissions.rejectionReason,
+      })
+      .from(pluginSubmissions)
+      .where(eq(pluginSubmissions.pluginId, params.pluginId))
+      .orderBy(desc(pluginSubmissions.submittedAt))
+      .limit(1);
+
+    if (!submission) throw new NotFoundError("Submission");
+
+    return {
+      id: submission.id,
+      status: submission.status,
+      submittedAt: submission.submittedAt.toISOString(),
+      reviewedBy: submission.reviewedBy,
+      reviewedAt: submission.reviewedAt?.toISOString() ?? null,
+      rejectionReason: submission.rejectionReason,
+    };
+  });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,6 +34,7 @@ const BotsSettings = lazy(() => import("./pages/settings/bots-settings.js"));
 const PluginsSettings = lazy(() => import("./pages/settings/PluginsSettings.js"));
 const PluginConfigure = lazy(() => import("./pages/settings/PluginConfigure.js"));
 const NotificationSettings = lazy(() => import("./pages/settings/notification-settings.js"));
+const DeveloperSettings = lazy(() => import("./pages/settings/developer-settings.js"));
 const Upgrade = lazy(() => import("./pages/Upgrade.js"));
 const Billing = lazy(() => import("./pages/Billing.js"));
 
@@ -86,6 +87,7 @@ const App = () => {
           <Route path="/upgrade" component={Upgrade} />
           <Route path="/billing" component={Billing} />
           <Route path="/notifications" component={NotificationSettings} />
+          <Route path="/developer" component={DeveloperSettings} />
         </Route>
       </Route>
 

--- a/apps/web/src/components/settings/developer-settings.tsx
+++ b/apps/web/src/components/settings/developer-settings.tsx
@@ -1,0 +1,469 @@
+import { createSignal, createResource, For, Show } from "solid-js";
+import { api } from "../../lib/api.js";
+import { showToast } from "../ui/toast.js";
+import { handleApiError } from "../../lib/error-handling.js";
+import { Button } from "../ui/button.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface PluginSubmission {
+  id: string;
+  status: "pending" | "approved" | "rejected";
+  submittedAt: string;
+  rejectionReason: string | null;
+  reviewedAt: string | null;
+}
+
+interface DeveloperPlugin {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  category: string;
+  scope: string;
+  image: string;
+  published: boolean;
+  createdAt: string;
+  submission: PluginSubmission | null;
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const CATEGORIES = ["ai", "productivity", "developer", "media", "social", "utility", "other"] as const;
+const SCOPES = ["server", "personal", "both"] as const;
+const PERMISSIONS = [
+  "server.read",
+  "members.read",
+  "channels.read",
+  "messages.read",
+  "messages.send",
+  "users.read",
+  "presence.read",
+  "notifications.send",
+  "config.read",
+  "storage.read",
+  "storage.write",
+] as const;
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+const DeveloperSettings = () => {
+  const [devMode, setDevMode] = createSignal(
+    localStorage.getItem("developerMode") === "true",
+  );
+
+  function toggleDevMode() {
+    const next = !devMode();
+    setDevMode(next);
+    localStorage.setItem("developerMode", String(next));
+  }
+
+  // Plugin list resource — only fetches when dev mode is on
+  const [plugins, { refetch }] = createResource(
+    () => devMode(),
+    async (enabled) => {
+      if (!enabled) return [];
+      const res = await api<{ plugins: DeveloperPlugin[] }>("/api/developer/plugins");
+      return res.plugins;
+    },
+  );
+
+  // ── Form state ────────────────────────────────────────────────────────────
+
+  const [formId, setFormId] = createSignal("");
+  const [formName, setFormName] = createSignal("");
+  const [formDesc, setFormDesc] = createSignal("");
+  const [formVersion, setFormVersion] = createSignal("1.0.0");
+  const [formCategory, setFormCategory] = createSignal<string>("utility");
+  const [formScope, setFormScope] = createSignal<string>("server");
+  const [formImage, setFormImage] = createSignal("");
+  const [formPort, setFormPort] = createSignal(3000);
+  const [formHealthCheck, setFormHealthCheck] = createSignal("/health");
+  const [formRepo, setFormRepo] = createSignal("");
+  const [formTags, setFormTags] = createSignal("");
+  const [formPermissions, setFormPermissions] = createSignal<Set<string>>(new Set());
+  const [submitting, setSubmitting] = createSignal(false);
+  const [formError, setFormError] = createSignal<string | null>(null);
+
+  function togglePermission(perm: string) {
+    setFormPermissions((prev) => {
+      const next = new Set<string>(prev);
+      if (next.has(perm)) next.delete(perm);
+      else next.add(perm);
+      return next;
+    });
+  }
+
+  function resetForm() {
+    setFormId("");
+    setFormName("");
+    setFormDesc("");
+    setFormVersion("1.0.0");
+    setFormCategory("utility");
+    setFormScope("server");
+    setFormImage("");
+    setFormPort(3000);
+    setFormHealthCheck("/health");
+    setFormRepo("");
+    setFormTags("");
+    setFormPermissions(new Set<string>());
+    setFormError(null);
+  }
+
+  async function handleSubmit(e: Event) {
+    e.preventDefault();
+    if (submitting()) return;
+    setFormError(null);
+
+    const permissions = [...formPermissions()];
+    if (permissions.length === 0) {
+      setFormError("Select at least one permission");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const body = {
+        id: formId().trim(),
+        name: formName().trim(),
+        description: formDesc().trim(),
+        author: formName().trim(), // author defaults to plugin name
+        category: formCategory(),
+        scope: formScope(),
+        image: formImage().trim(),
+        version: formVersion().trim(),
+        manifest: {
+          runtime: {
+            image: formImage().trim(),
+            port: formPort(),
+            healthCheck: formHealthCheck().trim(),
+          },
+          permissions,
+        },
+        tags: formTags()
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+        ...(formRepo().trim() ? { repository: formRepo().trim() } : {}),
+      };
+
+      await api("/api/developer/plugins", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+
+      showToast("Plugin submitted for review", "info");
+      resetForm();
+      refetch();
+    } catch (err) {
+      handleApiError(err, "Failed to submit plugin");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div class="space-y-6">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">Developer</h2>
+        <p class="text-sm text-muted-foreground">
+          Build and submit plugins to the UnCorded marketplace.
+        </p>
+      </div>
+
+      {/* Developer Mode Toggle */}
+      <div class="flex items-center justify-between rounded-lg border border-border p-4">
+        <div>
+          <p class="text-sm font-medium text-foreground">Developer Mode</p>
+          <p class="text-xs text-muted-foreground">
+            Enable plugin submission tools and developer features.
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={devMode()}
+          class={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+            devMode() ? "bg-primary" : "bg-muted"
+          }`}
+          onClick={toggleDevMode}
+        >
+          <span
+            class={`pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg transition-transform ${
+              devMode() ? "translate-x-5" : "translate-x-0"
+            }`}
+          />
+        </button>
+      </div>
+
+      <Show
+        when={devMode()}
+        fallback={
+          <div class="rounded-lg border border-border p-6 text-center">
+            <p class="text-sm text-muted-foreground">
+              Enable developer mode to submit plugins, view your submissions, and access developer tools.
+            </p>
+          </div>
+        }
+      >
+        {/* ── Section 2: My Submitted Plugins ───────────────────────────── */}
+        <div class="space-y-3">
+          <h3 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+            My Submitted Plugins
+          </h3>
+
+          <Show
+            when={!plugins.loading}
+            fallback={<p class="text-sm text-muted-foreground">Loading...</p>}
+          >
+            <Show
+              when={(plugins()?.length ?? 0) > 0}
+              fallback={
+                <div class="rounded-lg border border-border p-6 text-center">
+                  <p class="text-sm text-muted-foreground">
+                    You haven't submitted any plugins yet.
+                  </p>
+                </div>
+              }
+            >
+              <div class="space-y-2">
+                <For each={plugins()}>
+                  {(plugin) => (
+                    <div class="rounded-lg border border-border p-4">
+                      <div class="flex items-center justify-between gap-3">
+                        <div class="min-w-0 flex-1">
+                          <div class="flex items-center gap-2">
+                            <span class="font-semibold text-foreground">{plugin.name}</span>
+                            <span class="text-xs text-muted-foreground">v{plugin.version}</span>
+                          </div>
+                          <p class="text-xs text-muted-foreground">{plugin.id}</p>
+                        </div>
+                        <Show when={plugin.submission}>
+                          {(sub) => (
+                            <span
+                              class={`shrink-0 rounded px-2 py-0.5 text-xs font-medium ${
+                                sub().status === "pending"
+                                  ? "bg-yellow-500/20 text-yellow-400"
+                                  : sub().status === "approved"
+                                    ? "bg-green-500/20 text-green-400"
+                                    : "bg-red-500/20 text-red-400"
+                              }`}
+                            >
+                              {sub().status}
+                            </span>
+                          )}
+                        </Show>
+                      </div>
+
+                      {/* Rejection reason */}
+                      <Show when={plugin.submission?.status === "rejected" && plugin.submission?.rejectionReason}>
+                        <div class="mt-2 rounded bg-destructive/10 p-2">
+                          <p class="text-xs text-muted-foreground">
+                            <span class="font-medium text-destructive">Rejected:</span>{" "}
+                            {plugin.submission!.rejectionReason}
+                          </p>
+                        </div>
+                      </Show>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
+        </div>
+
+        {/* ── Section 3: Submit New Plugin ───────────────────────────────── */}
+        <div class="space-y-3">
+          <h3 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+            Submit New Plugin
+          </h3>
+
+          <form onSubmit={handleSubmit} class="space-y-4 rounded-lg border border-border p-4">
+            {/* Plugin ID */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Plugin ID</label>
+              <input
+                type="text"
+                value={formId()}
+                onInput={(e) => setFormId(e.currentTarget.value)}
+                placeholder="my-awesome-plugin"
+                maxLength={50}
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+              <p class="mt-1 text-xs text-muted-foreground">
+                Lowercase alphanumeric with hyphens (e.g. my-plugin)
+              </p>
+            </div>
+
+            {/* Name */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Name</label>
+              <input
+                type="text"
+                value={formName()}
+                onInput={(e) => setFormName(e.currentTarget.value)}
+                placeholder="My Awesome Plugin"
+                maxLength={100}
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            {/* Description */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Description</label>
+              <textarea
+                value={formDesc()}
+                onInput={(e) => setFormDesc(e.currentTarget.value)}
+                placeholder="What does your plugin do? (10-500 characters)"
+                maxLength={500}
+                rows={3}
+                class="w-full resize-none rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            {/* Version */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Version</label>
+              <input
+                type="text"
+                value={formVersion()}
+                onInput={(e) => setFormVersion(e.currentTarget.value)}
+                placeholder="1.0.0"
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            {/* Category + Scope row */}
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="mb-1 block text-sm font-medium text-foreground">Category</label>
+                <select
+                  value={formCategory()}
+                  onChange={(e) => setFormCategory(e.currentTarget.value)}
+                  class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none"
+                >
+                  <For each={[...CATEGORIES]}>
+                    {(cat) => <option value={cat}>{cat}</option>}
+                  </For>
+                </select>
+              </div>
+              <div>
+                <label class="mb-1 block text-sm font-medium text-foreground">Scope</label>
+                <select
+                  value={formScope()}
+                  onChange={(e) => setFormScope(e.currentTarget.value)}
+                  class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none"
+                >
+                  <For each={[...SCOPES]}>
+                    {(s) => <option value={s}>{s}</option>}
+                  </For>
+                </select>
+              </div>
+            </div>
+
+            {/* Docker Image */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Docker Image</label>
+              <input
+                type="text"
+                value={formImage()}
+                onInput={(e) => setFormImage(e.currentTarget.value)}
+                placeholder="ghcr.io/user/my-plugin:latest"
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            {/* Port + Health Check row */}
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="mb-1 block text-sm font-medium text-foreground">Container Port</label>
+                <input
+                  type="number"
+                  value={formPort()}
+                  onInput={(e) => setFormPort(Number(e.currentTarget.value))}
+                  min={1}
+                  max={65535}
+                  class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none"
+                />
+              </div>
+              <div>
+                <label class="mb-1 block text-sm font-medium text-foreground">Health Check Path</label>
+                <input
+                  type="text"
+                  value={formHealthCheck()}
+                  onInput={(e) => setFormHealthCheck(e.currentTarget.value)}
+                  placeholder="/health"
+                  class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+                />
+              </div>
+            </div>
+
+            {/* Repository URL (optional) */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">
+                Repository URL <span class="text-muted-foreground">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={formRepo()}
+                onInput={(e) => setFormRepo(e.currentTarget.value)}
+                placeholder="https://github.com/user/my-plugin"
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            {/* Tags */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">
+                Tags <span class="text-muted-foreground">(optional, comma-separated)</span>
+              </label>
+              <input
+                type="text"
+                value={formTags()}
+                onInput={(e) => setFormTags(e.currentTarget.value)}
+                placeholder="ai, chatbot, automation"
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            {/* Permissions */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Permissions</label>
+              <div class="grid grid-cols-2 gap-2">
+                <For each={[...PERMISSIONS]}>
+                  {(perm) => (
+                    <label class="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm text-foreground hover:bg-accent">
+                      <input
+                        type="checkbox"
+                        checked={formPermissions().has(perm)}
+                        onChange={() => togglePermission(perm)}
+                        class="rounded border-border"
+                      />
+                      <span class="font-mono text-xs">{perm}</span>
+                    </label>
+                  )}
+                </For>
+              </div>
+            </div>
+
+            {/* Error message */}
+            <Show when={formError()}>
+              {(err) => (
+                <p class="text-sm text-destructive">{err()}</p>
+              )}
+            </Show>
+
+            {/* Submit button */}
+            <Button type="submit" disabled={submitting()}>
+              {submitting() ? "Submitting..." : "Submit for Review"}
+            </Button>
+          </form>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default DeveloperSettings;

--- a/apps/web/src/components/settings/developer-settings.tsx
+++ b/apps/web/src/components/settings/developer-settings.tsx
@@ -72,6 +72,7 @@ const DeveloperSettings = () => {
 
   const [formId, setFormId] = createSignal("");
   const [formName, setFormName] = createSignal("");
+  const [formAuthor, setFormAuthor] = createSignal("");
   const [formDesc, setFormDesc] = createSignal("");
   const [formVersion, setFormVersion] = createSignal("1.0.0");
   const [formCategory, setFormCategory] = createSignal<string>("utility");
@@ -97,6 +98,7 @@ const DeveloperSettings = () => {
   function resetForm() {
     setFormId("");
     setFormName("");
+    setFormAuthor("");
     setFormDesc("");
     setFormVersion("1.0.0");
     setFormCategory("utility");
@@ -127,7 +129,7 @@ const DeveloperSettings = () => {
         id: formId().trim(),
         name: formName().trim(),
         description: formDesc().trim(),
-        author: formName().trim(), // author defaults to plugin name
+        author: formAuthor().trim() || formName().trim(),
         category: formCategory(),
         scope: formScope(),
         image: formImage().trim(),
@@ -245,10 +247,10 @@ const DeveloperSettings = () => {
                             <span
                               class={`shrink-0 rounded px-2 py-0.5 text-xs font-medium ${
                                 sub().status === "pending"
-                                  ? "bg-yellow-500/20 text-yellow-400"
+                                  ? "bg-warning/20 text-warning"
                                   : sub().status === "approved"
-                                    ? "bg-green-500/20 text-green-400"
-                                    : "bg-red-500/20 text-red-400"
+                                    ? "bg-success/20 text-success"
+                                    : "bg-destructive/20 text-destructive"
                               }`}
                             >
                               {sub().status}
@@ -308,6 +310,22 @@ const DeveloperSettings = () => {
                 maxLength={100}
                 class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
               />
+            </div>
+
+            {/* Author */}
+            <div>
+              <label class="mb-1 block text-sm font-medium text-foreground">Author</label>
+              <input
+                type="text"
+                value={formAuthor()}
+                onInput={(e) => setFormAuthor(e.currentTarget.value)}
+                placeholder="Your name or organization"
+                maxLength={100}
+                class="w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+              <p class="mt-1 text-xs text-muted-foreground">
+                Defaults to plugin name if left empty.
+              </p>
             </div>
 
             {/* Description */}

--- a/apps/web/src/pages/SettingsLayout.tsx
+++ b/apps/web/src/pages/SettingsLayout.tsx
@@ -14,6 +14,8 @@ const navItems = [
   { label: "Upgrade", href: "/settings/upgrade" },
   { label: "Billing", href: "/settings/billing" },
   { label: "Notifications", href: "/settings/notifications" },
+  { divider: true as const },
+  { label: "Developer", href: "/settings/developer" },
 ] as const;
 
 const SettingsLayout = (props: RouteSectionProps) => {

--- a/apps/web/src/pages/settings/developer-settings.tsx
+++ b/apps/web/src/pages/settings/developer-settings.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../components/settings/developer-settings.js";

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@stripe/stripe-js": "^8.10.0",
       },
       "devDependencies": {
-        "lucide-solid": "^1.7.0",
         "oxfmt": "^0.36.0",
         "oxlint": "^1.51.0",
         "sharp": "^0.34.5",


### PR DESCRIPTION
## Summary

- **New Developer tab** in Settings with developer mode toggle (localStorage-persisted)
- **Plugin submission form** — ID, name, description, version, category, scope, Docker image, port, health check, repo URL, tags, and 11 permission checkboxes
- **Submitted plugins list** with colored status badges (pending/approved/rejected) and rejection reasons
- **Server routes** (`/api/developer/*`) for plugin CRUD with strict Zod validation and ownership checks
- **Admin review endpoints** (`/api/admin/plugins/submissions/*`) for approve/reject with audit logging
- **Database migration** — `plugin_submissions` table + nullable `authorUserId` column on `plugin_registry`

## Changes

### Schema
- `pluginSubmissionStatusEnum` (pending, approved, rejected)
- `pluginSubmissions` table with FK to plugin_registry, user, and indexes
- `authorUserId` nullable column on `pluginRegistry` (existing admin-seeded entries get NULL)

### Server
- `apps/server/src/routes/developer.ts` — 4 endpoints: submit, list, update, status check
- `apps/server/src/routes/admin.ts` — 3 endpoints: list pending, approve, reject
- `apps/server/src/index.ts` — mount developerRoutes

### Frontend
- `apps/web/src/components/settings/developer-settings.tsx` — full SolidJS component
- `apps/web/src/pages/settings/developer-settings.tsx` — page entry point
- `apps/web/src/App.tsx` — lazy import + route
- `apps/web/src/pages/SettingsLayout.tsx` — nav item with divider

## Commits

- `4bbb6d1` feat: add developer settings tab with plugin submission flow

## Test plan

- [ ] Migration applies cleanly (`bunx drizzle-kit push`)
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (0 errors)
- [ ] Settings → Developer tab appears and renders
- [ ] Toggle developer mode on → form and plugin list appear
- [ ] Submit plugin form → POST succeeds → plugin appears in list with pending badge
- [ ] `GET /api/admin/plugins/submissions` returns pending submission
- [ ] Approve via PATCH → plugin becomes published
- [ ] Reject via PATCH → developer sees rejection reason
- [ ] Existing admin plugin management unchanged (nullable authorUserId doesn't break queries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin submission system enabling developers to submit new plugins with metadata, version, and runtime configuration
  * Introduced Developer Settings page with toggle for developer mode to access plugin submission features
  * Added plugin submission status tracking with pending, approved, and rejected states
  * Implemented admin review workflow to approve or reject pending plugin submissions with optional rejection reasons
  * Added "My Submitted Plugins" dashboard showing submission history and status for each plugin

<!-- end of auto-generated comment: release notes by coderabbit.ai -->