### PR TITLE
chore: add dist-electron/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 
 # Build output
 dist/
+dist-electron/
 
 # TypeScript
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
- Added `dist-electron/` to `.gitignore` — Electron build output was not ignored
- No dist directories were actually tracked in git (`.gitignore` already had `dist/`), so no `git rm --cached` was needed

## Test plan
- [x] Verify `apps/desktop/dist-electron/` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude build artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->