### PR TITLE
test: server auth middleware and rate limit Redis coverage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Changes
 
-- 
+-
 
 ## Test plan
 

--- a/apps/server/src/helpers/rate-limit.test.ts
+++ b/apps/server/src/helpers/rate-limit.test.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable eslint(no-await-in-loop) -- sequential calls required to test rate limiting */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RateLimitError } from "@uncorded/shared";
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
 
@@ -24,7 +25,9 @@ describe("checkUserRateLimit (Redis path)", () => {
 
   it("throws RateLimitError when Redis count exceeds limit", async () => {
     mockRedis.eval.mockResolvedValueOnce(6);
-    await expect(checkUserRateLimit("user_1", "messages", 5, 10_000)).rejects.toThrow();
+    await expect(checkUserRateLimit("user_1", "messages", 5, 10_000)).rejects.toBeInstanceOf(
+      RateLimitError,
+    );
   });
 
   it("passes correct Redis key and TTL", async () => {
@@ -44,9 +47,16 @@ describe("checkUserRateLimit (Redis path)", () => {
     await expect(checkUserRateLimit("user_1", "messages", 5, 10_000)).resolves.toBeUndefined();
   });
 
-  it("falls back to in-memory on Redis error", async () => {
-    mockRedis.eval.mockRejectedValueOnce(new Error("Redis connection lost"));
-    // First call should succeed (in-memory fallback, count = 1)
-    await expect(checkUserRateLimit("user_1", "fallback", 5, 10_000)).resolves.toBeUndefined();
+  it("falls back to in-memory on Redis error and enforces limit", async () => {
+    // All Redis calls fail — in-memory fallback should still enforce the limit
+    mockRedis.eval.mockRejectedValue(new Error("Redis connection lost"));
+
+    for (let i = 0; i < 5; i++) {
+      await expect(checkUserRateLimit("user_1", "fallback", 5, 10_000)).resolves.toBeUndefined();
+    }
+    // 6th call exceeds limit even via fallback
+    await expect(checkUserRateLimit("user_1", "fallback", 5, 10_000)).rejects.toBeInstanceOf(
+      RateLimitError,
+    );
   });
 });

--- a/apps/server/src/helpers/rate-limit.test.ts
+++ b/apps/server/src/helpers/rate-limit.test.ts
@@ -1,0 +1,52 @@
+/* oxlint-disable eslint(no-await-in-loop) -- sequential calls required to test rate limiting */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { mockRedis } = vi.hoisted(() => {
+  const mockRedis = { eval: vi.fn() };
+  return { mockRedis };
+});
+
+vi.mock("../lib/redis.js", () => ({ redis: mockRedis }));
+
+import { checkUserRateLimit } from "./rate-limit.js";
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("checkUserRateLimit (Redis path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows requests within limit", async () => {
+    mockRedis.eval.mockResolvedValueOnce(1);
+    await expect(checkUserRateLimit("user_1", "messages", 5, 10_000)).resolves.toBeUndefined();
+  });
+
+  it("throws RateLimitError when Redis count exceeds limit", async () => {
+    mockRedis.eval.mockResolvedValueOnce(6);
+    await expect(checkUserRateLimit("user_1", "messages", 5, 10_000)).rejects.toThrow();
+  });
+
+  it("passes correct Redis key and TTL", async () => {
+    mockRedis.eval.mockResolvedValueOnce(1);
+    await checkUserRateLimit("user_1", "messages", 5, 30_000);
+
+    expect(mockRedis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("INCR"),
+      1,
+      "rl:http:user_1:messages",
+      30, // 30_000ms → 30s
+    );
+  });
+
+  it("allows exactly at the limit", async () => {
+    mockRedis.eval.mockResolvedValueOnce(5);
+    await expect(checkUserRateLimit("user_1", "messages", 5, 10_000)).resolves.toBeUndefined();
+  });
+
+  it("falls back to in-memory on Redis error", async () => {
+    mockRedis.eval.mockRejectedValueOnce(new Error("Redis connection lost"));
+    // First call should succeed (in-memory fallback, count = 1)
+    await expect(checkUserRateLimit("user_1", "fallback", 5, 10_000)).resolves.toBeUndefined();
+  });
+});

--- a/apps/server/src/helpers/rate-limit.test.ts
+++ b/apps/server/src/helpers/rate-limit.test.ts
@@ -16,7 +16,7 @@ import { checkUserRateLimit } from "./rate-limit.js";
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("checkUserRateLimit (Redis path)", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.resetAllMocks());
 
   it("allows requests within limit", async () => {
     mockRedis.eval.mockResolvedValueOnce(1);

--- a/apps/server/src/middleware/auth.test.ts
+++ b/apps/server/src/middleware/auth.test.ts
@@ -1,0 +1,130 @@
+/* oxlint-disable eslint(no-shadow) -- vi.hoisted destructuring pattern */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { mockGetSession, mockGetBotSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGetBotSession: vi.fn(),
+}));
+
+vi.mock("../auth/index.js", () => ({
+  auth: {
+    handler: () => new Response(),
+    api: { getSession: mockGetSession },
+  },
+}));
+
+vi.mock("./bot-auth.js", () => ({
+  getBotSession: mockGetBotSession,
+}));
+
+import { authResolve, getSession } from "./auth.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function fakeRequest(headers?: Record<string, string>): Request {
+  return new Request("http://localhost/test", { headers });
+}
+
+const validUser = {
+  id: "user_1",
+  name: "alice",
+  banned: false,
+  subscriptionTier: "free",
+};
+const validSession = { id: "sess_1", userId: "user_1" };
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("getSession", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("delegates to auth.api.getSession", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: validUser, session: validSession });
+    const result = await getSession(new Headers());
+    expect(mockGetSession).toHaveBeenCalledWith({ headers: expect.any(Headers) });
+    expect(result).toEqual({ user: validUser, session: validSession });
+  });
+
+  it("returns null when no session exists", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const result = await getSession(new Headers());
+    expect(result).toBeNull();
+  });
+});
+
+describe("authResolve", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("session auth", () => {
+    it("returns user and session for valid session", async () => {
+      mockGetSession.mockResolvedValueOnce({ user: validUser, session: validSession });
+      const resolve = authResolve();
+      const result = await resolve({ request: fakeRequest() });
+
+      expect(result).toEqual({ user: validUser, session: validSession });
+    });
+
+    it("throws UnauthorizedError when no session and bots not allowed", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      const resolve = authResolve();
+
+      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+    });
+
+    it("throws ForbiddenError for banned users", async () => {
+      mockGetSession.mockResolvedValueOnce({
+        user: { ...validUser, banned: true },
+        session: validSession,
+      });
+      const resolve = authResolve();
+
+      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+    });
+  });
+
+  describe("bot auth fallback", () => {
+    it("falls back to bot auth when allowBots is true and no session", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      mockGetBotSession.mockResolvedValueOnce({
+        user: { ...validUser, isBot: true },
+        bot: { id: "bot_1" },
+      });
+      const resolve = authResolve({ allowBots: true });
+      const result = await resolve({ request: fakeRequest() });
+
+      expect(result).toEqual({
+        user: { ...validUser, isBot: true },
+        session: null,
+      });
+    });
+
+    it("does not try bot auth when allowBots is false (default)", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      const resolve = authResolve();
+
+      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+      expect(mockGetBotSession).not.toHaveBeenCalled();
+    });
+
+    it("throws ForbiddenError for banned bots", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      mockGetBotSession.mockResolvedValueOnce({
+        user: { ...validUser, banned: true, isBot: true },
+        bot: { id: "bot_1" },
+      });
+      const resolve = authResolve({ allowBots: true });
+
+      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+    });
+
+    it("throws UnauthorizedError when bot auth also fails", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      mockGetBotSession.mockResolvedValueOnce(null);
+      const resolve = authResolve({ allowBots: true });
+
+      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+    });
+  });
+});

