### PR TITLE
fix: harden plugin trust boundaries and bridge security

### DIFF
--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -924,7 +924,14 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
       tags: z.array(z.string().max(50)).max(20).optional(),
       image: z.string().min(1).max(500),
       version: z.string().min(1).max(20).optional(),
-      manifest: z.record(z.unknown()),
+      manifest: z.object({
+        runtime: z.object({
+          image: z.string().min(1),
+          port: z.number().int().min(1).max(65535),
+          healthCheck: z.string().min(1),
+        }),
+        permissions: z.array(z.string()).min(1),
+      }).passthrough(),
       repository: z.string().max(500).nullable().optional(),
       screenshots: z.array(z.string().max(500)).max(10).optional(),
     });
@@ -970,7 +977,14 @@ export const adminRoutes = new Elysia({ prefix: "/api/admin" })
       tags: z.array(z.string().max(50)).max(20).optional(),
       image: z.string().min(1).max(500).optional(),
       version: z.string().min(1).max(20).optional(),
-      manifest: z.record(z.unknown()).optional(),
+      manifest: z.object({
+        runtime: z.object({
+          image: z.string().min(1),
+          port: z.number().int().min(1).max(65535),
+          healthCheck: z.string().min(1),
+        }),
+        permissions: z.array(z.string()).min(1),
+      }).passthrough().optional(),
       repository: z.string().max(500).nullable().optional(),
       screenshots: z.array(z.string().max(500)).max(10).optional(),
     });

--- a/apps/server/src/routes/developer.ts
+++ b/apps/server/src/routes/developer.ts
@@ -27,7 +27,10 @@ const permissionEnum = z.enum(PLUGIN_PERMISSIONS);
 
 const manifestSchema = z.object({
   runtime: z.object({
-    image: z.string().min(1),
+    image: z.string().min(1).max(200).refine(
+      (img) => !img.includes("..") && !img.includes("\\") && /^[a-z0-9][a-z0-9._/-]*[a-z0-9]$/i.test(img),
+      { message: "Invalid Docker image reference" },
+    ),
     port: z.number().int().min(1).max(65535),
     healthCheck: z.string().min(1),
   }),
@@ -48,7 +51,7 @@ const pluginSubmitSchema = z.object({
   author: z.string().min(1).max(100),
   category: z.enum(["ai", "productivity", "developer", "media", "social", "utility", "other"]),
   scope: z.enum(["server", "personal", "both"]),
-  image: z.string().min(1),
+  image: z.string().min(1).max(200),
   version: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be semver format (e.g. 1.0.0)"),
   manifest: manifestSchema,
   tags: z.array(z.string().min(1).max(30)).max(10).optional(),
@@ -283,6 +286,15 @@ export const developerRoutes = new Elysia({ prefix: "/api/developer" })
 
     if (result.length === 0) {
       throw new ValidationError(`Version ${data.version} must be greater than the current version`);
+    }
+
+    // If image or manifest changed, require re-review
+    if (data.image !== undefined || data.manifest !== undefined) {
+      await db.update(pluginRegistry).set({ published: false }).where(eq(pluginRegistry.id, params.pluginId));
+      await db.insert(pluginSubmissions).values({
+        pluginId: params.pluginId,
+        authorUserId: sessionUser.id,
+      });
     }
 
     return { success: true, version: data.version };

--- a/apps/web/src/lib/plugin-bridge.ts
+++ b/apps/web/src/lib/plugin-bridge.ts
@@ -124,6 +124,9 @@ const handlers: Record<string, HandlerFn> = {
     if (!channelId || !content) {
       throw { code: "BAD_REQUEST", message: "channelId and content are required" };
     }
+    if (content.length > 4000) {
+      throw { code: "BAD_REQUEST", message: "Message content too long (max 4000 characters)" };
+    }
     // Verify the channel belongs to the current server
     const serverId = selectedServerId();
     if (!serverId) {
@@ -182,6 +185,11 @@ function sendResponse(source: MessageEventSource, origin: string, response: Plug
 async function handleMessage(event: MessageEvent): Promise<void> {
   const pluginId = allowedOrigins.get(event.origin);
   if (!pluginId) return; // unknown origin — silently ignore
+
+  // Reject oversized messages (64KB limit)
+  try {
+    if (typeof event.data === "object" && JSON.stringify(event.data).length > 65_536) return;
+  } catch { return; }
 
   const data = event.data as PluginRequest | undefined;
   if (!data || data.type !== "uncorded:request" || !data.id || !data.method) return;

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -41,7 +41,7 @@ export class UnCordedPlugin {
       try {
         this.#shellOrigin = new URL(document.referrer).origin;
       } catch {
-        this.#shellOrigin = "*";
+        throw new Error("Unable to determine shell origin. Pass shellOrigin in PluginOptions.");
       }
     }
 


### PR DESCRIPTION
## Summary
- Validate Docker image references in manifest schema
- Require re-review when version push changes image or manifest
- Use proper manifest schema in admin plugin routes
- Remove wildcard postMessage fallback in plugin client
- Add 64KB message size limit on plugin bridge
- Enforce 4000-char limit on plugin-sent messages

## Security Issues Addressed
- **High:** Arbitrary Docker images in plugin manifest
- **High:** Version push swaps image without re-review
- **High:** Admin route accepts any JSON as manifest
- **Medium:** Plugin client falls back to wildcard origin
- **Medium:** No size limits on bridge messages

## Test plan
- [ ] Verify plugin submission still works with valid manifest
- [ ] Confirm version push with image change triggers re-review
- [ ] Test plugin bridge message sending with normal content
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced message content length limit (4,000 chars) and event payload size guard (65,536 bytes).
  * Stricter validation for plugin manifests and runtime configuration.
  * Tightened Docker image string validation and related security checks.
  * Improved handling of missing plugin shell origin to prevent unsafe defaults.

* **Behavior Changes**
  * Updating a plugin's image or manifest now unpublishes it and triggers a required re-review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->