### PR TITLE
fix: harden WebSocket connection and file session handling

### DIFF
--- a/apps/server/src/ws/connections.ts
+++ b/apps/server/src/ws/connections.ts
@@ -14,12 +14,26 @@ import { lookupDmChannel, addDmChannelToCache } from "./channel-cache.js";
 /** userId → set of active WebSocket connections (supports multiple tabs) */
 export const clients = new Map<string, Set<AnyServerWebSocket>>();
 
+const MAX_CONNECTIONS_PER_USER = 10;
+
 export function addConnection(userId: string, ws: AnyServerWebSocket): void {
   let set = clients.get(userId);
   if (!set) {
     set = new Set();
     clients.set(userId, set);
   }
+
+  // Enforce per-user connection cap — close oldest if at limit
+  if (set.size >= MAX_CONNECTIONS_PER_USER) {
+    const oldest = set.values().next().value;
+    if (oldest) {
+      try {
+        oldest.close(4008, "Too many connections");
+      } catch { /* already closed */ }
+      set.delete(oldest);
+    }
+  }
+
   set.add(ws);
 }
 

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -28,6 +28,7 @@ interface FileSession {
   participants: Set<string>;
   completedParticipants: Set<string>;
   createdAt: Date;
+  lastActivityAt: number;
 }
 
 // ── In-Memory Store ─────────────────────────────────────────────────────────
@@ -36,18 +37,32 @@ const activeSessions = new Map<string, FileSession>();
 
 const FILE_SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
 
