### PR TITLE
feat: plugin auto-update system (Phase 3)

### DIFF
--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -152,8 +152,10 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     })
 
     .post("/plugins/:id/update", async ({ params }) => {
-      const { pendingMajorUpdates, removePendingUpdate } = await import("../index");
-      const update = pendingMajorUpdates.find((u) => u.pluginId === params.id);
+      const { removePendingUpdate, reinsertPendingUpdate } = await import("../index");
+
+      // Atomically remove the pending update so concurrent requests see 404
+      const update = removePendingUpdate(params.id);
       if (!update) {
         throw new Response(JSON.stringify({ error: "No pending update for this plugin" }), {
           status: 404,
@@ -163,13 +165,14 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
 
       const result = await options.plugins.update(params.id, update.manifest);
       if (result.errors && result.errors.length > 0) {
+        // Re-insert so the user can retry
+        reinsertPendingUpdate(update);
         throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
           status: 500,
           headers: { "Content-Type": "application/json" },
         });
       }
 
-      removePendingUpdate(params.id);
       return { success: true, version: update.availableVersion };
     })
 

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -137,6 +137,10 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
       }
       console.error("[bridge] Auth token received");
       options.plugins.setApiToken(token);
+
+      // Trigger plugin update check now that auth is available
+      import("../index").then((m) => m.runUpdateCheck()).catch(() => {});
+
       return { success: true };
     })
 
@@ -163,9 +167,19 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
         });
       }
 