--- a/apps/server/src/middleware/auth.test.ts
+++ b/apps/server/src/middleware/auth.test.ts
@@ -93,13 +93,15 @@ describe("authResolve", () => {
         bot: { id: "bot_1" },
       });
       const resolve = authResolve({ allowBots: true });
-      const result = await resolve({ request: fakeRequest() });
+      const req = fakeRequest({ authorization: "Bearer uncrd_test" });
+      const result = await resolve({ request: req });
 
       expect(result).toEqual({
         user: { ...validUser, isBot: true },
         session: null,
       });
-      expect(mockGetBotSession).toHaveBeenCalledWith(expect.any(Headers));
+      const passedHeaders = mockGetBotSession.mock.calls[0]![0] as Headers;
+      expect(passedHeaders.get("authorization")).toBe("Bearer uncrd_test");
     });
 
     it("does not try bot auth when allowBots is false (default)", async () => {

--- a/apps/server/src/middleware/auth.test.ts
+++ b/apps/server/src/middleware/auth.test.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable eslint(no-shadow) -- vi.hoisted destructuring pattern */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UnauthorizedError, ForbiddenError } from "@uncorded/shared";
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
 
@@ -70,7 +71,7 @@ describe("authResolve", () => {
       mockGetSession.mockResolvedValueOnce(null);
       const resolve = authResolve();
 
-      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+      await expect(resolve({ request: fakeRequest() })).rejects.toBeInstanceOf(UnauthorizedError);
     });
 
     it("throws ForbiddenError for banned users", async () => {
@@ -80,7 +81,7 @@ describe("authResolve", () => {
       });
       const resolve = authResolve();
 
-      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+      await expect(resolve({ request: fakeRequest() })).rejects.toBeInstanceOf(ForbiddenError);
     });
   });
 