-// Periodic sweep for stale file sessions
+/** Notify sender, participants, and pending invitees that a session is closing. */
+function fanoutSessionClose(id: string, session: FileSession): void {
+  const payload = { op: Opcode.FILE_SESSION_CLOSE, d: { sessionId: id } } as const;
+
+  // Notify sender
+  sendToUser(session.senderId, payload);
+
+  // Notify joined participants
+  for (const participantId of session.participants) {
+    sendToUser(participantId, payload);
+  }
+
+  // Notify invited-but-not-joined users
+  for (const inviteeId of session.invitees) {
+    if (!session.participants.has(inviteeId)) {
+      sendToUser(inviteeId, payload);
+    }
+  }
+}
+
+// Periodic sweep for stale file sessions (inactivity-based)
 const sweepTimer = setInterval(() => {
   const now = Date.now();
   for (const [id, session] of activeSessions) {
-    if (now - session.createdAt.getTime() > FILE_SESSION_TTL_MS) {
-      // Notify participants before cleanup
-      for (const participantId of session.participants) {
-        sendToUser(participantId, {
-          op: Opcode.FILE_SESSION_CLOSE,
-          d: { sessionId: id },
-        });
-      }
+    if (now - session.lastActivityAt > FILE_SESSION_TTL_MS) {
+      fanoutSessionClose(id, session);
       activeSessions.delete(id);
     }
   }
@@ -106,6 +121,7 @@ export async function handleFileSessionCreate(
     participants: new Set(),
     completedParticipants: new Set(),
     createdAt: new Date(),
+    lastActivityAt: Date.now(),
   };
   activeSessions.set(session.id, session);
 
@@ -149,6 +165,7 @@ export async function handleFileSessionJoin(
   if (session.participants.has(joiningUserId)) return;
 
   session.participants.add(joiningUserId);
+  session.lastActivityAt = Date.now();
 
   // Send magnetUri to the joining recipient so they can start downloading
   sendToUser(joiningUserId, {
@@ -188,6 +205,8 @@ export function handleFileSessionProgress(
   const session = activeSessions.get(data.sessionId);
   if (!session || !session.participants.has(reportingUserId)) return;
 
+  session.lastActivityAt = Date.now();
+
   sendToUser(session.senderId, {
     op: Opcode.FILE_SESSION_PROGRESS,
     d: {
@@ -208,6 +227,8 @@ export async function handleFileSessionComplete(
 
   // Dedupe: skip if already completed
   if (session.completedParticipants.has(reportingUserId)) return;
+
+  session.lastActivityAt = Date.now();
 
   // Create file receipt before marking complete (so retries can succeed if insert fails)
   try {
@@ -247,24 +268,7 @@ export function handleFileSessionClose(
   const session = activeSessions.get(data.sessionId);
   if (!session || session.senderId !== senderId) return;
 
-  // Notify all participants
-  for (const participantId of session.participants) {
-    sendToUser(participantId, {
-      op: Opcode.FILE_SESSION_CLOSE,
-      d: { sessionId: session.id },
-    });
-  }
-
-  // Also notify invited-but-not-joined users
-  for (const inviteeId of session.invitees) {
-    if (!session.participants.has(inviteeId)) {
-      sendToUser(inviteeId, {
-        op: Opcode.FILE_SESSION_CLOSE,
-        d: { sessionId: session.id },
-      });
-    }
-  }
-
+  fanoutSessionClose(session.id, session);
   activeSessions.delete(session.id);
 }
 
@@ -288,20 +292,7 @@ export function cleanupSessionsForUser(disconnectedUserId: string): void {
   for (const [sessionId, session] of activeSessions) {
     if (session.senderId === disconnectedUserId) {
       // Sender disconnected — close session for everyone
-      for (const participantId of session.participants) {
-        sendToUser(participantId, {
-          op: Opcode.FILE_SESSION_CLOSE,
-          d: { sessionId },
-        });
-      }
-      for (const inviteeId of session.invitees) {
-        if (!session.participants.has(inviteeId)) {
-          sendToUser(inviteeId, {
-            op: Opcode.FILE_SESSION_CLOSE,
-            d: { sessionId },
-          });
-        }
-      }
+      fanoutSessionClose(sessionId, session);
       activeSessions.delete(sessionId);
     } else {
       // Recipient disconnected — notify sender, remove from participants

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -69,6 +69,11 @@ const sweepTimer = setInterval(() => {
 }, 5 * 60 * 1000); // Sweep every 5 minutes
 sweepTimer.unref();
 
+/** Stop the periodic sweep (for graceful shutdown / tests). */
+export function clearFileSessionSweep(): void {
+  clearInterval(sweepTimer);
+}
+
 // ── Handlers ────────────────────────────────────────────────────────────────
 
 export async function handleFileSessionCreate(

--- a/apps/server/src/ws/file-sessions.ts
+++ b/apps/server/src/ws/file-sessions.ts
@@ -34,6 +34,26 @@ interface FileSession {
 
 const activeSessions = new Map<string, FileSession>();
 
+const FILE_SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+// Periodic sweep for stale file sessions
+const sweepTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [id, session] of activeSessions) {
+    if (now - session.createdAt.getTime() > FILE_SESSION_TTL_MS) {
+      // Notify participants before cleanup
+      for (const participantId of session.participants) {
+        sendToUser(participantId, {
+          op: Opcode.FILE_SESSION_CLOSE,
+          d: { sessionId: id },
+        });
+      }
+      activeSessions.delete(id);
+    }
+  }
+}, 5 * 60 * 1000); // Sweep every 5 minutes
+sweepTimer.unref();
+
 // ── Handlers ────────────────────────────────────────────────────────────────
 
 export async function handleFileSessionCreate(

--- a/apps/server/src/ws/gateway.ts
+++ b/apps/server/src/ws/gateway.ts
@@ -31,7 +31,7 @@ import {
 import { checkRateLimit } from "./rate-limit.js";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { user, messages, fileReceipts, dmMembers } from "../db/schema.js";
+import { user, messages, fileReceipts, dmMembers, channels } from "../db/schema.js";
 import { removeConnection, sendToUser, broadcastToServer, broadcastToDm } from "./connections.js";
 import { handleIdentify } from "./handlers.js";
 import { removeUserFromAllServers } from "./server-members.js";
@@ -283,6 +283,25 @@ export const gateway = new Elysia().ws("/gateway", {
               });
               break;
             }
+
+            // Check if file sharing is enabled for this channel
+            const [channelRow] = await db
+              .select({ fileSharingEnabled: channels.fileSharingEnabled })
+              .from(channels)
+              .where(eq(channels.id, d.channelId))
+              .limit(1);
+
+            if (channelRow && !channelRow.fileSharingEnabled) {
+              sendToUser(ctx.userId, {
+                op: Opcode.ERROR,
+                d: {
+                  code: "FILE_SHARING_DISABLED",
+                  message: "File sharing is disabled in this channel",
+                  channelId: d.channelId,
+                },
+              });
+              break;
+            }
           }
 
           resetIdleTimer(ctx.userId);
@@ -491,6 +510,21 @@ export const gateway = new Elysia().ws("/gateway", {
           if (!ctx.userId) {
             ws.close(CloseCode.NOT_IDENTIFIED, "Not identified");
             return;
+          }
+
+          if (
+            !(await checkRateLimit(
+              ctx.userId,
+              frame.op,
+              RATE_LIMIT_FILE_SESSION.limit,
+              RATE_LIMIT_FILE_SESSION.windowMs,
+            ))
+          ) {
+            sendToUser(ctx.userId, {
+              op: Opcode.ERROR,
+              d: { code: "RATE_LIMITED", message: "Too many file session requests" },
+            });
+            break;
           }
 
           const parsed = fileSessionJoinRequestSchema.safeParse(frame.d);

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -277,7 +277,7 @@ export const presenceUpdateEventSchema = z.object({
 
 /** Client → Server: create a share session */
 export const fileSessionCreateRequestSchema = z.object({
-  sessionId: z.string().min(1),
+  sessionId: z.string().min(1).max(36),
   fileName: z.string().min(1).max(MAX_FILE_NAME_LENGTH),
   fileSize: z.number().int().positive().max(MAX_FILE_SIZE_BYTES),
   contentType: z.string().min(1).max(MAX_CONTENT_TYPE_LENGTH),
@@ -288,29 +288,29 @@ export const fileSessionCreateRequestSchema = z.object({
 
 /** Client → Server: join a session */
 export const fileSessionJoinRequestSchema = z.object({
-  sessionId: z.string().min(1),
+  sessionId: z.string().min(1).max(36),
 });
 
 /** Client → Server: report download progress */
 export const fileSessionProgressRequestSchema = z.object({
-  sessionId: z.string().min(1),
+  sessionId: z.string().min(1).max(36),
   progress: z.number().min(0).max(1),
   speed: z.number().nonnegative(),
 });
 
 /** Client → Server: report download complete */
 export const fileSessionCompleteRequestSchema = z.object({
-  sessionId: z.string().min(1),
+  sessionId: z.string().min(1).max(36),
 });
 
 /** Client → Server: close session */
 export const fileSessionCloseRequestSchema = z.object({
-  sessionId: z.string().min(1),
+  sessionId: z.string().min(1).max(36),
 });
 
 /** Client → Server: leave session */
 export const fileSessionLeaveRequestSchema = z.object({
-  sessionId: z.string().min(1),
+  sessionId: z.string().min(1).max(36),
 });
 
 /** Server → Client: session invite */

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -319,7 +319,7 @@ export const fileSessionLeaveRequestSchema = z.object({
 
 /** Server → Client: session invite */
 export const fileSessionInviteEventSchema = z.object({
-  sessionId: z.string(),
+  sessionId: sessionIdSchema,
   senderId: z.string(),
   senderUsername: z.string(),
   senderDisplayName: z.string().nullable(),
@@ -331,13 +331,13 @@ export const fileSessionInviteEventSchema = z.object({
 
 /** Server → Client: magnetUri for the joining recipient */
 export const fileSessionJoinAcceptEventSchema = z.object({
-  sessionId: z.string(),
+  sessionId: sessionIdSchema,
   magnetUri: z.string(),
 });
 
 /** Server → Client: a user joined the session */
 export const fileSessionJoinedEventSchema = z.object({
-  sessionId: z.string(),
+  sessionId: sessionIdSchema,
   userId: z.string(),
   username: z.string(),
   displayName: z.string().nullable(),
@@ -346,7 +346,7 @@ export const fileSessionJoinedEventSchema = z.object({
 
 /** Server → Client: progress update for a participant */
 export const fileSessionProgressEventSchema = z.object({
-  sessionId: z.string(),
+  sessionId: sessionIdSchema,
   userId: z.string(),
   progress: z.number(),
   speed: z.number(),
@@ -354,17 +354,17 @@ export const fileSessionProgressEventSchema = z.object({
 
 /** Server → Client: participant completed download */
 export const fileSessionCompleteEventSchema = z.object({
-  sessionId: z.string(),
+  sessionId: sessionIdSchema,
   userId: z.string(),
 });
 
 /** Server → Client: session closed */
 export const fileSessionCloseEventSchema = z.object({
-  sessionId: z.string(),
+  sessionId: sessionIdSchema,
 });
 
 /** Server → Client: participant left the session */
 export const fileSessionLeaveEventSchema = z.object({
-  sessionId: z.string(),
+  sessionId: sessionIdSchema,
   userId: z.string(),
 });

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -275,9 +275,13 @@ export const presenceUpdateEventSchema = z.object({
 
 // ── File Share Session Schemas ──────────────────────────────────────────────
 
+/** Branded session ID — reused across all file-session event schemas. */
+export const sessionIdSchema = z.string().min(1).max(36).brand<"SessionId">();
+export type SessionId = z.infer<typeof sessionIdSchema>;
+
 /** Client → Server: create a share session */
 export const fileSessionCreateRequestSchema = z.object({
-  sessionId: z.string().min(1).max(36),
+  sessionId: sessionIdSchema,
   fileName: z.string().min(1).max(MAX_FILE_NAME_LENGTH),
   fileSize: z.number().int().positive().max(MAX_FILE_SIZE_BYTES),
   contentType: z.string().min(1).max(MAX_CONTENT_TYPE_LENGTH),
@@ -288,29 +292,29 @@ export const fileSessionCreateRequestSchema = z.object({
 
 /** Client → Server: join a session */
 export const fileSessionJoinRequestSchema = z.object({
-  sessionId: z.string().min(1).max(36),
+  sessionId: sessionIdSchema,
 });
 
 /** Client → Server: report download progress */
 export const fileSessionProgressRequestSchema = z.object({
-  sessionId: z.string().min(1).max(36),
+  sessionId: sessionIdSchema,
   progress: z.number().min(0).max(1),
   speed: z.number().nonnegative(),
 });
 
 /** Client → Server: report download complete */
 export const fileSessionCompleteRequestSchema = z.object({
-  sessionId: z.string().min(1).max(36),
+  sessionId: sessionIdSchema,
 });
 
 /** Client → Server: close session */
 export const fileSessionCloseRequestSchema = z.object({
-  sessionId: z.string().min(1).max(36),
+  sessionId: sessionIdSchema,
 });
 
 /** Client → Server: leave session */
 export const fileSessionLeaveRequestSchema = z.object({
-  sessionId: z.string().min(1).max(36),
+  sessionId: sessionIdSchema,
 });
 
 /** Server → Client: session invite */


### PR DESCRIPTION
## Summary
- Add per-user WebSocket connection cap (max 10, closes oldest)
- Add 1-hour TTL sweep for stale file sessions
- Check fileSharingEnabled before allowing FILE_SHARE in server channels
- Add rate limiting to FILE_SESSION_JOIN matching CREATE
- Limit session ID length in protocol schema

## Security Issues Addressed
- **Medium:** Unlimited WS connections per user enables memory exhaustion
- **Medium:** File sessions never expire, leaking memory indefinitely
- **Medium:** fileSharingEnabled bypass — users can share files in restricted channels
- **Low:** FILE_SESSION_JOIN not rate limited
- **Low:** Session IDs not length-validated

## Test plan
- [ ] Verify WebSocket connections work normally (under 10 tabs)
- [ ] Confirm file sharing blocked in channels with fileSharingEnabled=false
- [ ] Test file session creation and join still work
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic file session expiration after 1 hour of inactivity
  * Per-channel control to enable or disable file sharing

* **Bug Fixes**
  * Connection limits per user to prevent excessive concurrent connections
  * Rate limiting for file session join requests
  * Strengthened validation for session identifiers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->