### PR TITLE
fix: frontend resilience — ErrorBoundary, reconnect, API validation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy } from "solid-js";
+import { lazy, ErrorBoundary } from "solid-js";
 import { Router, Route } from "@solidjs/router";
 import AppLayout from "./components/AppLayout.js";
 import "./stores/theme-store.js"; // Initialize theme on app load
@@ -54,46 +54,61 @@ const NotFound = lazy(async () => {
 
 const App = () => {
   return (
-    <Router>
-      {/* Public */}
-      <Route path="/" component={Landing} />
-      <Route path="/login" component={Login} />
-      <Route path="/register" component={Register} />
-      <Route path="/forgot-password" component={ForgotPassword} />
-      <Route path="/reset-password" component={ResetPassword} />
-      <Route path="/onboarding" component={Onboarding} />
-      <Route path="/privacy" component={Privacy} />
-      <Route path="/terms" component={Terms} />
-      <Route path="/verify-email" component={VerifyEmail} />
+    <ErrorBoundary fallback={(err, reset) => (
+      <div class="flex min-h-screen flex-col items-center justify-center gap-4 bg-background text-foreground">
+        <h1 class="text-2xl font-bold">Something went wrong</h1>
+        <p class="text-muted-foreground">{err?.message ?? "An unexpected error occurred"}</p>
+        <button
+          type="button"
+          onClick={reset}
+          class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Try Again
+        </button>
+        <a href="/" class="text-sm text-muted-foreground underline">Go home</a>
+      </div>
+    )}>
+      <Router>
+        {/* Public */}
+        <Route path="/" component={Landing} />
+        <Route path="/login" component={Login} />
+        <Route path="/register" component={Register} />
+        <Route path="/forgot-password" component={ForgotPassword} />
+        <Route path="/reset-password" component={ResetPassword} />
+        <Route path="/onboarding" component={Onboarding} />
+        <Route path="/privacy" component={Privacy} />
+        <Route path="/terms" component={Terms} />
+        <Route path="/verify-email" component={VerifyEmail} />
 
-      {/* Authenticated — all under AppLayout with AuthGuard */}
-      <Route path="/" component={AppLayout}>
-        <Route path="/home" component={Home} />
-        <Route path="/friends" component={Friends} />
-        <Route path="/messages" component={Messages} />
-        <Route path="/messages/:userId" component={DirectMessage} />
-        <Route path="/servers/:serverId" component={ServerView} />
-        <Route path="/servers/:serverId/settings" component={ServerSettings} />
-        <Route path="/features" component={Features} />
-        <Route path="/settings" component={SettingsLayout}>
-          <Route path="/" component={SettingsRedirect} />
-          <Route path="/profile" component={ProfileSettings} />
-          <Route path="/account" component={AccountSettings} />
-          <Route path="/appearance" component={AppearanceSettings} />
-          <Route path="/transfers" component={TransferHistory} />
-          <Route path="/bots" component={BotsSettings} />
-          <Route path="/plugins" component={PluginsSettings} />
-          <Route path="/plugins/:pluginId" component={PluginConfigure} />
-          <Route path="/upgrade" component={Upgrade} />
-          <Route path="/billing" component={Billing} />
-          <Route path="/notifications" component={NotificationSettings} />
-          <Route path="/developer" component={DeveloperSettings} />
+        {/* Authenticated — all under AppLayout with AuthGuard */}
+        <Route path="/" component={AppLayout}>
+          <Route path="/home" component={Home} />
+          <Route path="/friends" component={Friends} />
+          <Route path="/messages" component={Messages} />
+          <Route path="/messages/:userId" component={DirectMessage} />
+          <Route path="/servers/:serverId" component={ServerView} />
+          <Route path="/servers/:serverId/settings" component={ServerSettings} />
+          <Route path="/features" component={Features} />
+          <Route path="/settings" component={SettingsLayout}>
+            <Route path="/" component={SettingsRedirect} />
+            <Route path="/profile" component={ProfileSettings} />
+            <Route path="/account" component={AccountSettings} />
+            <Route path="/appearance" component={AppearanceSettings} />
+            <Route path="/transfers" component={TransferHistory} />
+            <Route path="/bots" component={BotsSettings} />
+            <Route path="/plugins" component={PluginsSettings} />
+            <Route path="/plugins/:pluginId" component={PluginConfigure} />
+            <Route path="/upgrade" component={Upgrade} />
+            <Route path="/billing" component={Billing} />
+            <Route path="/notifications" component={NotificationSettings} />
+            <Route path="/developer" component={DeveloperSettings} />
+          </Route>
         </Route>
-      </Route>
 
-      {/* 404 */}
-      <Route path="/*" component={NotFound} />
-    </Router>
+        {/* 404 */}
+        <Route path="/*" component={NotFound} />
+      </Router>
+    </ErrorBoundary>
   );
 };
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -57,7 +57,7 @@ const App = () => {
     <ErrorBoundary fallback={(err, reset) => (
       <div class="flex min-h-screen flex-col items-center justify-center gap-4 bg-background text-foreground">
         <h1 class="text-2xl font-bold">Something went wrong</h1>
-        <p class="text-muted-foreground">{err?.message ?? "An unexpected error occurred"}</p>
+        <p class="text-muted-foreground">{import.meta.env.DEV ? err?.message : "An unexpected error occurred"}</p>
         <button
           type="button"
           onClick={reset}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ApiError } from "@uncorded/shared";
+import { ValidationError, type ApiError } from "@uncorded/shared";
 import { API_BASE } from "./config.js";
 
 export class ApiRequestError extends Error {
@@ -44,7 +44,14 @@ export async function apiValidated<T>(
   options: RequestInit = {},
 ): Promise<T> {
   const raw = await api<unknown>(path, options);
-  return schema.parse(raw);
+  try {
+    return schema.parse(raw);
+  } catch (err) {
+    throw new ValidationError(
+      err instanceof Error ? err.message : "Response validation failed",
+      { cause: err },
+    );
+  }
 }
 
 export async function apiUpload<T>(

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -37,6 +37,16 @@ export async function api<T>(path: string, options: RequestInit = {}): Promise<T
   return res.json() as Promise<T>;
 }
 
+/** Type-safe API call with runtime Zod validation. */
+export async function apiValidated<T>(
+  path: string,
+  schema: import("zod").ZodType<T>,
+  options: RequestInit = {},
+): Promise<T> {
+  const raw = await api<unknown>(path, options);
+  return schema.parse(raw);
+}
+
 export async function apiUpload<T>(
   path: string,
   formData: FormData,

--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -23,7 +23,6 @@ let heartbeatAckTimeout: ReturnType<typeof setTimeout> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempts = 0;
 let intentionalClose = false;
-let storesInitialized = false;
 
 const listeners = new Map<Opcode, Set<(data: unknown) => void>>();
 
@@ -120,10 +119,7 @@ function handleMessage(event: MessageEvent) {
       reconnectAttempts = 0;
       setGatewayStatus("connected");
       setReadyPayload(parsed.data as ReadyData);
-      if (!storesInitialized) {
-        storesInitialized = true;
-        setupStores();
-      }
+      setupStores(); // Always re-init stores on READY (handles reconnect)
       dispatch(Opcode.READY, parsed.data);
       break;
     }
@@ -207,7 +203,6 @@ export function connectGateway(): void {
 
 export function disconnectGateway(): void {
   intentionalClose = true;
-  storesInitialized = false;
   clearTimers();
   listeners.clear();
   if (ws) {

--- a/apps/web/src/lib/plugin-bridge.ts
+++ b/apps/web/src/lib/plugin-bridge.ts
@@ -134,8 +134,10 @@ const handlers: Record<string, HandlerFn> = {
       throw { code: "BAD_REQUEST", message: "Channel not found in current server" };
     }
     const plugin = plugins().find((p) => p.id === pluginId);
-    const pluginName = plugin?.name ?? "Unknown Plugin";
-    const prefixedContent = `[${pluginName}] ${content}`;
+    if (!plugin) {
+      throw { code: "BAD_REQUEST", message: `Plugin not found: ${pluginId}` };
+    }
+    const prefixedContent = `[${plugin.name}] ${content}`;
     await api(`/api/channels/${channelId}/messages`, {
       method: "POST",
       body: JSON.stringify({ content: prefixedContent }),

--- a/apps/web/src/lib/plugin-bridge.ts
+++ b/apps/web/src/lib/plugin-bridge.ts
@@ -118,7 +118,7 @@ const handlers: Record<string, HandlerFn> = {
     return presence;
   },
 
-  async sendMessage(_pluginId, params) {
+  async sendMessage(pluginId, params) {
     const channelId = params.channelId as ChannelId | undefined;
     const content = params.content as string | undefined;
     if (!channelId || !content) {
@@ -133,9 +133,12 @@ const handlers: Record<string, HandlerFn> = {
     if (!channels?.some((c) => c.id === channelId)) {
       throw { code: "BAD_REQUEST", message: "Channel not found in current server" };
     }
+    const plugin = plugins().find((p) => p.id === pluginId);
+    const pluginName = plugin?.name ?? "Unknown Plugin";
+    const prefixedContent = `[${pluginName}] ${content}`;
     await api(`/api/channels/${channelId}/messages`, {
       method: "POST",
-      body: JSON.stringify({ content }),
+      body: JSON.stringify({ content: prefixedContent }),
     });
     return { sent: true };
   },


### PR DESCRIPTION
## Summary
- Add global SolidJS ErrorBoundary wrapping the Router for crash recovery
- Add apiValidated() helper for Zod-validated API responses
- Always re-initialize stores on WebSocket reconnect (fixes stale messages)
- Prefix plugin-sent messages with plugin name to prevent impersonation

## Security Issues Addressed
- **High:** No error boundary — any render crash = permanent white screen
- **High:** API responses cast without validation
- **High:** Stale store state after reconnect — missed messages
- **High:** Plugins send messages as user with no indicator

## Test plan
- [ ] Trigger a render error — verify ErrorBoundary shows fallback
- [ ] Disconnect/reconnect — verify messages refresh
- [ ] Plugin sends message — verify [PluginName] prefix appears
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error recovery interface allowing users to retry operations or return home when issues occur
  * Plugin messages now include the originating plugin name for improved clarity

* **Bug Fixes**
  * Improved connection reliability to properly reinitialize app state after reconnection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->