### PR TITLE
chore: remaining infra batches (3c, 4, 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
       - run: bun run lint
       - run: bun run test
       - run: bun run build
+      - name: Check migrations
+        run: cd apps/server && bunx drizzle-kit check --dialect=postgresql --out=./drizzle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release Desktop App
 
 on:
+  push:
+    tags: ["v*.*.*"]
   workflow_dispatch:
     inputs:
       version:
@@ -10,7 +12,7 @@ on:
 
 jobs:
   preflight:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.validate.outputs.version }}
       tag: ${{ steps.validate.outputs.tag }}
@@ -31,10 +33,17 @@ jobs:
       - run: bun run typecheck
       - run: bun run lint
       - run: bun run test
-      - name: Validate version
+      - name: Resolve version
         id: validate
         run: |
-          VERSION="${{ inputs.version }}"
+          # Tag push: extract version from tag; manual dispatch: use input
+          if [[ -n "${{ github.ref_name }}" && "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"  # strip leading v
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "Invalid semver: $VERSION"
             exit 1
@@ -103,7 +112,7 @@ jobs:
 
   release:
     needs: [preflight, build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -122,7 +122,10 @@ const app = new Elysia()
     set.status = 500;
     return { code: "INTERNAL_ERROR", message: "Internal server error" };
   })
-  .listen(env.PORT);
+  .listen({
+    port: env.PORT,
+    maxRequestBodySize: 1024 * 1024 * 2, // 2 MB
+  });
 
 // ── Redis cache invalidation subscribers ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **Batch 3c — Migration check in CI:** Adds `drizzle-kit check` step that validates migration file consistency without a database connection
- **Batch 4 — Tag-triggered releases:** Adds `on: push: tags: ["v*.*.*"]` to release.yml alongside existing manual dispatch. Pins runners to ubuntu-24.04
- **Batch 6 — Security hardening:** Sets 2 MB request body size limit. CSRF evaluated: `SameSite=none` is used for cross-origin Electron/admin, but existing `Content-Type: application/json` enforcement on mutating endpoints provides sufficient CSRF mitigation (browsers can't send JSON via form submissions)

## Test plan
- [ ] CI passes (migration check step runs)
- [ ] Typecheck passes
- [ ] Existing tests pass (78/78)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Server now enforces a 2 MB maximum limit on incoming request body sizes.

* **Chores**
  * Automated migration validation added to CI pipeline.
  * Release workflow now automatically triggers on version tag creation with updated infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->