### PR TITLE
feat: touch gestures — swipe sidebar and member list

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,6 @@ import { lazy, ErrorBoundary } from "solid-js";
 import { Router, Route } from "@solidjs/router";
 import AppLayout from "./components/AppLayout.js";
 import OfflineIndicator from "./components/OfflineIndicator.js";
-import InstallPrompt from "./components/InstallPrompt.js";
 import "./stores/theme-store.js"; // Initialize theme on app load
 
 // Public pages
@@ -79,7 +78,6 @@ const App = () => {
       )}
     >
       <OfflineIndicator />
-      <InstallPrompt />
       <Router>
         {/* Public */}
         <Route path="/" component={Landing} />

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -36,6 +36,8 @@ import {
   updateAllowedOrigins,
 } from "../lib/plugin-bridge.js";
 import FileReceiveModal from "./modals/FileReceiveModal.js";
+import InstallPrompt from "./InstallPrompt.js";
+
 const AppLayout: ParentComponent = (props) => {
   const session = useSession();
   const [showConnected, setShowConnected] = createSignal(false);
@@ -152,6 +154,7 @@ const AppLayout: ParentComponent = (props) => {
         <AppSidebar />
         <SidebarInset>
           <VerificationBanner />
+          <InstallPrompt />
           <div class="relative flex min-h-0 flex-1 flex-col overflow-hidden">
             {/* Always render children so chat content persists during disconnects */}
             <div

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -21,6 +21,7 @@ import FileDropZone from "./FileDropZone.js";
 import MemberList from "./MemberList.js";
 import { StatusDotInline, type UserStatus } from "./StatusDot.js";
 import { Sheet, SheetContent } from "./ui/sheet.js";
+import { createSwipeGesture } from "../lib/create-swipe-gesture.js";
 
 const ChatArea = () => {
   // Use Sheet overlay when viewport is too narrow for inline member list.
@@ -34,6 +35,15 @@ const ChatArea = () => {
     mql.addEventListener("change", handleResize);
   });
   onCleanup(() => mql?.removeEventListener("change", handleResize));
+
+  // Swipe right to close member list sheet on mobile
+  const [memberPanelRef, setMemberPanelRef] = createSignal<HTMLDivElement | undefined>();
+  createSwipeGesture({
+    target: memberPanelRef,
+    direction: "right",
+    enabled: () => useSheet() && showMembers(),
+    onSwipe: () => setShowMembers(false),
+  });
 
   const channelId = createMemo(
     () => selectedChannelId() ?? (selectedDmChannelId() as AnyChannelId | null),
@@ -209,7 +219,11 @@ const ChatArea = () => {
             <Show when={useSheet() && isServerChannel() && currentServer()}>
               {(server) => (
                 <Sheet open={showMembers()} onOpenChange={setShowMembers} side="right">
-                  <SheetContent side="right" onClose={() => setShowMembers(false)}>
+                  <SheetContent
+                    side="right"
+                    onClose={() => setShowMembers(false)}
+                    onPanelRef={setMemberPanelRef}
+                  >
                     <MemberList serverId={server().id} ownerId={server().ownerId} />
                   </SheetContent>
                 </Sheet>

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -39,22 +39,26 @@ const Sheet = (props: SheetProps) => {
 interface SheetContentProps extends JSX.HTMLAttributes<HTMLDivElement> {
   side?: "left" | "right";
   onClose?: () => void;
+  /** Callback to receive the panel element on mount (and undefined on unmount). */
+  onPanelRef?: (el: HTMLDivElement | undefined) => void;
 }
 
 const SheetContent = (props: SheetContentProps) => {
-  const [local, rest] = splitProps(props, ["class", "children", "side", "onClose"]);
+  const [local, rest] = splitProps(props, ["class", "children", "side", "onClose", "onPanelRef"]);
   const side = () => local.side ?? "left";
   // oxlint-disable-next-line eslint(no-unassigned-vars) -- SolidJS ref pattern
   let panelRef!: HTMLDivElement;
 
   onMount(() => {
     lockScroll();
+    local.onPanelRef?.(panelRef);
     const first = panelRef.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
     first?.focus();
   });
 
   onCleanup(() => {
     unlockScroll();
+    local.onPanelRef?.(undefined);
   });
 
   const handleKeyDown = (e: KeyboardEvent) => {

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -14,6 +14,7 @@ import {
 } from "solid-js";
 import { cn } from "../../lib/cn.js";
 import { Sheet, SheetContent } from "./sheet.js";
+import { createSwipeGesture } from "../../lib/create-swipe-gesture.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -89,6 +90,16 @@ const SidebarProvider = (props: SidebarProviderProps) => {
     });
   });
 
+  // Swipe from left edge to open sidebar on mobile
+  createSwipeGesture({
+    target: () => document.body,
+    direction: "right",
+    edgeZone: 30,
+    edgeFrom: "left",
+    enabled: () => isMobile() && !openMobile(),
+    onSwipe: () => setOpenMobile(true),
+  });
+
   const ctxValue: SidebarContextValue = {
     state,
     open,
@@ -137,6 +148,15 @@ const Sidebar = (props: SidebarComponentProps) => {
 
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
 
+  // Swipe left to close sidebar on mobile
+  const [sidebarPanelRef, setSidebarPanelRef] = createSignal<HTMLDivElement | undefined>();
+  createSwipeGesture({
+    target: sidebarPanelRef,
+    direction: "left",
+    enabled: () => isMobile() && openMobile(),
+    onSwipe: () => setOpenMobile(false),
+  });
+
   // Non-collapsible: simple static sidebar
   const renderNone = () => (
     <aside
@@ -156,6 +176,7 @@ const Sidebar = (props: SidebarComponentProps) => {
       <SheetContent
         side={side()}
         onClose={() => setOpenMobile(false)}
+        onPanelRef={setSidebarPanelRef}
         class="w-[var(--sidebar-width)] p-0"
         style={{ "--sidebar-width": SIDEBAR_WIDTH_MOBILE }}
       >

--- a/apps/web/src/lib/create-swipe-gesture.ts
+++ b/apps/web/src/lib/create-swipe-gesture.ts
@@ -1,0 +1,90 @@
+import { createEffect, onCleanup } from "solid-js";
+
+interface SwipeGestureOptions {
+  /** Reactive accessor — element to listen on. May appear/disappear (e.g. Sheet content). */
+  target: () => HTMLElement | undefined;
+  /** Swipe direction that triggers the callback. */
+  direction: "left" | "right";
+  /** Min horizontal distance in px to commit the swipe (default 50). */
+  threshold?: number;
+  /** Max start-x from edge in px, or null for anywhere (default null). */
+  edgeZone?: number | null;
+  /** Which viewport edge the edgeZone is measured from (default "left"). */
+  edgeFrom?: "left" | "right";
+  /** Reactive gate — listeners only attach when true. */
+  enabled: () => boolean;
+  /** Called when a qualifying swipe completes. */
+  onSwipe: () => void;
+}
+
+/**
+ * Reactive swipe gesture primitive.
+ * Attaches/detaches touch listeners when `enabled()` and `target()` change.
+ */
+export function createSwipeGesture(options: SwipeGestureOptions): void {
+  const threshold = options.threshold ?? 50;
+  const edgeZone = options.edgeZone ?? null;
+  const edgeFrom = options.edgeFrom ?? "left";
+
+  createEffect(() => {
+    const el = options.target();
+    const active = options.enabled();
+    if (!el || !active) return;
+
+    let startX = 0;
+    let startY = 0;
+    let aborted = false;
+
+    const onTouchStart = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      startX = touch.clientX;
+      startY = touch.clientY;
+      aborted = false;
+
+      if (edgeZone !== null) {
+        const x = touch.clientX;
+        if (edgeFrom === "left" && x > edgeZone) {
+          aborted = true;
+        } else if (edgeFrom === "right" && x < window.innerWidth - edgeZone) {
+          aborted = true;
+        }
+      }
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (aborted) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+      const deltaX = Math.abs(touch.clientX - startX);
+      const deltaY = Math.abs(touch.clientY - startY);
+      if (deltaY > deltaX) {
+        aborted = true;
+      }
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      if (aborted) return;
+      const touch = e.changedTouches[0];
+      if (!touch) return;
+      const deltaX = touch.clientX - startX;
+
+      if (options.direction === "right" && deltaX >= threshold) {
+        options.onSwipe();
+      } else if (options.direction === "left" && deltaX <= -threshold) {
+        options.onSwipe();
+      }
+    };
+
+    const opts: AddEventListenerOptions = { passive: true };
+    el.addEventListener("touchstart", onTouchStart, opts);
+    el.addEventListener("touchmove", onTouchMove, opts);
+    el.addEventListener("touchend", onTouchEnd, opts);
+
+    onCleanup(() => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `createSwipeGesture` primitive — reactive touch handler with `enabled()` gate, edge zone detection, and vertical scroll guard
- Swipe right from left edge (30px) opens sidebar on mobile
- Swipe left on open sidebar closes it
- Swipe right on member list sheet closes it
- Expose `onPanelRef` callback on `SheetContent` (mount + unmount lifecycle)
- All listeners passive, desktop completely unaffected

## Test plan

- [ ] Chrome DevTools mobile emulation: swipe right from left edge opens sidebar
- [ ] Swipe left on sidebar panel closes it
- [ ] Open member list on narrow viewport, swipe right to close
- [ ] Vertical scrolling in message list still works (no gesture interference)
- [ ] Desktop: sidebar toggle button, keyboard shortcut, member list button all work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile swipe gestures for navigation: swipe right from left edge to open the sidebar, swipe left to close it, and swipe right to close the member panel.
  * Install prompt relocated into the app layout (now shown in the sidebar inset area) — removed from the previous App placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->