### PR TITLE
fix: harden server auth and rate limiting

### DIFF
--- a/apps/server/src/helpers/request.ts
+++ b/apps/server/src/helpers/request.ts
@@ -1,7 +1,14 @@
+/**
+ * Extract client IP from proxy headers.
+ *
+ * SECURITY: This trusts X-Forwarded-For / X-Real-IP headers.
+ * The server MUST run behind a reverse proxy (nginx) that sets these.
+ * Direct exposure without a proxy allows IP spoofing to bypass rate limits.
+ */
 export function getClientIp(request: Request): string {
   return (
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     request.headers.get("x-real-ip") ??
-    "unknown"
+    "0.0.0.0"
   );
 }

--- a/apps/server/src/middleware/ip-rate-limit.ts
+++ b/apps/server/src/middleware/ip-rate-limit.ts
@@ -43,10 +43,12 @@ async function checkViaRedis(key: string, limit: number, windowMs: number): Prom
   const ttlSeconds = Math.ceil(windowMs / 1000);
 
   try {
-    const count = await redis!.incr(redisKey);
-    if (count === 1) {
-      await redis!.expire(redisKey, ttlSeconds);
-    }
+    const count = (await redis!.eval(
+      "local c = redis.call('INCR', KEYS[1]); if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end; return c",
+      1,
+      redisKey,
+      ttlSeconds,
+    )) as number;
     return count <= limit;
   } catch {
     return checkInMemory(key, limit, windowMs);

--- a/apps/server/src/routes/gateway.ts
+++ b/apps/server/src/routes/gateway.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { AppError } from "@uncorded/shared";
+import { AppError, RateLimitError } from "@uncorded/shared";
 import { authResolve } from "../middleware/auth.js";
 import { redis } from "../lib/redis.js";
 
@@ -48,24 +48,31 @@ export async function consumeTicket(ticket: string): Promise<string | null> {
 export const gatewayTicketRoutes = new Elysia({ prefix: "/api/gateway" })
   .resolve(authResolve({ allowBots: true }))
   .post("/ticket", async ({ user: sessionUser }) => {
-    // Per-user ticket cap
+    // Atomic check-and-increment to prevent TOCTOU bypass under concurrency
     const currentCount = userTicketCounts.get(sessionUser.id) ?? 0;
     if (currentCount >= USER_MAX_TICKETS) {
-      throw new AppError(
-        "RateLimitError",
-        429,
-        "RATE_LIMITED",
-        "Too many outstanding tickets",
-      );
+      throw new RateLimitError("Too many outstanding tickets");
     }
+    userTicketCounts.set(sessionUser.id, currentCount + 1);
 
     const ticket = crypto.randomUUID();
     const redisKey = `ws:ticket:${ticket}`;
 
-    if (redis) {
-      try {
-        await redis.set(redisKey, sessionUser.id, "EX", TICKET_TTL_SECONDS);
-      } catch {
+    try {
+      if (redis) {
+        try {
+          await redis.set(redisKey, sessionUser.id, "EX", TICKET_TTL_SECONDS);
+        } catch {
+          if (!storeTicketInMemory(ticket, sessionUser.id, TICKET_TTL_SECONDS * 1000)) {
+            throw new AppError(
+              "ServiceUnavailableError",
+              503,
+              "SERVICE_UNAVAILABLE",
+              "Ticket store at capacity",
+            );
+          }
+        }
+      } else {
         if (!storeTicketInMemory(ticket, sessionUser.id, TICKET_TTL_SECONDS * 1000)) {
           throw new AppError(
             "ServiceUnavailableError",
@@ -75,19 +82,17 @@ export const gatewayTicketRoutes = new Elysia({ prefix: "/api/gateway" })
           );
         }
       }
-    } else {
-      if (!storeTicketInMemory(ticket, sessionUser.id, TICKET_TTL_SECONDS * 1000)) {
-        throw new AppError(
-          "ServiceUnavailableError",
-          503,
-          "SERVICE_UNAVAILABLE",
-          "Ticket store at capacity",
-        );
+    } catch (err) {
+      // Roll back the counter if ticket storage failed
+      const c = userTicketCounts.get(sessionUser.id);
+      if (c !== undefined) {
+        if (c <= 1) userTicketCounts.delete(sessionUser.id);
+        else userTicketCounts.set(sessionUser.id, c - 1);
       }
+      throw err;
     }
 
-    // Track per-user ticket count with auto-decrement on TTL
-    userTicketCounts.set(sessionUser.id, (userTicketCounts.get(sessionUser.id) ?? 0) + 1);
+    // Auto-decrement after TTL
     const timer = setTimeout(() => {
       const c = userTicketCounts.get(sessionUser.id);
       if (c !== undefined) {

--- a/apps/server/src/routes/gateway.ts
+++ b/apps/server/src/routes/gateway.ts
@@ -8,6 +8,10 @@ import { redis } from "../lib/redis.js";
 const MAX_IN_MEMORY_TICKETS = 10_000;
 const tickets = new Map<string, string>();
 
+// Per-user ticket cap (prevent a single user from exhausting the store)
+const USER_MAX_TICKETS = 5;
+const userTicketCounts = new Map<string, number>();
+
 function storeTicketInMemory(ticket: string, uid: string, ttlMs: number): boolean {
   if (tickets.size >= MAX_IN_MEMORY_TICKETS) return false;
   tickets.set(ticket, uid);
@@ -44,6 +48,17 @@ export async function consumeTicket(ticket: string): Promise<string | null> {
 export const gatewayTicketRoutes = new Elysia({ prefix: "/api/gateway" })
   .resolve(authResolve({ allowBots: true }))
   .post("/ticket", async ({ user: sessionUser }) => {
+    // Per-user ticket cap
+    const currentCount = userTicketCounts.get(sessionUser.id) ?? 0;
+    if (currentCount >= USER_MAX_TICKETS) {
+      throw new AppError(
+        "RateLimitError",
+        429,
+        "RATE_LIMITED",
+        "Too many outstanding tickets",
+      );
+    }
+
     const ticket = crypto.randomUUID();
     const redisKey = `ws:ticket:${ticket}`;
 
@@ -70,6 +85,17 @@ export const gatewayTicketRoutes = new Elysia({ prefix: "/api/gateway" })
         );
       }
     }
+
+    // Track per-user ticket count with auto-decrement on TTL
+    userTicketCounts.set(sessionUser.id, (userTicketCounts.get(sessionUser.id) ?? 0) + 1);
+    const timer = setTimeout(() => {
+      const c = userTicketCounts.get(sessionUser.id);
+      if (c !== undefined) {
+        if (c <= 1) userTicketCounts.delete(sessionUser.id);
+        else userTicketCounts.set(sessionUser.id, c - 1);
+      }
+    }, TICKET_TTL_SECONDS * 1000);
+    timer.unref();
 
     return { ticket };
   });

--- a/apps/server/src/ws/rate-limit.ts
+++ b/apps/server/src/ws/rate-limit.ts
@@ -43,14 +43,14 @@ async function checkViaRedis(key: string, limit: number, windowMs: number): Prom
   const ttlSeconds = Math.ceil(windowMs / 1000);
 
   try {
-    const count = await redis!.incr(redisKey);
-    if (count === 1) {
-      // First request in window — set expiry
-      await redis!.expire(redisKey, ttlSeconds);
-    }
+    const count = (await redis!.eval(
+      "local c = redis.call('INCR', KEYS[1]); if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end; return c",
+      1,
+      redisKey,
+      ttlSeconds,
+    )) as number;
     return count <= limit;
   } catch {
-    // Redis error — fall back to in-memory
     return checkInMemory(key, limit, windowMs);
   }
 }


### PR DESCRIPTION
## Summary
- Document nginx proxy dependency for IP extraction, use 0.0.0.0 fallback instead of "unknown"
- Make Redis INCR/EXPIRE atomic via Lua script in IP and WS rate limiters
- Add per-user cap (5) on gateway tickets to prevent store exhaustion

## Security Issues Addressed
- **High:** IP spoofing could bypass all IP-based rate limits (documented proxy requirement, safer fallback)
- **Medium:** Non-atomic Redis INCR/EXPIRE could permanently block IPs on crash
- **Low:** Single user could exhaust gateway ticket store

## Test plan
- [ ] Verify rate limiting still works (IP + WS)
- [ ] Confirm gateway ticket generation works with cap
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented per-user outstanding ticket rate limiting that restricts how many concurrent ticket requests a user can submit at once, enhancing platform stability and preventing potential system abuse through excessive submissions.

* **Performance Improvements**
  * Optimized rate-limiting mechanisms across HTTP and WebSocket connections with atomic database operations for improved efficiency, reduced latency, and better consistency in request handling and IP detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->