### PR TITLE
fix: patch critical XSS and iframe sandbox escape

### DIFF
--- a/apps/server/drizzle/0019_tunnel_url_https_constraint.sql
+++ b/apps/server/drizzle/0019_tunnel_url_https_constraint.sql
@@ -1,0 +1,4 @@
+-- Backfill non-HTTPS tunnel URLs to NULL
+UPDATE server_plugins SET tunnel_url = NULL WHERE tunnel_url IS NOT NULL AND tunnel_url NOT LIKE 'https://%';--> statement-breakpoint
+-- Enforce HTTPS-only tunnel URLs at DB level
+ALTER TABLE server_plugins ADD CONSTRAINT server_plugins_tunnel_url_https_chk CHECK (tunnel_url IS NULL OR tunnel_url LIKE 'https://%');

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1743436800000,
       "tag": "0018_plugin_submissions",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1743523200000,
+      "tag": "0019_tunnel_url_https_constraint",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/helpers/rate-limit-keys.ts
+++ b/apps/server/src/helpers/rate-limit-keys.ts
@@ -11,6 +11,7 @@ export const RL = {
   SERVER_PLUGIN_INSTALL: "server-plugin-install",
   SERVER_PLUGIN_UNINSTALL: "server-plugin-uninstall",
   SERVER_PLUGIN_UPDATE: "server-plugin-update",
+  SERVER_PLUGIN_TUNNEL_READ: "server-plugin-tunnel-read",
   INVITE_LOOKUP: "invite-lookup",
   PLUGIN_CHECK_UPDATES: "plugin-check-updates",
 

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -36,6 +36,11 @@ const updateTunnelSchema = z.object({
   state: z.string().optional(),
 });
 
+function normalizeTunnelUrl(url: string | null): string | null {
+  if (!url) return null;
+  return url.startsWith("https://") ? url : null;
+}
+
 function safeJsonParse(value: string | null): Record<string, unknown> {
   if (!value) return {};
   try {
@@ -210,7 +215,7 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
       throw new NotFoundError("Server plugin");
     }
 
-    return { tunnelUrl: row.tunnelUrl, state: row.state };
+    return { tunnelUrl: normalizeTunnelUrl(row.tunnelUrl), state: row.state };
   })
 
   // ── PUT /:pluginId/tunnel — update tunnel URL (owner, called by sidecar)

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -28,7 +28,11 @@ const updatePluginSchema = z.object({
 });
 
 const updateTunnelSchema = z.object({
-  tunnelUrl: z.string().nullable(),
+  tunnelUrl: z
+    .string()
+    .url()
+    .refine((u) => u.startsWith("https://"), { message: "tunnelUrl must use https://" })
+    .nullable(),
   state: z.string().optional(),
 });
 

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -205,7 +205,7 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
   // ── GET /:pluginId/tunnel — get tunnel URL (any member) ────────────────
   .get("/:pluginId/tunnel", async ({ user: sessionUser, params, request }) => {
     const ip = getClientIp(request);
-    if (!(await checkIpRateLimit(ip, 30, 60_000, RL.SERVER_PLUGIN_UPDATE))) {
+    if (!(await checkIpRateLimit(ip, 30, 60_000, RL.SERVER_PLUGIN_TUNNEL_READ))) {
       throw new RateLimitError("Too many requests, try again later");
     }
 

--- a/apps/server/src/routes/server-plugins.ts
+++ b/apps/server/src/routes/server-plugins.ts
@@ -38,7 +38,12 @@ const updateTunnelSchema = z.object({
 
 function normalizeTunnelUrl(url: string | null): string | null {
   if (!url) return null;
-  return url.startsWith("https://") ? url : null;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
 }
 
 function safeJsonParse(value: string | null): Record<string, unknown> {
@@ -198,7 +203,12 @@ export const serverPluginRoutes = new Elysia({ prefix: "/api/servers/:serverId/p
   })
 
   // ── GET /:pluginId/tunnel — get tunnel URL (any member) ────────────────
-  .get("/:pluginId/tunnel", async ({ user: sessionUser, params }) => {
+  .get("/:pluginId/tunnel", async ({ user: sessionUser, params, request }) => {
+    const ip = getClientIp(request);
+    if (!(await checkIpRateLimit(ip, 30, 60_000, RL.SERVER_PLUGIN_UPDATE))) {
+      throw new RateLimitError("Too many requests, try again later");
+    }
+
     await requireMember(sessionUser.id, params.serverId);
 
     const [row] = await db

--- a/apps/web/src/components/MessageContent.tsx
+++ b/apps/web/src/components/MessageContent.tsx
@@ -2,6 +2,14 @@ import { Lexer, type Token, type Tokens } from "marked";
 import { For, Show } from "solid-js";
 import type { JSX } from "solid-js";
 
+function sanitizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url, "https://placeholder.invalid");
+    if (["http:", "https:", "mailto:"].includes(parsed.protocol)) return url;
+  } catch { /* invalid URL */ }
+  return "#";
+}
+
 function renderInlineTokens(tokens: Token[]): JSX.Element {
   return <For each={tokens}>{(t) => renderToken(t)}</For>;
 }
@@ -29,7 +37,7 @@ function renderToken(token: Token): JSX.Element {
     case "link":
       return (
         <a
-          href={(token as Tokens.Link).href}
+          href={sanitizeUrl((token as Tokens.Link).href)}
           target="_blank"
           rel="noopener noreferrer"
           class="text-primary underline underline-offset-2 hover:text-primary/80"

--- a/apps/web/src/components/PluginFrame.tsx
+++ b/apps/web/src/components/PluginFrame.tsx
@@ -38,9 +38,15 @@ const PluginFrame = (props: PluginFrameProps) => {
   // Determine the iframe URL based on scope
   const iframeUrl = () => {
     // Tunnel URL takes priority (server plugin for browser user)
-    if (props.tunnelUrl) return props.tunnelUrl;
+    if (props.tunnelUrl) {
+      if (!props.tunnelUrl.startsWith("https://")) return null;
+      return props.tunnelUrl;
+    }
     // Server plugin with tunnel URL from plugin info
-    if (props.plugin.scope === "server" && props.plugin.tunnelUrl) return props.plugin.tunnelUrl;
+    if (props.plugin.scope === "server" && props.plugin.tunnelUrl) {
+      if (!props.plugin.tunnelUrl.startsWith("https://")) return null;
+      return props.plugin.tunnelUrl;
+    }
     // Local plugin (personal or server on desktop owner)
     if (props.plugin.port) return `http://localhost:${props.plugin.port}/`;
     return null;
@@ -119,7 +125,7 @@ const PluginFrame = (props: PluginFrameProps) => {
       <Show when={(props.plugin.status === "running" || props.tunnelUrl) && !error() && !isOffline()}>
         <iframe
           src={iframeUrl()!}
-          sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
+          sandbox="allow-scripts allow-forms allow-popups"
           allow="clipboard-write"
           referrerpolicy="no-referrer"
           class="h-full w-full border-none"


### PR DESCRIPTION
## Summary
- Remove `allow-same-origin` from plugin iframe sandbox to prevent sandbox escape
- Sanitize markdown link hrefs to block `javascript:`, `data:`, and `vbscript:` XSS vectors
- Validate tunnel URLs enforce `https://` scheme on both server and client

## Security Issues Addressed
- **Critical:** iframe sandbox escape via `allow-scripts` + `allow-same-origin` combination
- **Critical:** Stored XSS through markdown links with `javascript:` URIs
- **Critical:** Unvalidated tunnel URLs allowing SSRF, phishing, and script injection

## Test plan
- [ ] Verify plugins still load and communicate via postMessage bridge
- [ ] Test markdown messages with `javascript:` links render as `#` href
- [ ] Confirm tunnel URL rejects non-https schemes
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced HTTPS-only tunnel URLs; non-HTTPS tunnels are treated as unavailable and will no longer load in iframes.
  * Improved URL sanitization for rendered links to block unsafe protocols.
  * Tightened iframe sandbox permissions to reduce exposure to unsafe content.

* **Chores**
  * Backfilled and enforced HTTPS constraint for stored tunnel URLs via a database migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->