### PR TITLE
fix: harden upload and file handling

### DIFF
--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -28,6 +28,31 @@ import { checkUserRateLimit } from "../helpers/rate-limit.js";
 import { RL } from "../helpers/rate-limit-keys.js";
 import { sendToUser, disconnectUser } from "../ws/connections.js";
 
+/** Validate file content matches claimed MIME type by checking magic bytes. */
+function validateImageMagicBytes(buffer: ArrayBuffer, claimedType: string): boolean {
+  const bytes = new Uint8Array(buffer);
+  if (bytes.length < 4) return false;
+
+  switch (claimedType) {
+    case "image/png":
+      // PNG: 89 50 4E 47
+      return bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47;
+    case "image/jpeg":
+      // JPEG: FF D8 FF
+      return bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF;
+    case "image/gif":
+      // GIF: 47 49 46 38
+      return bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38;
+    case "image/webp":
+      // WebP: 52 49 46 46 ... 57 45 42 50
+      return bytes.length >= 12 &&
+        bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+        bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50;
+    default:
+      return false;
+  }
+}
+
 // ── Pending deletion state (in-memory, single-server) ──────────
 type DeletionStatus = "reserved" | "pending" | "executing";
 
@@ -129,6 +154,9 @@ const avatarRoutes = new Elysia({ prefix: "/api/users" })
 
     // Upload new avatar first — don't delete old until DB is updated
     const buffer = await file.arrayBuffer();
+    if (!validateImageMagicBytes(buffer, file.type)) {
+      throw new ValidationError("File content does not match declared type");
+    }
     const avatarUrl = await uploadAvatar(sessionUser.id, buffer, file.type);
 
     const [updated] = await db

--- a/apps/server/src/ws/gateway.ts
+++ b/apps/server/src/ws/gateway.ts
@@ -265,6 +265,9 @@ export const gateway = new Elysia().ws("/gateway", {
           if (!parsed.success) break;
           const d = parsed.data;
 
+          // Sanitize file metadata
+          const sanitizedFileName = d.fileName.replace(/[/\\<>:"|?*\x00-\x1F]/g, "_");
+
           const resolution = await resolveChannelMembership(ctx.userId, d.channelId);
           if (!resolution) break;
 
@@ -305,7 +308,7 @@ export const gateway = new Elysia().ws("/gateway", {
             id: receiptId,
             channelId: d.channelId,
             senderId: ctx.userId,
-            fileName: d.fileName,
+            fileName: sanitizedFileName,
             fileSize: d.fileSize,
             contentType: d.contentType,
             magnetUri: d.magnetUri,
@@ -340,7 +343,7 @@ export const gateway = new Elysia().ws("/gateway", {
                 : { id: ctx.userId, username: null, displayName: null, avatarUrl: null, isBot: false },
               fileReceipt: {
                 id: receiptId,
-                fileName: d.fileName,
+                fileName: sanitizedFileName,
                 fileSize: d.fileSize,
                 contentType: d.contentType,
                 magnetUri: d.magnetUri,
@@ -356,7 +359,7 @@ export const gateway = new Elysia().ws("/gateway", {
               fileReceiptId: receiptId,
               channelId: d.channelId,
               senderId: ctx.userId,
-              fileName: d.fileName,
+              fileName: sanitizedFileName,
               fileSize: d.fileSize,
               contentType: d.contentType,
               magnetUri: d.magnetUri,

--- a/apps/web/src/components/FileMessage.tsx
+++ b/apps/web/src/components/FileMessage.tsx
@@ -31,7 +31,6 @@ const TEXT_TYPES = new Set([
   "text/plain",
   "text/markdown",
   "text/csv",
-  "text/html",
   "application/json",
   "application/xml",
 ]);

--- a/apps/web/src/stores/file-store.ts
+++ b/apps/web/src/stores/file-store.ts
@@ -23,6 +23,7 @@ import { api, ApiRequestError } from "../lib/api.js";
 import { showToast } from "../components/ui/toast.js";
 
 const MAX_PREVIEW_CACHE = 10;
+const MAX_PREVIEW_CACHE_BYTES = 500 * 1024 * 1024; // 500MB
 const P2P_ACK_KEY = "uncorded:p2p-ip-acknowledged";
 
 // ── P2P IP disclosure dialog state ──────────────────────────────────────────
@@ -148,6 +149,17 @@ function updateSeeders(frId: FileReceiptId, uId: UserId, available: boolean): vo
   );
 }
 
+function getPreviewCacheTotalBytes(): number {
+  let total = 0;
+  for (const key of store.previewOrder) {
+    const files = store.previews[key];
+    if (files) {
+      for (const f of files) total += f.size;
+    }
+  }
+  return total;
+}
+
 function touchPreviewLru(infoHash: string): void {
   setStore(
     "previewOrder",
@@ -155,7 +167,13 @@ function touchPreviewLru(infoHash: string): void {
       const idx = order.indexOf(infoHash);
       if (idx !== -1) order.splice(idx, 1);
       order.push(infoHash);
+      // Evict by count
       while (order.length > MAX_PREVIEW_CACHE) {
+        const evicted = order.shift()!;
+        setStore("previews", evicted, undefined!);
+      }
+      // Evict by total size
+      while (order.length > 1 && getPreviewCacheTotalBytes() > MAX_PREVIEW_CACHE_BYTES) {
         const evicted = order.shift()!;
         setStore("previews", evicted, undefined!);
       }


### PR DESCRIPTION
## Summary
- Validate avatar upload magic bytes against claimed MIME type
- Sanitize file names in FILE_SHARE to strip path separators and control chars
- Add 500MB total size cap to file preview cache
- Remove text/html from auto-preview types

## Security Issues Addressed
- **Medium:** Avatar upload trusts client MIME — HTML file with image/png bypasses
- **Medium:** Preview cache count-only eviction allows multi-GB memory usage
- **Medium:** HTML files auto-previewed as text
- **Low:** File metadata (fileName) not sanitized

## Test plan
- [ ] Upload PNG/JPEG/GIF/WebP avatars — verify they still work
- [ ] Upload non-image file with image MIME — verify rejection
- [ ] Share file with special chars in name — verify sanitized
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)