@@ -98,13 +99,14 @@ describe("authResolve", () => {
         user: { ...validUser, isBot: true },
         session: null,
       });
+      expect(mockGetBotSession).toHaveBeenCalledWith(expect.any(Headers));
     });
 
     it("does not try bot auth when allowBots is false (default)", async () => {
       mockGetSession.mockResolvedValueOnce(null);
       const resolve = authResolve();
 
-      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+      await expect(resolve({ request: fakeRequest() })).rejects.toBeInstanceOf(UnauthorizedError);
       expect(mockGetBotSession).not.toHaveBeenCalled();
     });
 
@@ -116,7 +118,7 @@ describe("authResolve", () => {
       });
       const resolve = authResolve({ allowBots: true });
 
-      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+      await expect(resolve({ request: fakeRequest() })).rejects.toBeInstanceOf(ForbiddenError);
     });
 
     it("throws UnauthorizedError when bot auth also fails", async () => {
@@ -124,7 +126,7 @@ describe("authResolve", () => {
       mockGetBotSession.mockResolvedValueOnce(null);
       const resolve = authResolve({ allowBots: true });
 
-      await expect(resolve({ request: fakeRequest() })).rejects.toThrow();
+      await expect(resolve({ request: fakeRequest() })).rejects.toBeInstanceOf(UnauthorizedError);
     });
   });
 });

--- a/apps/server/src/middleware/auth.test.ts
+++ b/apps/server/src/middleware/auth.test.ts
@@ -120,7 +120,9 @@ describe("authResolve", () => {
       });
       const resolve = authResolve({ allowBots: true });
 
-      await expect(resolve({ request: fakeRequest() })).rejects.toBeInstanceOf(ForbiddenError);
+      await expect(
+        resolve({ request: fakeRequest({ authorization: "Bearer uncrd_banned" }) }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
     });
 
     it("throws UnauthorizedError when bot auth also fails", async () => {
@@ -128,7 +130,9 @@ describe("authResolve", () => {
       mockGetBotSession.mockResolvedValueOnce(null);
       const resolve = authResolve({ allowBots: true });
 
-      await expect(resolve({ request: fakeRequest() })).rejects.toBeInstanceOf(UnauthorizedError);
+      await expect(
+        resolve({ request: fakeRequest({ authorization: "Bearer uncrd_invalid" }) }),
+      ).rejects.toBeInstanceOf(UnauthorizedError);
     });
   });
 });

