### PR TITLE
fix: protocol type safety — decode limits, branded IDs, date validation

### DIFF
--- a/apps/web/src/lib/gateway.ts
+++ b/apps/web/src/lib/gateway.ts
@@ -1,4 +1,4 @@
-import { Opcode, CloseCode, encode, decode, readyEventSchema } from "@uncorded/protocol";
+import { Opcode, CloseCode, encode, decodeClient as decode, readyEventSchema } from "@uncorded/protocol";
 import type { GatewayFrame } from "@uncorded/protocol";
 import { API_BASE } from "./config.js";
 import {

--- a/packages/protocol/src/branded.ts
+++ b/packages/protocol/src/branded.ts
@@ -15,36 +15,51 @@ export type RoleId = Brand<string, "RoleId">;
 export type PluginId = Brand<string, "PluginId">;
 
 // Cast constructors (brand raw strings at application boundaries)
+function assertNonEmpty(raw: string, label: string): void {
+  if (!raw) throw new Error(`${label} must not be empty`);
+}
+
 export function userId(raw: string): UserId {
+  assertNonEmpty(raw, "UserId");
   return raw as UserId;
 }
 export function serverId(raw: string): ServerId {
+  assertNonEmpty(raw, "ServerId");
   return raw as ServerId;
 }
 export function channelId(raw: string): ChannelId {
+  assertNonEmpty(raw, "ChannelId");
   return raw as ChannelId;
 }
 export function messageId(raw: string): MessageId {
+  assertNonEmpty(raw, "MessageId");
   return raw as MessageId;
 }
 export function inviteCode(raw: string): InviteCode {
+  assertNonEmpty(raw, "InviteCode");
   return raw as InviteCode;
 }
 export function fileReceiptId(raw: string): FileReceiptId {
+  assertNonEmpty(raw, "FileReceiptId");
   return raw as FileReceiptId;
 }
 export function dmChannelId(raw: string): DmChannelId {
+  assertNonEmpty(raw, "DmChannelId");
   return raw as DmChannelId;
 }
 export function subscriptionId(raw: string): SubscriptionId {
+  assertNonEmpty(raw, "SubscriptionId");
   return raw as SubscriptionId;
 }
 export function reportId(raw: string): ReportId {
+  assertNonEmpty(raw, "ReportId");
   return raw as ReportId;
 }
 export function roleId(raw: string): RoleId {
+  assertNonEmpty(raw, "RoleId");
   return raw as RoleId;
 }
 export function pluginId(raw: string): PluginId {
+  assertNonEmpty(raw, "PluginId");
   return raw as PluginId;
 }

--- a/packages/protocol/src/codec.ts
+++ b/packages/protocol/src/codec.ts
@@ -22,8 +22,30 @@ export function encode(frame: GatewayFrame): Uint8Array {
   return msgpackEncode(frame);
 }
 
+/** Tighter limits for client-side decoding (browser memory is more constrained). */
+export const CLIENT_DECODE_OPTIONS: DecoderOptions = {
+  maxStrLength: 16_384,
+  maxBinLength: 16_384,
+  maxArrayLength: 2_000,
+  maxMapLength: 200,
+};
+
 export function decode(data: ArrayLike<number> | BufferSource): GatewayFrame {
   const result = msgpackDecode(data as Uint8Array, DECODE_OPTIONS);
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !("op" in result) ||
+    typeof (result as Record<string, unknown>).op !== "number" ||
+    !("d" in result)
+  ) {
+    throw new Error("Invalid GatewayFrame: missing op or d");
+  }
+  return result as GatewayFrame;
+}
+
+export function decodeClient(data: ArrayLike<number> | BufferSource): GatewayFrame {
+  const result = msgpackDecode(data as Uint8Array, CLIENT_DECODE_OPTIONS);
   if (
     typeof result !== "object" ||
     result === null ||

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,6 +1,6 @@
 export { Opcode } from "./opcodes.js";
 export { CloseCode } from "./close-codes.js";
-export { encode, decode } from "./codec.js";
+export { encode, decode, decodeClient, CLIENT_DECODE_OPTIONS } from "./codec.js";
 export type { GatewayFrame } from "./codec.js";
 export * from "./branded.js";
 export type {

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -11,7 +11,10 @@ import {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /** Accepts both ISO strings and Date objects (MessagePack preserves Dates). */
-export const coerceDate = z.union([z.string(), z.date().transform((d) => d.toISOString())]);
+export const coerceDate = z.union([
+  z.string().refine((s) => !Number.isNaN(Date.parse(s)), { message: "Invalid date string" }),
+  z.date().transform((d) => d.toISOString()),
+]);
 export const coerceDateNullable = coerceDate.nullable();
 
 export const authorSchema = z.object({


### PR DESCRIPTION
## Summary
- Add tighter CLIENT_DECODE_OPTIONS for browser-side MessagePack decoding (M15)
- Add non-empty validation to branded ID constructors (L7)
- Validate date strings in coerceDate schema (L8)
- Skip OAuth callback fix M16 (verified server-side allowlist handles it)

## Security Issues Addressed
- **Medium M15:** Client-side decode limits too generous (OOM via large payloads)
- **Medium M16:** OAuth callback — verified not needed (server validates origin)
- **Low L7:** Branded IDs accept empty strings
- **Low L8:** coerceDate accepts invalid date strings

## Test plan
- [ ] Verify gateway connection works with decodeClient
- [ ] Test branded ID functions reject empty strings
- [ ] Verify date parsing in message events
- [ ] Typecheck and lint pass (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)