### PR TITLE
fix: message data corruption, DM race condition, pubsub diagnostics

### DIFF
--- a/apps/server/src/helpers/dm.ts
+++ b/apps/server/src/helpers/dm.ts
@@ -38,28 +38,39 @@ function brandProfile(u: {
  *          already existed (no action taken).
  */
 export async function ensureDmChannel(userIdA: string, userIdB: string): Promise<string | null> {
-  // Check for existing DM via intersection query
-  const myChannels = db
-    .select({ channelId: dmMembers.channelId })
-    .from(dmMembers)
-    .where(eq(dmMembers.userId, userIdA));
+  // Sort IDs for deterministic advisory lock key
+  const [lo, hi] = userIdA < userIdB ? [userIdA, userIdB] : [userIdB, userIdA];
+  // Hash the pair into a 32-bit integer for pg_advisory_xact_lock
+  const lockKey =
+    [...`${lo}:${hi}`].reduce((h, c) => (Math.imul(31, h) + c.charCodeAt(0)) | 0, 0) >>> 0;
 
-  const [existingDm] = await db
-    .select({ channelId: dmMembers.channelId })
-    .from(dmMembers)
-    .where(and(eq(dmMembers.userId, userIdB), inArray(dmMembers.channelId, myChannels)))
-    .limit(1);
+  const dmId = await db.transaction(async (tx) => {
+    // Advisory lock prevents concurrent creation for the same user pair
+    await tx.execute(`SELECT pg_advisory_xact_lock(${lockKey})`);
 
-  if (existingDm) return null; // DM already exists
+    const myChannels = tx
+      .select({ channelId: dmMembers.channelId })
+      .from(dmMembers)
+      .where(eq(dmMembers.userId, userIdA));
 
-  const dmId = createId();
-  await db.transaction(async (tx) => {
-    await tx.insert(dmChannels).values({ id: dmId });
+    const [existingDm] = await tx
+      .select({ channelId: dmMembers.channelId })
+      .from(dmMembers)
+      .where(and(eq(dmMembers.userId, userIdB), inArray(dmMembers.channelId, myChannels)))
+      .limit(1);
+
+    if (existingDm) return null;
+
+    const newId = createId();
+    await tx.insert(dmChannels).values({ id: newId });
     await tx.insert(dmMembers).values([
-      { channelId: dmId, userId: userIdA },
-      { channelId: dmId, userId: userIdB },
+      { channelId: newId, userId: userIdA },
+      { channelId: newId, userId: userIdB },
     ]);
+    return newId;
   });
+
+  if (!dmId) return null;
 
   addDmChannelToCache(dmId, [userIdA, userIdB]);
 

--- a/apps/server/src/helpers/dm.ts
+++ b/apps/server/src/helpers/dm.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and, inArray, sql } from "drizzle-orm";
 import { createId } from "@uncorded/shared";
 import { Opcode, dmChannelId as brandDmChannelId, userId as brandUserId } from "@uncorded/protocol";
 import { db } from "../db/index.js";
@@ -46,7 +46,7 @@ export async function ensureDmChannel(userIdA: string, userIdB: string): Promise
 
   const dmId = await db.transaction(async (tx) => {
     // Advisory lock prevents concurrent creation for the same user pair
-    await tx.execute(`SELECT pg_advisory_xact_lock(${lockKey})`);
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(${lockKey})`);
 
     const myChannels = tx
       .select({ channelId: dmMembers.channelId })

--- a/apps/server/src/helpers/rate-limit-keys.ts
+++ b/apps/server/src/helpers/rate-limit-keys.ts
@@ -17,6 +17,7 @@ export const RL = {
 
   // User-based (used with checkUserRateLimit)
   MESSAGE_CREATE: "messages:create",
+  MESSAGE_EDIT: "messages:edit",
   FRIEND_REQUEST: "friends:request",
   FEEDBACK_CREATE: "feedback:create",
   FEEDBACK_VOTE: "feedback:vote",

--- a/apps/server/src/lib/redis-pubsub.ts
+++ b/apps/server/src/lib/redis-pubsub.ts
@@ -45,10 +45,14 @@ function ensureMessageListener(): void {
 // ── Publish (native PUBLISH) ────────────────────────────────────────────────
 
 export function publishCacheInvalidation(channel: PubSubChannelName, payload: object): void {
+  // Local handler already ran at the call site — publish is for other instances.
   if (!redis || isDev) return;
 
   redis.publish(channel, JSON.stringify({ ...payload, instanceId })).catch((err: Error) => {
-    console.error(`[redis-pubsub] Failed to publish to ${channel}:`, err);
+    console.error(
+      `[redis-pubsub] Failed to publish to ${channel} — other instances may serve stale data`,
+      { error: err.message, channel, payload },
+    );
   });
 }
 

--- a/apps/server/src/routes/message.ts
+++ b/apps/server/src/routes/message.ts
@@ -229,6 +229,13 @@ export const messageRoutes = new Elysia({ prefix: "/api/channels/:channelId/mess
 
   // PATCH /:messageId — Edit message
   .patch("/:messageId", async ({ user: sessionUser, params, body }) => {
+    await checkUserRateLimit(
+      sessionUser.id,
+      RL.MESSAGE_EDIT,
+      RATE_LIMIT_MESSAGE_CREATE.limit,
+      RATE_LIMIT_MESSAGE_CREATE.windowMs,
+    );
+
     const resolution = await resolveChannel(params.channelId, sessionUser.id);
 
     const parsed = validateInput(updateMessageSchema, body);

--- a/apps/server/src/routes/message.ts
+++ b/apps/server/src/routes/message.ts
@@ -24,11 +24,6 @@ import { validateInput } from "../helpers/validation.js";
 
 const DEFAULT_LIMIT = MESSAGE_PAGE_LIMIT;
 
-/** Escape HTML entities in message content (defense-in-depth, sanitize on write). */
-function sanitizeContent(text: string): string {
-  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-}
-
 const listQuerySchema = z.object({
   before: z.string().min(1).optional(),
   after: z.string().min(1).optional(),
@@ -102,14 +97,12 @@ export const messageRoutes = new Elysia({ prefix: "/api/channels/:channelId/mess
       throw new ValidationError("Message content is required");
     }
 
-    const content = sanitizeContent(parsed.content);
-
     const [inserted] = await db
       .insert(messages)
       .values({
         channelId: params.channelId,
         authorId: sessionUser.id,
-        content,
+        content: parsed.content,
       })
       .returning();
 
@@ -255,11 +248,10 @@ export const messageRoutes = new Elysia({ prefix: "/api/channels/:channelId/mess
       throw new ForbiddenError("Only the author can edit this message");
     }
 
-    const sanitizedContent = sanitizeContent(parsed.content);
     const editedAt = new Date();
     await db
       .update(messages)
-      .set({ content: sanitizedContent, editedAt })
+      .set({ content: parsed.content, editedAt })
       .where(eq(messages.id, params.messageId));
 
     const updated = await fetchMessageWithAuthor(params.messageId);
@@ -269,7 +261,7 @@ export const messageRoutes = new Elysia({ prefix: "/api/channels/:channelId/mess
       d: {
         id: messageId(params.messageId),
         channelId: channelId(params.channelId),
-        content: sanitizedContent,
+        content: parsed.content,
         editedAt,
       },
     } as const;


### PR DESCRIPTION
## Summary
From Codex audit findings, verified against current code:

- **Message escaping removed** — `sanitizeContent` was HTML-encoding content at write time, corrupting stored data (`<3` → `&lt;3`). Client renders as plain text tokens, not innerHTML, so this was defense-in-depth that actively harmed users
- **DM race condition fixed** — `ensureDmChannel` now uses a Postgres advisory lock (`pg_advisory_xact_lock`) scoped to the sorted user pair hash, making the check+insert atomic. Prevents duplicate DM channels from concurrent requests
- **Redis pubsub error logging improved** — Publish failures now log structured context (channel, payload) instead of just the error. Local cache mutations happen before publish so the local instance stays correct; the warning flags cross-instance staleness

## Test plan
- [x] Typecheck passes
- [x] 78/78 tests pass
- [ ] CI passes
- [ ] Manual: send a message containing `<3` and verify it stores/displays correctly
- [ ] Manual: verify DM creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of direct message channel creation under concurrent usage by adding a transactional lock to prevent duplicate channels.

* **Improvements**
  * Enhanced error logging for cache invalidation failures to aid cross-instance visibility.
  * Messages now preserve original content formatting when created or edited.
  * Added a new message-edit rate-limit key and enforced rate limiting on message edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->