--- a/apps/server/src/middleware/auth.test.ts
+++ b/apps/server/src/middleware/auth.test.ts
@@ -100,6 +100,7 @@ describe("authResolve", () => {
         user: { ...validUser, isBot: true },
         session: null,
       });
+      expect(mockGetBotSession).toHaveBeenCalledTimes(1);
       const passedHeaders = mockGetBotSession.mock.calls[0]![0] as Headers;
       expect(passedHeaders.get("authorization")).toBe("Bearer uncrd_test");
     });

--- a/apps/server/src/middleware/auth.test.ts
+++ b/apps/server/src/middleware/auth.test.ts
@@ -24,7 +24,7 @@ import { authResolve, getSession } from "./auth.js";
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 function fakeRequest(headers?: Record<string, string>): Request {
-  return new Request("http://localhost/test", { headers });
+  return new Request("http://localhost/test", headers ? { headers } : {});
 }
 
 const validUser = {

--- a/apps/server/src/middleware/bot-auth.test.ts
+++ b/apps/server/src/middleware/bot-auth.test.ts
@@ -1,0 +1,111 @@
+/* oxlint-disable eslint(no-shadow) -- vi.hoisted destructuring pattern */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { selectResults, mockDb, capturedUpdates } = vi.hoisted(() => {
+  // Mock Bun.CryptoHasher (not available in Vitest's Node runtime)
+  const mockDigest = { digest: () => "mocked_hash" };
+  globalThis.Bun = {
+    CryptoHasher: function () {
+      return { update: () => mockDigest };
+    },
+  } as never;
+
+  const selectResults: unknown[][] = [];
+  const capturedUpdates: unknown[] = [];
+
+  const mockDb = {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockImplementation(() => Promise.resolve(selectResults.shift() ?? [])),
+          }),
+        }),
+      }),
+    })),
+    update: vi.fn().mockImplementation(() => ({
+      set: vi.fn().mockImplementation((data: unknown) => {
+        capturedUpdates.push(data);
+        return {
+          where: vi.fn().mockReturnValue({
+            catch: vi.fn(),
+          }),
+        };
+      }),
+    })),
+  };
+
+  return { selectResults, capturedUpdates, mockDb };
+});
+
+vi.mock("drizzle-orm", () => ({ eq: vi.fn() }));
+vi.mock("../db/index.js", () => ({ db: mockDb }));
+vi.mock("../db/schema.js", () => ({
+  bots: { userId: "bots.userId", tokenHash: "bots.tokenHash", id: "bots.id", lastUsedAt: "bots.lastUsedAt" },
+  user: { id: "user.id" },
+}));
+
+import { getBotSession } from "./bot-auth.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function headers(auth?: string): Headers {
+  const h = new Headers();
+  if (auth) h.set("Authorization", auth);
+  return h;
+}
+
+const fakeBot = { id: "bot_1", tokenHash: "abc", lastUsedAt: null };
+const fakeUser = { id: "user_1", name: "bot-user", banned: false };
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("getBotSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectResults.length = 0;
+    capturedUpdates.length = 0;
+  });
+
+  it("returns null when no Authorization header", async () => {
+    expect(await getBotSession(headers())).toBeNull();
+  });
+
+  it("returns null for non-bot Bearer tokens", async () => {
+    expect(await getBotSession(headers("Bearer sk_regular_token"))).toBeNull();
+  });
+
+  it("returns null when no matching bot found", async () => {
+    selectResults.push([]);
+    expect(await getBotSession(headers("Bearer uncrd_test_token"))).toBeNull();
+  });
+
+  it("returns user and bot for valid token", async () => {
+    selectResults.push([{ bots: fakeBot, user: fakeUser }]);
+    const result = await getBotSession(headers("Bearer uncrd_test_token"));
+
+    expect(result).toEqual({ user: fakeUser, bot: fakeBot });
+    expect(mockDb.select).toHaveBeenCalled();
+  });
+
+  it("updates lastUsedAt when stale (>5 min)", async () => {
+    const staleBot = { ...fakeBot, lastUsedAt: new Date(Date.now() - 6 * 60_000) };
+    selectResults.push([{ bots: staleBot, user: fakeUser }]);
+
+    await getBotSession(headers("Bearer uncrd_test_token"));
+
+    expect(capturedUpdates).toHaveLength(1);
+    expect(capturedUpdates[0]).toHaveProperty("lastUsedAt");
+  });
+
+  it("skips lastUsedAt update when recent (<5 min)", async () => {
+    const freshBot = { ...fakeBot, lastUsedAt: new Date(Date.now() - 60_000) };
+    selectResults.push([{ bots: freshBot, user: fakeUser }]);
+
+    await getBotSession(headers("Bearer uncrd_test_token"));
+
+    expect(capturedUpdates).toHaveLength(0);
+  });
+});