-      const result = await options.plugins.update(params.id, update.manifest);
+      let result: { errors?: string[] };
+      try {
+        result = await options.plugins.update(params.id, update.manifest);
+      } catch (err) {
+        reinsertPendingUpdate(update);
+        const message = err instanceof Error ? err.message : "Unknown error";
+        throw new Response(JSON.stringify({ error: message }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
       if (result.errors && result.errors.length > 0) {
-        // Re-insert so the user can retry
         reinsertPendingUpdate(update);
         throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
           status: 500,

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -145,6 +145,34 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
       return notificationQueue.drain();
     })
 
+    // --- Plugin updates (called by Electron main process, no auth) ---
+    .get("/plugins/updates", async () => {
+      const { pendingMajorUpdates } = await import("../index");
+      return { updates: pendingMajorUpdates };
+    })
+
+    .post("/plugins/:id/update", async ({ params }) => {
+      const { pendingMajorUpdates, removePendingUpdate } = await import("../index");
+      const update = pendingMajorUpdates.find((u) => u.pluginId === params.id);
+      if (!update) {
+        throw new Response(JSON.stringify({ error: "No pending update for this plugin" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      const result = await options.plugins.update(params.id, update.manifest);
+      if (result.errors && result.errors.length > 0) {
+        throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      removePendingUpdate(params.id);
+      return { success: true, version: update.availableVersion };
+    })
+
     .post("/plugins/:id/uninstall", async ({ params }) => {
       try {
         await options.plugins.uninstall(params.id);

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -152,7 +152,7 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     // --- Plugin updates (called by Electron main process, no auth) ---
     .get("/plugins/updates", async () => {
       const { pendingMajorUpdates } = await import("../index");
-      return { updates: pendingMajorUpdates };
+      return { updates: [...pendingMajorUpdates] };
     })
 
     .post("/plugins/:id/update", async ({ params }) => {

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -24,6 +24,7 @@ interface BridgeServer {
 export async function startBridgeServer(options: BridgeServerOptions): Promise<BridgeServer> {
   const dataDir = options.dataDir ?? process.env["UNCORDED_DATA_DIR"] ?? "./sidecar-data";
   const storage = new PluginStorage(dataDir);
+  const inFlightUpdates = new Set<string>();
 
   const app = new Elysia()
     // Health check (unauthenticated)
@@ -139,7 +140,9 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
       options.plugins.setApiToken(token);
 
       // Trigger plugin update check now that auth is available
-      import("../index").then((m) => m.runUpdateCheck()).catch(() => {});
+      import("../index")
+        .then((m) => m.runUpdateCheck())
+        .catch((err) => console.error("[bridge] runUpdateCheck failed after auth:", err));
 
       return { success: true };
     })
@@ -150,6 +153,7 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     })
 
     // --- Plugin updates (called by Electron main process, no auth) ---
+
     .get("/plugins/updates", async () => {
       const { pendingMajorUpdates } = await import("../index");
       return { updates: [...pendingMajorUpdates] };
@@ -158,7 +162,15 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     .post("/plugins/:id/update", async ({ params }) => {
       const { removePendingUpdate, reinsertPendingUpdate } = await import("../index");
 
-      // Atomically remove the pending update so concurrent requests see 404
+      // If already in-flight, return 202 so the client knows it's being processed
+      if (inFlightUpdates.has(params.id)) {
+        return new Response(JSON.stringify({ status: "in_progress" }), {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      // Atomically remove the pending update
       const update = removePendingUpdate(params.id);
       if (!update) {
         throw new Response(JSON.stringify({ error: "No pending update for this plugin" }), {
@@ -167,10 +179,12 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
         });
       }
 
+      inFlightUpdates.add(params.id);
       let result: { errors?: string[] };
       try {
         result = await options.plugins.update(params.id, update.manifest);
       } catch (err) {
+        inFlightUpdates.delete(params.id);
         reinsertPendingUpdate(update);
         const message = err instanceof Error ? err.message : "Unknown error";
         throw new Response(JSON.stringify({ error: message }), {
@@ -178,11 +192,20 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
           headers: { "Content-Type": "application/json" },
         });
       }
+      inFlightUpdates.delete(params.id);
 
       if (result.errors && result.errors.length > 0) {
-        reinsertPendingUpdate(update);
-        throw new Response(JSON.stringify({ error: result.errors.join(", ") }), {
-          status: 500,
+        const joined = result.errors.join(", ");
+        // Permanent validation failures — don't requeue
+        const isPermanent = result.errors.some((e) =>
+          /not found|manifest|scope|parse/i.test(e),
+        );
+        if (!isPermanent) {
+          reinsertPendingUpdate(update);
+        }
+        const status = isPermanent ? 400 : 500;
+        throw new Response(JSON.stringify({ error: joined }), {
+          status,
           headers: { "Content-Type": "application/json" },
         });
       }

--- a/apps/desktop/sidecar/index.ts
+++ b/apps/desktop/sidecar/index.ts
@@ -3,6 +3,7 @@ import { DockerManager } from "./docker/manager";
 import { GatewayClient } from "./gateway/client";
 import { SeedingEngine } from "./seeding/engine";
 import { PluginLifecycle } from "./plugins/lifecycle";
+import { checkForUpdates, applyAutoUpdates, type UpdateInfo } from "./plugins/update-checker";
 import { TunnelManager } from "./tunnel/manager";
 import path from "node:path";
 import fs from "node:fs";
@@ -48,6 +49,40 @@ await seeding.resume();
 // --- Resume plugins that were previously running ---
 
 await plugins.resumeAll();
+
+// --- Check for plugin updates (async, non-blocking) ---
+
+export let pendingMajorUpdates: UpdateInfo[] = [];
+
+export function removePendingUpdate(pluginId: string): void {
+  pendingMajorUpdates = pendingMajorUpdates.filter((u) => u.pluginId !== pluginId);
+}
+
+const apiBaseUrl = plugins.getApiBaseUrl();
+const apiToken = plugins.getApiToken();
+if (apiBaseUrl && apiToken) {
+  checkForUpdates(plugins, apiBaseUrl, apiToken)
+    .then(async (updates) => {
+      const autoUpdates = updates.filter((u) => u.updateType !== "major");
+      const majorUpdates = updates.filter((u) => u.updateType === "major");
+
+      if (autoUpdates.length > 0) {
+        const result = await applyAutoUpdates(plugins, autoUpdates);
+        if (result.applied.length > 0) {
+          console.error(`[update-checker] Auto-updated: ${result.applied.join(", ")}`);
+        }
+        if (result.skipped.length > 0) {
+          console.error(`[update-checker] Skipped: ${result.skipped.join(", ")}`);
+        }
+      }
+
+      pendingMajorUpdates = majorUpdates;
+      if (majorUpdates.length > 0) {
+        console.error(`[update-checker] Major updates available: ${majorUpdates.map((u) => `${u.pluginId}@${u.availableVersion}`).join(", ")}`);
+      }
+    })
+    .catch((err) => console.error("[update-checker] Update check failed:", err));
+}
 
 // --- Graceful shutdown ---
 

--- a/apps/desktop/sidecar/index.ts
+++ b/apps/desktop/sidecar/index.ts
@@ -91,7 +91,15 @@ export async function runUpdateCheck(): Promise<void> {
       }
     }
 
-    pendingMajorUpdates = majorUpdates;
+    // Merge new major updates into pending list, preserving user-queued items
+    for (const update of majorUpdates) {
+      const existing = pendingMajorUpdates.findIndex((u) => u.pluginId === update.pluginId);
+      if (existing === -1) {
+        pendingMajorUpdates.push(update);
+      } else if (pendingMajorUpdates[existing]!.availableVersion !== update.availableVersion) {
+        pendingMajorUpdates[existing] = update;
+      }
+    }
     if (majorUpdates.length > 0) {
       console.error(`[update-checker] Major updates available: ${majorUpdates.map((u) => `${u.pluginId}@${u.availableVersion}`).join(", ")}`);
     }

--- a/apps/desktop/sidecar/index.ts
+++ b/apps/desktop/sidecar/index.ts
@@ -54,8 +54,17 @@ await plugins.resumeAll();
 
 export let pendingMajorUpdates: UpdateInfo[] = [];
 
-export function removePendingUpdate(pluginId: string): void {
-  pendingMajorUpdates = pendingMajorUpdates.filter((u) => u.pluginId !== pluginId);
+export function removePendingUpdate(pluginId: string): UpdateInfo | undefined {
+  const idx = pendingMajorUpdates.findIndex((u) => u.pluginId === pluginId);
+  if (idx === -1) return undefined;
+  const [removed] = pendingMajorUpdates.splice(idx, 1);
+  return removed;
+}
+
+export function reinsertPendingUpdate(update: UpdateInfo): void {
+  if (!pendingMajorUpdates.some((u) => u.pluginId === update.pluginId)) {
+    pendingMajorUpdates.push(update);
+  }
 }
 
 const apiBaseUrl = plugins.getApiBaseUrl();

--- a/apps/desktop/sidecar/index.ts
+++ b/apps/desktop/sidecar/index.ts
@@ -67,31 +67,43 @@ export function reinsertPendingUpdate(update: UpdateInfo): void {
   }
 }
 
-const apiBaseUrl = plugins.getApiBaseUrl();
-const apiToken = plugins.getApiToken();
-if (apiBaseUrl && apiToken) {
-  checkForUpdates(plugins, apiBaseUrl, apiToken)
-    .then(async (updates) => {
-      const autoUpdates = updates.filter((u) => u.updateType !== "major");
-      const majorUpdates = updates.filter((u) => u.updateType === "major");
+let updateCheckRunning = false;
 
-      if (autoUpdates.length > 0) {
-        const result = await applyAutoUpdates(plugins, autoUpdates);
-        if (result.applied.length > 0) {
-          console.error(`[update-checker] Auto-updated: ${result.applied.join(", ")}`);
-        }
-        if (result.skipped.length > 0) {
-          console.error(`[update-checker] Skipped: ${result.skipped.join(", ")}`);
-        }
-      }
+export async function runUpdateCheck(): Promise<void> {
+  const apiBaseUrl = plugins.getApiBaseUrl();
+  const apiToken = plugins.getApiToken();
+  if (!apiBaseUrl || !apiToken) return;
+  if (updateCheckRunning) return;
+  updateCheckRunning = true;
 
-      pendingMajorUpdates = majorUpdates;
-      if (majorUpdates.length > 0) {
-        console.error(`[update-checker] Major updates available: ${majorUpdates.map((u) => `${u.pluginId}@${u.availableVersion}`).join(", ")}`);
+  try {
+    const updates = await checkForUpdates(plugins, apiBaseUrl, apiToken);
+    const autoUpdates = updates.filter((u) => u.updateType !== "major");
+    const majorUpdates = updates.filter((u) => u.updateType === "major");
+
+    if (autoUpdates.length > 0) {
+      const result = await applyAutoUpdates(plugins, autoUpdates);
+      if (result.applied.length > 0) {
+        console.error(`[update-checker] Auto-updated: ${result.applied.join(", ")}`);
       }
-    })
-    .catch((err) => console.error("[update-checker] Update check failed:", err));
+      if (result.skipped.length > 0) {
+        console.error(`[update-checker] Skipped: ${result.skipped.join(", ")}`);
+      }
+    }
+
+    pendingMajorUpdates = majorUpdates;
+    if (majorUpdates.length > 0) {
+      console.error(`[update-checker] Major updates available: ${majorUpdates.map((u) => `${u.pluginId}@${u.availableVersion}`).join(", ")}`);
+    }
+  } catch (err) {
+    console.error("[update-checker] Update check failed:", err);
+  } finally {
+    updateCheckRunning = false;
+  }
 }
+
+// Run immediately if token is already available (e.g. from gateway-token.txt)
+runUpdateCheck();
 
 // --- Graceful shutdown ---
 

--- a/apps/desktop/sidecar/plugins/update-checker.ts
+++ b/apps/desktop/sidecar/plugins/update-checker.ts
@@ -8,11 +8,17 @@ export interface UpdateInfo {
   updateType: "major" | "minor" | "patch";
 }
 
+function coreSegments(version: string): [number, number, number] {
+  const core = version.replace(/[-+].*$/, "");
+  const parts = core.split(".").map(Number);
+  return [(parts[0] ?? 0) || 0, (parts[1] ?? 0) || 0, (parts[2] ?? 0) || 0];
+}
+
 function classifyUpdate(current: string, available: string): "major" | "minor" | "patch" {
-  const c = current.split(".").map(Number);
-  const a = available.split(".").map(Number);
-  if ((a[0] ?? 0) !== (c[0] ?? 0)) return "major";
-  if ((a[1] ?? 0) !== (c[1] ?? 0)) return "minor";
+  const c = coreSegments(current);
+  const a = coreSegments(available);
+  if (a[0] !== c[0]) return "major";
+  if (a[1] !== c[1]) return "minor";
   return "patch";
 }
 

--- a/apps/desktop/sidecar/plugins/update-checker.ts
+++ b/apps/desktop/sidecar/plugins/update-checker.ts
@@ -1,0 +1,100 @@
+import type { PluginLifecycle } from "./lifecycle";
+
+export interface UpdateInfo {
+  pluginId: string;
+  currentVersion: string;
+  availableVersion: string;
+  manifest: unknown;
+  updateType: "major" | "minor" | "patch";
+}
+
+function classifyUpdate(current: string, available: string): "major" | "minor" | "patch" {
+  const c = current.split(".").map(Number);
+  const a = available.split(".").map(Number);
+  if ((a[0] ?? 0) !== (c[0] ?? 0)) return "major";
+  if ((a[1] ?? 0) !== (c[1] ?? 0)) return "minor";
+  return "patch";
+}
+
+const CHECK_TIMEOUT_MS = 15_000;
+
+export async function checkForUpdates(
+  plugins: PluginLifecycle,
+  apiBaseUrl: string,
+  apiToken: string,
+): Promise<UpdateInfo[]> {
+  const installed = plugins.list();
+  if (installed.length === 0) return [];
+
+  const input = installed.map((p) => ({
+    id: p.pluginId,
+    version: p.manifest.version,
+  }));
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CHECK_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${apiBaseUrl}/api/plugins/check-updates`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `__Secure-uncorded.session_token=${apiToken}`,
+      },
+      body: JSON.stringify({ plugins: input }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      console.error(`[update-checker] Server returned ${res.status}`);
+      return [];
+    }
+
+    const data = (await res.json()) as {
+      updates: { pluginId: string; currentVersion: string; latestVersion: string; manifest: unknown }[];
+    };
+
+    return data.updates.map((u) => ({
+      pluginId: u.pluginId,
+      currentVersion: u.currentVersion,
+      availableVersion: u.latestVersion,
+      manifest: u.manifest,
+      updateType: classifyUpdate(u.currentVersion, u.latestVersion),
+    }));
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      console.error("[update-checker] Request timed out");
+    } else {
+      console.error("[update-checker] Failed to check for updates:", err);
+    }
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function applyAutoUpdates(
+  plugins: PluginLifecycle,
+  updates: UpdateInfo[],
+): Promise<{ applied: string[]; skipped: string[] }> {
+  const autoUpdatable = updates.filter((u) => u.updateType !== "major");
+  const applied: string[] = [];
+  const skipped: string[] = [];
+
+  for (const update of autoUpdatable) {
+    try {
+      const result = await plugins.update(update.pluginId, update.manifest);
+      if (result.errors && result.errors.length > 0) {
+        console.error(`[update-checker] Failed to update ${update.pluginId}:`, result.errors);
+        skipped.push(update.pluginId);
+      } else {
+        applied.push(update.pluginId);
+      }
+    } catch (err) {
+      console.error(`[update-checker] Error updating ${update.pluginId}:`, err);
+      skipped.push(update.pluginId);
+    }
+  }
+
+  return { applied, skipped };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -393,12 +393,12 @@ function startPluginPolling(): void {
     // Check for plugin updates every ~60s (every 20th poll)
     updatePollCounter++;
     if (updatePollCounter >= 20) {
-      updatePollCounter = 0;
       try {
         const port = sidecar.getPort();
         if (port) {
           const updateRes = await fetch(`http://localhost:${port}/plugins/updates`);
           if (updateRes.ok) {
+            updatePollCounter = 0;
             const { updates } = (await updateRes.json()) as { updates: PluginUpdateInfo[] };
             const payload = JSON.stringify(updates);
             if (payload !== lastUpdatePayload) {
@@ -411,7 +411,7 @@ function startPluginPolling(): void {
             }
           }
         }
-      } catch { /* silently ignore update check failures */ }
+      } catch { /* silently ignore — counter stays high so next poll retries sooner */ }
     }
   }, 3000);
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -373,6 +373,7 @@ function setupPluginIpc(): void {
 // Poll sidecar for plugin state changes (until we have a push mechanism)
 let pluginPollTimer: ReturnType<typeof setInterval> | null = null;
 let updatePollCounter = 0;
+let lastUpdatePayload = "";
 
 function startPluginPolling(): void {
   if (pluginPollTimer) return;
@@ -399,7 +400,9 @@ function startPluginPolling(): void {
           const updateRes = await fetch(`http://localhost:${port}/plugins/updates`);
           if (updateRes.ok) {
             const { updates } = (await updateRes.json()) as { updates: PluginUpdateInfo[] };
-            if (updates.length > 0) {
+            const payload = JSON.stringify(updates);
+            if (payload !== lastUpdatePayload) {
+              lastUpdatePayload = payload;
               for (const win of BrowserWindow.getAllWindows()) {
                 if (!win.isDestroyed()) {
                   win.webContents.send("plugins:updates-available", updates);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -193,6 +193,13 @@ interface PluginInfo {
   permissions: string[];
 }
 
+interface PluginUpdateInfo {
+  pluginId: string;
+  currentVersion: string;
+  availableVersion: string;
+  updateType: "major" | "minor" | "patch";
+}
+
 let cachedPlugins: PluginInfo[] = [];
 
 // Derive API base URL: explicit env > web URL origin > hardcoded default
@@ -391,7 +398,7 @@ function startPluginPolling(): void {
         if (port) {
           const updateRes = await fetch(`http://localhost:${port}/plugins/updates`);
           if (updateRes.ok) {
-            const { updates } = (await updateRes.json()) as { updates: unknown[] };
+            const { updates } = (await updateRes.json()) as { updates: PluginUpdateInfo[] };
             if (updates.length > 0) {
               for (const win of BrowserWindow.getAllWindows()) {
                 if (!win.isDestroyed()) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -338,6 +338,18 @@ function setupPluginIpc(): void {
     broadcastPluginState();
   });
 
+  ipcMain.handle("plugins:update", async (_event, pluginId: string) => {
+    const port = sidecar.getPort();
+    if (!port) throw new Error("Sidecar not running");
+    const res = await fetch(`http://localhost:${port}/plugins/${pluginId}/update`, { method: "POST" });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Plugin update failed (${res.status}): ${body}`);
+    }
+    cachedPlugins = await fetchPluginsFromSidecar();
+    broadcastPluginState();
+  });
+
   ipcMain.handle("plugins:get-permissions", async (_event, pluginId: string) => {
     const port = sidecar.getPort();
     if (!port) return [];
@@ -353,6 +365,7 @@ function setupPluginIpc(): void {
 
 // Poll sidecar for plugin state changes (until we have a push mechanism)
 let pluginPollTimer: ReturnType<typeof setInterval> | null = null;
+let updatePollCounter = 0;
 
 function startPluginPolling(): void {
   if (pluginPollTimer) return;
@@ -367,6 +380,28 @@ function startPluginPolling(): void {
     cachedPlugins = await fetchPluginsFromSidecar();
     if (JSON.stringify(cachedPlugins) !== prev) {
       broadcastPluginState();
+    }
+
+    // Check for plugin updates every ~60s (every 20th poll)
+    updatePollCounter++;
+    if (updatePollCounter >= 20) {
+      updatePollCounter = 0;
+      try {
+        const port = sidecar.getPort();
+        if (port) {
+          const updateRes = await fetch(`http://localhost:${port}/plugins/updates`);
+          if (updateRes.ok) {
+            const { updates } = (await updateRes.json()) as { updates: unknown[] };
+            if (updates.length > 0) {
+              for (const win of BrowserWindow.getAllWindows()) {
+                if (!win.isDestroyed()) {
+                  win.webContents.send("plugins:updates-available", updates);
+                }
+              }
+            }
+          }
+        }
+      } catch { /* silently ignore update check failures */ }
     }
   }, 3000);
 }

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -40,6 +40,13 @@ interface UpdateResult {
   state: UpdateState;
 }
 
+interface PluginUpdateInfo {
+  pluginId: string;
+  currentVersion: string;
+  availableVersion: string;
+  updateType: "major" | "minor" | "patch";
+}
+
 const desktopBridge = {
   // --- Sidecar ---
   getSidecarStatus: (): Promise<SidecarStatus> =>
@@ -76,6 +83,15 @@ const desktopBridge = {
 
     uninstall: (pluginId: string): Promise<void> =>
       ipcRenderer.invoke("plugins:uninstall", pluginId),
+
+    onUpdatesAvailable: (listener: (updates: PluginUpdateInfo[]) => void): (() => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, updates: PluginUpdateInfo[]) => listener(updates);
+      ipcRenderer.on("plugins:updates-available", handler);
+      return () => ipcRenderer.removeListener("plugins:updates-available", handler);
+    },
+
+    update: (pluginId: string): Promise<void> =>
+      ipcRenderer.invoke("plugins:update", pluginId),
   },
 
   // --- Auto-update ---

--- a/apps/server/src/helpers/rate-limit-keys.ts
+++ b/apps/server/src/helpers/rate-limit-keys.ts
@@ -12,6 +12,7 @@ export const RL = {
   SERVER_PLUGIN_UNINSTALL: "server-plugin-uninstall",
   SERVER_PLUGIN_UPDATE: "server-plugin-update",
   INVITE_LOOKUP: "invite-lookup",
+  PLUGIN_CHECK_UPDATES: "plugin-check-updates",
 
   // User-based (used with checkUserRateLimit)
   MESSAGE_CREATE: "messages:create",
@@ -25,4 +26,5 @@ export const RL = {
   USER_SEARCH: "users:search",
   DEVELOPER_PLUGIN_SUBMIT: "developer:plugin-submit",
   DEVELOPER_PLUGIN_UPDATE: "developer:plugin-update",
+  DEVELOPER_PLUGIN_VERSION_PUSH: "developer:plugin-version-push",
 } as const;

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -56,6 +56,12 @@ const pluginSubmitSchema = z.object({
   screenshots: z.array(z.string().url()).max(5).optional(),
 });
 
+const versionPushSchema = z.object({
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be semver format (e.g. 1.0.0)"),
+  image: z.string().min(1).optional(),
+  manifest: manifestSchema.optional(),
+});
+
 const pluginUpdateSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().min(10).max(500).optional(),
@@ -229,14 +235,7 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
   // ── PUT /api/developer/plugins/:pluginId/version — Push a new version ───
   .put("/plugins/:pluginId/version", async ({ params, body, user: sessionUser }) => {
     await checkUserRateLimit(sessionUser.id, RL.DEVELOPER_PLUGIN_VERSION_PUSH, 10, 3_600_000);
-
-    const parsed = body as { version?: string; image?: string; manifest?: object } | null;
-    if (!parsed?.version || typeof parsed.version !== "string") {
-      throw new ValidationError("version is required");
-    }
-    if (!/^\d+\.\d+\.\d+$/.test(parsed.version)) {
-      throw new ValidationError("version must be semver format (e.g. 1.0.0)");
-    }
+    const data = validateInput(versionPushSchema, body);
 
     // Verify ownership
     const [plugin] = await db
@@ -254,15 +253,15 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
     if (!plugin.published) throw new ForbiddenError("Cannot push versions to unpublished plugins");
 
     const updates: Record<string, unknown> = {
-      version: parsed.version,
+      version: data.version,
       updatedAt: new Date(),
     };
-    if (parsed.image !== undefined) updates.image = parsed.image;
-    if (parsed.manifest !== undefined) updates.manifest = parsed.manifest;
+    if (data.image !== undefined) updates.image = data.image;
+    if (data.manifest !== undefined) updates.manifest = data.manifest;
 
     await db.update(pluginRegistry).set(updates).where(eq(pluginRegistry.id, params.pluginId));
 
-    return { success: true, version: parsed.version };
+    return { success: true, version: data.version };
   })
 
   // ── GET /api/developer/plugins/:pluginId/status — Check submission status

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -261,19 +261,22 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
 
     // Atomic conditional update — only succeeds if new version > current version
     // Compares semver parts numerically using SQL to avoid TOCTOU races
-    const [major, minor, patch] = data.version.split(".").map(Number);
+    const parts = data.version.split(".").map(Number);
+    const major = parts[0] ?? 0;
+    const minor = parts[1] ?? 0;
+    const patch = parts[2] ?? 0;
     const result = await db
       .update(pluginRegistry)
       .set(updates)
       .where(and(
         eq(pluginRegistry.id, params.pluginId),
         sql`(
-          split_part(${pluginRegistry.version}, '.', 1)::int < ${major!}
-          OR (split_part(${pluginRegistry.version}, '.', 1)::int = ${major!}
-              AND split_part(${pluginRegistry.version}, '.', 2)::int < ${minor!})
-          OR (split_part(${pluginRegistry.version}, '.', 1)::int = ${major!}
-              AND split_part(${pluginRegistry.version}, '.', 2)::int = ${minor!}
-              AND split_part(${pluginRegistry.version}, '.', 3)::int < ${patch!})
+          split_part(${pluginRegistry.version}, '.', 1)::int < ${major}
+          OR (split_part(${pluginRegistry.version}, '.', 1)::int = ${major}
+              AND split_part(${pluginRegistry.version}, '.', 2)::int < ${minor})
+          OR (split_part(${pluginRegistry.version}, '.', 1)::int = ${major}
+              AND split_part(${pluginRegistry.version}, '.', 2)::int = ${minor}
+              AND split_part(${pluginRegistry.version}, '.', 3)::int < ${patch})
         )`,
       ))
       .returning({ id: pluginRegistry.id });

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -243,6 +243,7 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
         id: pluginRegistry.id,
         authorUserId: pluginRegistry.authorUserId,
         published: pluginRegistry.published,
+        version: pluginRegistry.version,
       })
       .from(pluginRegistry)
       .where(eq(pluginRegistry.id, params.pluginId))
@@ -251,6 +252,18 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
     if (!plugin) throw new NotFoundError("Plugin");
     if (plugin.authorUserId !== sessionUser.id) throw new ForbiddenError("Not your plugin");
     if (!plugin.published) throw new ForbiddenError("Cannot push versions to unpublished plugins");
+
+    // Prevent same-version or downgrade pushes
+    const newParts = data.version.split(".").map(Number);
+    const curParts = plugin.version.split(".").map(Number);
+    let isNewer = false;
+    for (let i = 0; i < 3; i++) {
+      if ((newParts[i] ?? 0) > (curParts[i] ?? 0)) { isNewer = true; break; }
+      if ((newParts[i] ?? 0) < (curParts[i] ?? 0)) break;
+    }
+    if (!isNewer) {
+      throw new ValidationError(`Version ${data.version} must be greater than current version ${plugin.version}`);
+    }
 
     const updates: Record<string, unknown> = {
       version: data.version,

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -226,6 +226,45 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
     return { success: true };
   })
 
+  // ── PUT /api/developer/plugins/:pluginId/version — Push a new version ───
+  .put("/plugins/:pluginId/version", async ({ params, body, user: sessionUser }) => {
+    await checkUserRateLimit(sessionUser.id, RL.DEVELOPER_PLUGIN_VERSION_PUSH, 10, 3_600_000);
+
+    const parsed = body as { version?: string; image?: string; manifest?: object } | null;
+    if (!parsed?.version || typeof parsed.version !== "string") {
+      throw new ValidationError("version is required");
+    }
+    if (!/^\d+\.\d+\.\d+$/.test(parsed.version)) {
+      throw new ValidationError("version must be semver format (e.g. 1.0.0)");
+    }
+
+    // Verify ownership
+    const [plugin] = await db
+      .select({
+        id: pluginRegistry.id,
+        authorUserId: pluginRegistry.authorUserId,
+        published: pluginRegistry.published,
+      })
+      .from(pluginRegistry)
+      .where(eq(pluginRegistry.id, params.pluginId))
+      .limit(1);
+
+    if (!plugin) throw new NotFoundError("Plugin");
+    if (plugin.authorUserId !== sessionUser.id) throw new ForbiddenError("Not your plugin");
+    if (!plugin.published) throw new ForbiddenError("Cannot push versions to unpublished plugins");
+
+    const updates: Record<string, unknown> = {
+      version: parsed.version,
+      updatedAt: new Date(),
+    };
+    if (parsed.image !== undefined) updates.image = parsed.image;
+    if (parsed.manifest !== undefined) updates.manifest = parsed.manifest;
+
+    await db.update(pluginRegistry).set(updates).where(eq(pluginRegistry.id, params.pluginId));
+
+    return { success: true, version: parsed.version };
+  })
+
   // ── GET /api/developer/plugins/:pluginId/status — Check submission status
   .get("/plugins/:pluginId/status", async ({ params, user: sessionUser }) => {
     // Verify ownership

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, and, sql } from "drizzle-orm";
 import { z } from "zod";
 import { NotFoundError, ForbiddenError, ValidationError } from "@uncorded/shared";
 import { db } from "../db/index.js";
@@ -253,26 +253,34 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
     if (plugin.authorUserId !== sessionUser.id) throw new ForbiddenError("Not your plugin");
     if (!plugin.published) throw new ForbiddenError("Cannot push versions to unpublished plugins");
 
-    // Prevent same-version or downgrade pushes
-    const newParts = data.version.split(".").map(Number);
-    const curParts = plugin.version.split(".").map(Number);
-    let isNewer = false;
-    for (let i = 0; i < 3; i++) {
-      if ((newParts[i] ?? 0) > (curParts[i] ?? 0)) { isNewer = true; break; }
-      if ((newParts[i] ?? 0) < (curParts[i] ?? 0)) break;
-    }
-    if (!isNewer) {
-      throw new ValidationError(`Version ${data.version} must be greater than current version ${plugin.version}`);
-    }
-
     const updates: Record<string, unknown> = {
       version: data.version,
-      updatedAt: new Date(),
     };
     if (data.image !== undefined) updates.image = data.image;
     if (data.manifest !== undefined) updates.manifest = data.manifest;
 
-    await db.update(pluginRegistry).set(updates).where(eq(pluginRegistry.id, params.pluginId));
+    // Atomic conditional update — only succeeds if new version > current version
+    // Compares semver parts numerically using SQL to avoid TOCTOU races
+    const [major, minor, patch] = data.version.split(".").map(Number);
+    const result = await db
+      .update(pluginRegistry)
+      .set(updates)
+      .where(and(
+        eq(pluginRegistry.id, params.pluginId),
+        sql`(
+          split_part(${pluginRegistry.version}, '.', 1)::int < ${major!}
+          OR (split_part(${pluginRegistry.version}, '.', 1)::int = ${major!}
+              AND split_part(${pluginRegistry.version}, '.', 2)::int < ${minor!})
+          OR (split_part(${pluginRegistry.version}, '.', 1)::int = ${major!}
+              AND split_part(${pluginRegistry.version}, '.', 2)::int = ${minor!}
+              AND split_part(${pluginRegistry.version}, '.', 3)::int < ${patch!})
+        )`,
+      ))
+      .returning({ id: pluginRegistry.id });
+
+    if (result.length === 0) {
+      throw new ValidationError(`Version ${data.version} must be greater than the current version`);
+    }
 
     return { success: true, version: data.version };
   })

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -9,10 +9,17 @@ import { getClientIp } from "../helpers/request.js";
 import { RL } from "../helpers/rate-limit-keys.js";
 
 function compareSemver(a: string, b: string): number {
-  const [coreA, preA] = a.split("-", 2);
-  const [coreB, preB] = b.split("-", 2);
-  const pa = (coreA ?? "").replace(/\+.*$/, "").split(".").map((s) => Number(s) || 0);
-  const pb = (coreB ?? "").replace(/\+.*$/, "").split(".").map((s) => Number(s) || 0);
+  // Strip build metadata first, then split core from prerelease at first hyphen
+  const cleanA = a.split("+")[0] ?? a;
+  const cleanB = b.split("+")[0] ?? b;
+  const dashA = cleanA.indexOf("-");
+  const dashB = cleanB.indexOf("-");
+  const coreA = dashA === -1 ? cleanA : cleanA.slice(0, dashA);
+  const preA = dashA === -1 ? undefined : cleanA.slice(dashA + 1);
+  const coreB = dashB === -1 ? cleanB : cleanB.slice(0, dashB);
+  const preB = dashB === -1 ? undefined : cleanB.slice(dashB + 1);
+  const pa = coreA.split(".").map((s) => Number(s) || 0);
+  const pb = coreB.split(".").map((s) => Number(s) || 0);
   for (let i = 0; i < 3; i++) {
     const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
     if (diff !== 0) return diff;
@@ -294,13 +301,26 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
       throw new RateLimitError("Too many requests, try again later");
     }
 
-    const parsed = body as { plugins?: { id: string; version: string }[] } | null;
+    const parsed = body as { plugins?: unknown[] } | null;
     if (!parsed?.plugins || !Array.isArray(parsed.plugins) || parsed.plugins.length === 0) {
       return { updates: [] };
     }
 
-    // Cap input to 50 plugins per request
-    const input = parsed.plugins.slice(0, 50);
+    // Validate and filter entries — only keep objects with string id and version
+    const validEntries: { id: string; version: string }[] = [];
+    for (const entry of parsed.plugins.slice(0, 50)) {
+      if (
+        entry && typeof entry === "object" &&
+        "id" in entry && typeof (entry as Record<string, unknown>).id === "string" &&
+        "version" in entry && typeof (entry as Record<string, unknown>).version === "string"
+      ) {
+        validEntries.push(entry as { id: string; version: string });
+      }
+    }
+
+    if (validEntries.length === 0) return { updates: [] };
+
+    const input = validEntries;
     const ids = input.map((p) => p.id);
 
     const rows = await db

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { eq, and, sql, desc } from "drizzle-orm";
+import { eq, and, sql, desc, inArray } from "drizzle-orm";
 import { NotFoundError, RateLimitError } from "@uncorded/shared";
 import { db } from "../db/index.js";
 import { pluginRegistry, pluginInstalls, bots, user } from "../db/schema.js";
@@ -7,6 +7,16 @@ import { authResolve } from "../middleware/auth.js";
 import { checkIpRateLimit } from "../middleware/ip-rate-limit.js";
 import { getClientIp } from "../helpers/request.js";
 import { RL } from "../helpers/rate-limit-keys.js";
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
 
 // ── Public routes (no auth) ─────────────────────────────────────────────────
 
@@ -245,4 +255,47 @@ export const pluginRoutes = new Elysia({ prefix: "/api/plugins" })
       .where(eq(pluginInstalls.pluginId, params.pluginId));
 
     return { success: true, installCount: countRow?.count ?? 0 };
+  })
+
+  // ── POST /api/plugins/check-updates — batch version check ───────────
+  .post("/check-updates", async ({ body, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 10, 60_000, RL.PLUGIN_CHECK_UPDATES))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
+
+    const parsed = body as { plugins?: { id: string; version: string }[] } | null;
+    if (!parsed?.plugins || !Array.isArray(parsed.plugins) || parsed.plugins.length === 0) {
+      return { updates: [] };
+    }
+
+    // Cap input to 50 plugins per request
+    const input = parsed.plugins.slice(0, 50);
+    const ids = input.map((p) => p.id);
+
+    const rows = await db
+      .select({
+        id: pluginRegistry.id,
+        version: pluginRegistry.version,
+        manifest: pluginRegistry.manifest,
+      })
+      .from(pluginRegistry)
+      .where(and(eq(pluginRegistry.published, true), inArray(pluginRegistry.id, ids)));
+
+    const inputMap = new Map(input.map((p) => [p.id, p.version]));
+
+    const updates = rows
+      .filter((row) => {
+        const currentVersion = inputMap.get(row.id);
+        if (!currentVersion || !row.version) return false;
+        return compareSemver(row.version, currentVersion) > 0;
+      })
+      .map((row) => ({
+        pluginId: row.id,
+        currentVersion: inputMap.get(row.id)!,
+        latestVersion: row.version,
+        manifest: row.manifest,
+      }));
+
+    return { updates };
   });

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -9,11 +9,41 @@ import { getClientIp } from "../helpers/request.js";
 import { RL } from "../helpers/rate-limit-keys.js";
 
 function compareSemver(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
+  const [coreA, preA] = a.split("-", 2);
+  const [coreB, preB] = b.split("-", 2);
+  const pa = (coreA ?? "").replace(/\+.*$/, "").split(".").map((s) => Number(s) || 0);
+  const pb = (coreB ?? "").replace(/\+.*$/, "").split(".").map((s) => Number(s) || 0);
   for (let i = 0; i < 3; i++) {
     const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
     if (diff !== 0) return diff;
+  }
+  // A version without prerelease is greater than one with prerelease
+  if (!preA && preB) return 1;
+  if (preA && !preB) return -1;
+  if (preA && preB) {
+    const partsA = preA.split(".");
+    const partsB = preB.split(".");
+    const len = Math.max(partsA.length, partsB.length);
+    for (let i = 0; i < len; i++) {
+      const segA = partsA[i];
+      const segB = partsB[i];
+      if (segA === undefined) return -1;
+      if (segB === undefined) return 1;
+      const numA = Number(segA);
+      const numB = Number(segB);
+      const aIsNum = !Number.isNaN(numA);
+      const bIsNum = !Number.isNaN(numB);
+      if (aIsNum && bIsNum) {
+        if (numA !== numB) return numA - numB;
+      } else if (aIsNum) {
+        return -1; // numeric < non-numeric
+      } else if (bIsNum) {
+        return 1;
+      } else {
+        const cmp = segA < segB ? -1 : segA > segB ? 1 : 0;
+        if (cmp !== 0) return cmp;
+      }
+    }
   }
   return 0;
 }

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createResource, For, Show } from "solid-js";
+import { createSignal, createResource, For, Show, onMount, onCleanup } from "solid-js";
 import type { ServerId, PluginId, UserId } from "@uncorded/protocol";
 import { api } from "../../lib/api.js";
 import { showToast } from "../ui/toast.js";
@@ -7,6 +7,7 @@ import { Button } from "../ui/button.js";
 import { PluginCard, type PluginCardData } from "../ui/plugin-card.js";
 import { readyData } from "../../lib/gateway-store.js";
 import { isDesktop } from "../../stores/plugin-store.js";
+import type { PluginUpdateInfo } from "../../types/desktop-bridge.js";
 
 interface ServerPluginsProps {
   serverId: ServerId;
@@ -43,7 +44,17 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
   const [installing, setInstalling] = createSignal<PluginId | null>(null);
   const [uninstalling, setUninstalling] = createSignal<PluginId | null>(null);
   const [toggling, setToggling] = createSignal<PluginId | null>(null);
+  const [updating, setUpdating] = createSignal<PluginId | null>(null);
   const [search, setSearch] = createSignal("");
+  const [pluginUpdates, setPluginUpdates] = createSignal<PluginUpdateInfo[]>([]);
+
+  onMount(() => {
+    if (!isDesktop()) return;
+    const bridge = window.desktopBridge;
+    if (!bridge?.plugins?.onUpdatesAvailable) return;
+    const unsub = bridge.plugins.onUpdatesAvailable((updates) => setPluginUpdates(updates));
+    onCleanup(unsub);
+  });
 
   const isServerOwnerTier = () =>
     readyData.data?.user.subscriptionTier === "server_owner";
@@ -198,6 +209,21 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     }
   }
 
+  async function handleUpdate(pluginId: PluginId) {
+    if (!isDesktop()) return;
+    setUpdating(pluginId);
+    try {
+      await window.desktopBridge!.plugins.update(pluginId);
+      showToast("Plugin updated successfully", "info");
+      setPluginUpdates((prev) => prev.filter((u) => u.pluginId !== pluginId));
+      await refetchInstalled();
+    } catch (err) {
+      handleApiError(err, "Failed to update plugin");
+    } finally {
+      setUpdating(null);
+    }
+  }
+
   return (
     <div class="space-y-6">
       <div>
@@ -239,9 +265,28 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
                 <PluginCard
                   plugin={installedToCardData(plugin)}
                   status={stateStatus(plugin.state)}
+                  badge={
+                    <Show when={pluginUpdates().find((u) => u.pluginId === plugin.pluginId)}>
+                      {(update) => (
+                        <span class="inline-flex items-center gap-1 rounded-full bg-warning/20 px-2 py-0.5 text-xs font-medium text-warning">
+                          v{update().availableVersion} available
+                        </span>
+                      )}
+                    </Show>
+                  }
                   actions={
                     <Show when={isServerOwnerTier()}>
                       <div class="flex gap-2">
+                        <Show when={pluginUpdates().find((u) => u.pluginId === plugin.pluginId)}>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleUpdate(plugin.pluginId)}
+                            disabled={updating() === plugin.pluginId}
+                          >
+                            {updating() === plugin.pluginId ? "Updating..." : "Update"}
+                          </Button>
+                        </Show>
                         <Button
                           variant="outline"
                           size="sm"

--- a/apps/web/src/components/ui/plugin-card.tsx
+++ b/apps/web/src/components/ui/plugin-card.tsx
@@ -20,6 +20,8 @@ interface PluginCardProps {
   plugin: PluginCardData;
   /** Status indicator (e.g., "Running", "Stopped") — shown as a dot + label */
   status?: { label: string; color: string } | undefined;
+  /** Extra badge rendered after the status indicator */
+  badge?: JSX.Element | undefined;
   /** Action buttons rendered on the right side */
   actions?: JSX.Element | undefined;
 }
@@ -88,6 +90,7 @@ export const PluginCard = (props: PluginCardProps) => {
                 </span>
               )}
             </Show>
+            <Show when={props.badge}>{props.badge}</Show>
           </div>
           <p class="mt-1 text-sm text-muted-foreground">{p().description}</p>
           <div class="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">

--- a/apps/web/src/types/desktop-bridge.d.ts
+++ b/apps/web/src/types/desktop-bridge.d.ts
@@ -19,6 +19,13 @@ interface UpdateResult {
   state: UpdateState;
 }
 
+interface PluginUpdateInfo {
+  pluginId: string;
+  currentVersion: string;
+  availableVersion: string;
+  updateType: "major" | "minor" | "patch";
+}
+
 interface DesktopBridgePlugins {
   getAll(): Promise<PluginInfo[]>;
   onStateChange(listener: (plugins: PluginInfo[]) => void): () => void;
@@ -27,6 +34,8 @@ interface DesktopBridgePlugins {
   restart(pluginId: string): Promise<void>;
   getPermissions(pluginId: string): Promise<string[]>;
   uninstall(pluginId: string): Promise<void>;
+  onUpdatesAvailable(listener: (updates: PluginUpdateInfo[]) => void): () => void;
+  update(pluginId: string): Promise<void>;
 }
 
 interface DesktopBridge {
@@ -49,4 +58,4 @@ declare global {
   }
 }
 
-export {};
+export type { PluginUpdateInfo };


### PR DESCRIPTION
## Summary

- **Server:** Batch version check endpoint (`POST /api/plugins/check-updates`) and developer version push (`PUT /api/developer/plugins/:pluginId/version`) with ownership verification, semver validation, and rate limiting
- **Sidecar:** New `update-checker` module that checks for updates on startup, auto-applies minor/patch updates, and caches major updates for user approval via management endpoints
- **Electron:** Polls sidecar for pending major updates every ~60s, broadcasts to renderer via IPC, and exposes `onUpdatesAvailable()` + `update()` on the preload bridge
- **Frontend:** Update badge ("v2.0.0 available") and "Update" button on installed plugin cards in server plugin settings, with toast feedback

## Commits

- `089a5ed` feat: plugin auto-update system (Phase 3)

## Test plan

- [ ] `bun run typecheck` passes (verified)
- [ ] `bun run lint` passes with 0 errors (verified)
- [ ] Publish a test plugin at v1.0.0, install on desktop
- [ ] Push v1.0.1 via `PUT /api/developer/plugins/:id/version` → restart desktop → plugin auto-updates silently (check sidecar logs for `[update-checker] Auto-updated:`)
- [ ] Push v2.0.0 → user sees "v2.0.0 available" badge in server plugin settings + "Update" button
- [ ] Click "Update" → plugin updates, badge disappears, toast shows success
- [ ] `POST /api/plugins/check-updates` returns correct diff when called with outdated versions
- [ ] Rate limits enforced on both new endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic background plugin update checks and periodic polling.
  * Desktop UI shows available plugin updates with version and update-type badges.
  * “Update” action in Settings to apply updates with per-plugin progress feedback.

* **Improvements**
  * Update availability is broadcast so UI stays in sync across windows.
  * Desktop bridge exposes update events and a trigger to initiate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->