--- a/apps/server/src/middleware/bot-auth.test.ts
+++ b/apps/server/src/middleware/bot-auth.test.ts
@@ -1,10 +1,11 @@
 /* oxlint-disable eslint(no-shadow) -- vi.hoisted destructuring pattern */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterAll, describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
 
-const { selectResults, mockDb, capturedUpdates } = vi.hoisted(() => {
+const { selectResults, mockDb, capturedUpdates, originalBun } = vi.hoisted(() => {
   // Mock Bun.CryptoHasher (not available in Vitest's Node runtime)
+  const originalBun = globalThis.Bun;
   const mockDigest = { digest: () => "mocked_hash" };
   globalThis.Bun = {
     CryptoHasher: function () {
@@ -37,7 +38,7 @@ const { selectResults, mockDb, capturedUpdates } = vi.hoisted(() => {
     })),
   };
 
-  return { selectResults, capturedUpdates, mockDb };
+  return { selectResults, capturedUpdates, mockDb, originalBun };
 });
 
 vi.mock("drizzle-orm", () => ({ eq: vi.fn() }));
@@ -63,6 +64,10 @@ const fakeUser = { id: "user_1", name: "bot-user", banned: false };
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("getBotSession", () => {
+  afterAll(() => {
+    globalThis.Bun = originalBun;
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     selectResults.length = 0;

--- a/apps/server/src/middleware/bot-auth.test.ts
+++ b/apps/server/src/middleware/bot-auth.test.ts
@@ -44,7 +44,12 @@ const { selectResults, mockDb, capturedUpdates, originalBun } = vi.hoisted(() =>
 vi.mock("drizzle-orm", () => ({ eq: vi.fn() }));
 vi.mock("../db/index.js", () => ({ db: mockDb }));
 vi.mock("../db/schema.js", () => ({
-  bots: { userId: "bots.userId", tokenHash: "bots.tokenHash", id: "bots.id", lastUsedAt: "bots.lastUsedAt" },
+  bots: {
+    userId: "bots.userId",
+    tokenHash: "bots.tokenHash",
+    id: "bots.id",
+    lastUsedAt: "bots.lastUsedAt",
+  },
   user: { id: "user.id" },
 }));
 

--- a/apps/server/src/middleware/ip-rate-limit-redis.test.ts
+++ b/apps/server/src/middleware/ip-rate-limit-redis.test.ts
@@ -52,12 +52,13 @@ describe("checkIpRateLimit (Redis path)", () => {
   });
 
   it("falls back to in-memory on Redis error and enforces limit", async () => {
+    // Use a unique IP so the in-memory bucket doesn't collide with other tests
     mockRedis.eval.mockRejectedValue(new Error("connection refused"));
 
     for (let i = 0; i < 5; i++) {
-      expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(true);
+      expect(await checkIpRateLimit("10.99.99.1", 5, 10_000)).toBe(true);
     }
     // 6th call exceeds limit even via fallback
-    expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(false);
+    expect(await checkIpRateLimit("10.99.99.1", 5, 10_000)).toBe(false);
   });
 });

--- a/apps/server/src/middleware/ip-rate-limit-redis.test.ts
+++ b/apps/server/src/middleware/ip-rate-limit-redis.test.ts
@@ -51,8 +51,13 @@ describe("checkIpRateLimit (Redis path)", () => {
     );
   });
 
-  it("falls back to in-memory on Redis error", async () => {
-    mockRedis.eval.mockRejectedValueOnce(new Error("connection refused"));
-    expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(true);
+  it("falls back to in-memory on Redis error and enforces limit", async () => {
+    mockRedis.eval.mockRejectedValue(new Error("connection refused"));
+
+    for (let i = 0; i < 5; i++) {
+      expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(true);
+    }
+    // 6th call exceeds limit even via fallback
+    expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(false);
   });
 });

--- a/apps/server/src/middleware/ip-rate-limit-redis.test.ts
+++ b/apps/server/src/middleware/ip-rate-limit-redis.test.ts
@@ -1,0 +1,58 @@
+/* oxlint-disable eslint(no-await-in-loop) -- sequential calls required to test rate limiting */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { mockRedis } = vi.hoisted(() => {
+  const mockRedis = { eval: vi.fn() };
+  return { mockRedis };
+});
+
+vi.mock("../lib/redis.js", () => ({ redis: mockRedis }));
+
+import { checkIpRateLimit } from "./ip-rate-limit.js";
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("checkIpRateLimit (Redis path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns true when within limit", async () => {
+    mockRedis.eval.mockResolvedValueOnce(1);
+    expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(true);
+  });
+
+  it("returns false when exceeding limit", async () => {
+    mockRedis.eval.mockResolvedValueOnce(6);
+    expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(false);
+  });
+
+  it("uses correct Redis key with default prefix", async () => {
+    mockRedis.eval.mockResolvedValueOnce(1);
+    await checkIpRateLimit("10.0.0.1", 5, 10_000);
+
+    expect(mockRedis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("INCR"),
+      1,
+      "rl:ip:10.0.0.1",
+      10,
+    );
+  });
+
+  it("uses custom prefix when provided", async () => {
+    mockRedis.eval.mockResolvedValueOnce(1);
+    await checkIpRateLimit("10.0.0.1", 5, 10_000, "signup");
+
+    expect(mockRedis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("INCR"),
+      1,
+      "rl:signup:10.0.0.1",
+      10,
+    );
+  });
+
+  it("falls back to in-memory on Redis error", async () => {
+    mockRedis.eval.mockRejectedValueOnce(new Error("connection refused"));
+    expect(await checkIpRateLimit("10.0.0.1", 5, 10_000)).toBe(true);
+  });
+});

--- a/apps/server/src/middleware/ip-rate-limit-redis.test.ts
+++ b/apps/server/src/middleware/ip-rate-limit-redis.test.ts
@@ -15,7 +15,7 @@ import { checkIpRateLimit } from "./ip-rate-limit.js";
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("checkIpRateLimit (Redis path)", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.resetAllMocks());
 
   it("returns true when within limit", async () => {
     mockRedis.eval.mockResolvedValueOnce(1);

--- a/apps/server/src/ws/rate-limit-redis.test.ts
+++ b/apps/server/src/ws/rate-limit-redis.test.ts
@@ -39,10 +39,14 @@ describe("checkRateLimit WS (Redis path)", () => {
     );
   });
 
-  it("falls back to in-memory on Redis error", async () => {
-    mockRedis.eval.mockRejectedValueOnce(new Error("timeout"));
-    // Should succeed via in-memory fallback
-    expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(true);
+  it("falls back to in-memory on Redis error and enforces limit", async () => {
+    mockRedis.eval.mockRejectedValue(new Error("timeout"));
+
+    for (let i = 0; i < 10; i++) {
+      expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(true);
+    }
+    // 11th call exceeds limit even via fallback
+    expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(false);
   });
 
   it("returns true at exact limit boundary", async () => {

--- a/apps/server/src/ws/rate-limit-redis.test.ts
+++ b/apps/server/src/ws/rate-limit-redis.test.ts
@@ -15,7 +15,7 @@ import { checkRateLimit } from "./rate-limit.js";
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("checkRateLimit WS (Redis path)", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.resetAllMocks());
 
   it("returns true when within limit", async () => {
     mockRedis.eval.mockResolvedValueOnce(1);

--- a/apps/server/src/ws/rate-limit-redis.test.ts
+++ b/apps/server/src/ws/rate-limit-redis.test.ts
@@ -1,0 +1,52 @@
+/* oxlint-disable eslint(no-await-in-loop) -- sequential calls required to test rate limiting */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { mockRedis } = vi.hoisted(() => {
+  const mockRedis = { eval: vi.fn() };
+  return { mockRedis };
+});
+
+vi.mock("../lib/redis.js", () => ({ redis: mockRedis }));
+
+import { checkRateLimit } from "./rate-limit.js";
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("checkRateLimit WS (Redis path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns true when within limit", async () => {
+    mockRedis.eval.mockResolvedValueOnce(1);
+    expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(true);
+  });
+
+  it("returns false when exceeding limit", async () => {
+    mockRedis.eval.mockResolvedValueOnce(11);
+    expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(false);
+  });
+
+  it("uses rl:ws: key prefix", async () => {
+    mockRedis.eval.mockResolvedValueOnce(1);
+    await checkRateLimit("user_1", 3, 10, 60_000);
+
+    expect(mockRedis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("INCR"),
+      1,
+      "rl:ws:user_1:3",
+      60,
+    );
+  });
+
+  it("falls back to in-memory on Redis error", async () => {
+    mockRedis.eval.mockRejectedValueOnce(new Error("timeout"));
+    // Should succeed via in-memory fallback
+    expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(true);
+  });
+
+  it("returns true at exact limit boundary", async () => {
+    mockRedis.eval.mockResolvedValueOnce(10);
+    expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(true);
+  });
+});

--- a/apps/server/src/ws/rate-limit-redis.test.ts
+++ b/apps/server/src/ws/rate-limit-redis.test.ts
@@ -40,13 +40,14 @@ describe("checkRateLimit WS (Redis path)", () => {
   });
 
   it("falls back to in-memory on Redis error and enforces limit", async () => {
+    // Use a unique user+opcode so the in-memory bucket doesn't collide with other tests
     mockRedis.eval.mockRejectedValue(new Error("timeout"));
 
     for (let i = 0; i < 10; i++) {
-      expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(true);
+      expect(await checkRateLimit("user_fallback", 99, 10, 60_000)).toBe(true);
     }
     // 11th call exceeds limit even via fallback
-    expect(await checkRateLimit("user_1", 1, 10, 60_000)).toBe(false);
+    expect(await checkRateLimit("user_fallback", 99, 10, 60_000)).toBe(false);
   });
 
   it("returns true at exact limit boundary", async () => {


### PR DESCRIPTION
## Summary
- Auth middleware tests: `authResolve` session auth, bot token fallback, banned user rejection
- Bot auth tests: token parsing, DB lookup, `lastUsedAt` staleness throttling
- Redis rate limit tests for all 3 limiters (HTTP, WebSocket, IP): key format, TTL, boundary, fallback to in-memory on Redis error

Goes from 5 → 10 test files, 56 → 78 passing tests.

## Test plan
- [x] All 78 tests pass locally (`bun run test`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive rate-limit tests covering user, IP, and WebSocket flows
  * Verified exact-limit, over-limit, boundary behavior, and fallback when Redis is unavailable
  * Added auth middleware and bot-auth tests covering session, bot fallback, banned users, and token handling

* **Chores**
  * Minor formatting tweak to the pull request template
<!-- end of auto-generated comment: release notes by coderabbit.ai -->