### PR TITLE
feat: mobile UX polish — safe areas, touch behavior, overlay history

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/web/src/components/VirtualMessageList.tsx
+++ b/apps/web/src/components/VirtualMessageList.tsx
@@ -127,7 +127,12 @@ const VirtualMessageList = (props: { channelId: AnyChannelId }) => {
   }
 
   return (
-    <div ref={scrollRef} onScroll={handleScroll} class="min-h-0 flex-1 overflow-y-auto">
+    <div
+      ref={scrollRef}
+      onScroll={handleScroll}
+      data-slot="virtual-message-list"
+      class="min-h-0 flex-1 overflow-y-auto"
+    >
       <Show when={loading()}>
         <div class="space-y-3 py-4">
           <MessageSkeleton showHeader />

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "solid-js";
 import { Portal } from "solid-js/web";
 import { cn } from "../../lib/cn.js";
+import { pushOverlay, popOverlay } from "../../lib/overlay-history.js";
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -35,6 +36,10 @@ interface DialogContextValue {
 
 const DialogContext = createContext<DialogContextValue>();
 
+// Separate context to carry onOpenChange from Dialog → DialogContent
+// (DialogContext lives inside DialogContent for aria IDs, so can't carry close)
+const DialogCloseContext = createContext<() => void>();
+
 interface DialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -50,7 +55,13 @@ const Dialog = (props: DialogProps) => {
   onMount(() => document.addEventListener("keydown", handleKeyDown));
   onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
 
-  return <Show when={props.open}>{props.children}</Show>;
+  return (
+    <Show when={props.open}>
+      <DialogCloseContext.Provider value={() => props.onOpenChange(false)}>
+        {props.children}
+      </DialogCloseContext.Provider>
+    </Show>
+  );
 };
 
 const DialogOverlay = (props: JSX.HTMLAttributes<HTMLDivElement>) => {
@@ -72,6 +83,9 @@ const DialogContent = (props: DialogContentProps) => {
   const [local, rest] = splitProps(props, ["class", "children", "onClose"]);
   const titleId = createUniqueId();
   const descriptionId = createUniqueId();
+  const closeFromContext = useContext(DialogCloseContext);
+  const close = () => (local.onClose ?? closeFromContext ?? (() => {}))();
+  const overlayId = `dialog-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   // oxlint-disable-next-line eslint(no-unassigned-vars) -- SolidJS ref pattern
   let panelRef!: HTMLDivElement;
 
@@ -79,9 +93,11 @@ const DialogContent = (props: DialogContentProps) => {
     const first = panelRef.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
     first?.focus();
     lockScroll();
+    pushOverlay(overlayId, close);
   });
 
   onCleanup(() => {
+    popOverlay(overlayId);
     unlockScroll();
   });
 
@@ -106,10 +122,7 @@ const DialogContent = (props: DialogContentProps) => {
   return (
     <DialogContext.Provider value={{ titleId, descriptionId }}>
       <Portal mount={document.body}>
-        <div
-          class="fixed inset-0 z-50 flex items-center justify-center"
-          onClick={() => local.onClose?.()}
-        >
+        <div class="fixed inset-0 z-50 flex items-center justify-center" onClick={close}>
           <DialogOverlay />
           <div
             ref={panelRef}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,6 +1,7 @@
 import { Show, onMount, onCleanup, splitProps, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { cn } from "../../lib/cn.js";
+import { pushOverlay, popOverlay } from "../../lib/overlay-history.js";
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -49,14 +50,18 @@ const SheetContent = (props: SheetContentProps) => {
   // oxlint-disable-next-line eslint(no-unassigned-vars) -- SolidJS ref pattern
   let panelRef!: HTMLDivElement;
 
+  const overlayId = `sheet-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
   onMount(() => {
     lockScroll();
     local.onPanelRef?.(panelRef);
+    pushOverlay(overlayId, () => local.onClose?.());
     const first = panelRef.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
     first?.focus();
   });
 
   onCleanup(() => {
+    popOverlay(overlayId);
     unlockScroll();
     local.onPanelRef?.(undefined);
   });

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,7 +1,17 @@
-import { Show, onMount, onCleanup, splitProps, type JSX } from "solid-js";
+import {
+  Show,
+  onMount,
+  onCleanup,
+  splitProps,
+  createContext,
+  useContext,
+  type JSX,
+} from "solid-js";
 import { Portal } from "solid-js/web";
 import { cn } from "../../lib/cn.js";
 import { pushOverlay, popOverlay } from "../../lib/overlay-history.js";
+
+const SheetCloseContext = createContext<() => void>();
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -34,7 +44,13 @@ const Sheet = (props: SheetProps) => {
   onMount(() => document.addEventListener("keydown", handleKeyDown));
   onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
 
-  return <Show when={props.open}>{props.children}</Show>;
+  return (
+    <Show when={props.open}>
+      <SheetCloseContext.Provider value={() => props.onOpenChange(false)}>
+        {props.children}
+      </SheetCloseContext.Provider>
+    </Show>
+  );
 };
 
 interface SheetContentProps extends JSX.HTMLAttributes<HTMLDivElement> {
@@ -50,12 +66,14 @@ const SheetContent = (props: SheetContentProps) => {
   // oxlint-disable-next-line eslint(no-unassigned-vars) -- SolidJS ref pattern
   let panelRef!: HTMLDivElement;
 
+  const closeFromContext = useContext(SheetCloseContext);
+  const close = () => (local.onClose ?? closeFromContext ?? (() => {}))();
   const overlayId = `sheet-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
 
   onMount(() => {
     lockScroll();
     local.onPanelRef?.(panelRef);
-    pushOverlay(overlayId, () => local.onClose?.());
+    pushOverlay(overlayId, close);
     const first = panelRef.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
     first?.focus();
   });

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -101,7 +101,7 @@ const SheetContent = (props: SheetContentProps) => {
 
   return (
     <Portal mount={document.body}>
-      <div class="fixed inset-0 z-50 flex" onClick={() => local.onClose?.()}>
+      <div class="fixed inset-0 z-50 flex" onClick={close}>
         {/* Overlay */}
         <div class="fixed inset-0 bg-black/50 backdrop-blur-sm" />
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -269,6 +269,33 @@ body::after {
   }
 }
 
+/* ── Mobile UX ─────────────────────────────────────────────────────── */
+
+/* Safe area insets — notch, home indicator, punch-hole cameras */
+#app {
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  box-sizing: border-box;
+}
+
+/* Prevent double-tap zoom on interactive elements */
+button,
+a,
+input,
+select,
+textarea,
+[role="button"] {
+  touch-action: manipulation;
+}
+
+/* Prevent pull-to-refresh and overscroll bounce in scrollable panels */
+[data-slot="sidebar-content"],
+[data-slot="virtual-message-list"] {
+  overscroll-behavior: contain;
+}
+
 .no-transitions *,
 .no-transitions *::before,
 .no-transitions *::after {

--- a/apps/web/src/lib/overlay-history.ts
+++ b/apps/web/src/lib/overlay-history.ts
@@ -20,16 +20,24 @@ let handlingPopstate = false;
 /** Count of popstate events to suppress (triggered by our own history.back() cleanup). */
 let skipPopstateCount = 0;
 
-function onPopstate(): void {
+function onPopstate(event: Event): void {
   if (skipPopstateCount > 0) {
     skipPopstateCount--;
     return;
   }
   if (stack.length === 0) return;
 
-  const entry = stack.pop()!;
+  // Validate that the history state matches the topmost overlay
+  const top = stack[stack.length - 1]!;
+  const state = (event as PopStateEvent).state as { overlayId?: string } | null;
+  if (!state?.overlayId || state.overlayId !== top.id) return;
+
+  // Prevent SolidJS router from also handling this popstate
+  event.stopImmediatePropagation();
+
+  stack.pop();
   handlingPopstate = true;
-  entry.close();
+  top.close();
   handlingPopstate = false;
 }
 
@@ -50,11 +58,16 @@ export function pushOverlay(id: string, close: CloseCallback): void {
 export function popOverlay(id: string): void {
   const idx = stack.findIndex((e) => e.id === id);
   if (idx === -1) return;
+
+  const wasTopmost = idx === stack.length - 1;
   stack.splice(idx, 1);
 
   if (handlingPopstate) return;
 
-  // Overlay closed via Escape/click — clean up the dead history entry
-  skipPopstateCount++;
-  history.back();
+  // Only manipulate history for the topmost overlay — non-topmost entries
+  // don't have the matching history state on top of the history stack
+  if (wasTopmost) {
+    skipPopstateCount++;
+    history.back();
+  }
 }

--- a/apps/web/src/lib/overlay-history.ts
+++ b/apps/web/src/lib/overlay-history.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared overlay history manager.
+ * Pushes history entries when overlays open so the Android back button
+ * (and browser back) closes overlays instead of navigating away.
+ */
+
+type CloseCallback = () => void;
+
+interface OverlayEntry {
+  id: string;
+  close: CloseCallback;
+}
+
+const stack: OverlayEntry[] = [];
+let listening = false;
+
+/** True while the popstate listener is closing an overlay via user back press. */
+let handlingPopstate = false;
+
+/** Count of popstate events to suppress (triggered by our own history.back() cleanup). */
+let skipPopstateCount = 0;
+
+function onPopstate(): void {
+  if (skipPopstateCount > 0) {
+    skipPopstateCount--;
+    return;
+  }
+  if (stack.length === 0) return;
+
+  const entry = stack.pop()!;
+  handlingPopstate = true;
+  entry.close();
+  handlingPopstate = false;
+}
+
+function ensureListening(): void {
+  if (listening) return;
+  window.addEventListener("popstate", onPopstate);
+  listening = true;
+}
+
+/** Register an overlay. Pushes a history entry so back-button closes it. */
+export function pushOverlay(id: string, close: CloseCallback): void {
+  ensureListening();
+  stack.push({ id, close });
+  history.pushState({ overlayId: id }, "");
+}
+
+/** Unregister an overlay. Cleans up the matching history entry if needed. */
+export function popOverlay(id: string): void {
+  const idx = stack.findIndex((e) => e.id === id);
+  if (idx === -1) return;
+  stack.splice(idx, 1);
+
+  if (handlingPopstate) return;
+
+  // Overlay closed via Escape/click — clean up the dead history entry
+  skipPopstateCount++;
+  history.back();
+}

--- a/apps/web/src/lib/overlay-history.ts
+++ b/apps/web/src/lib/overlay-history.ts
@@ -1,7 +1,8 @@
 /**
  * Shared overlay history manager.
- * Pushes history entries when overlays open so the Android back button
- * (and browser back) closes overlays instead of navigating away.
+ *
+ * Maintains exactly ONE history entry while any overlay is open, zero when none are.
+ * Back button closes the topmost overlay. Escape/click close also cleans up correctly.
  */
 
 type CloseCallback = () => void;
@@ -20,6 +21,8 @@ let handlingPopstate = false;
 /** Count of popstate events to suppress (triggered by our own history.back() cleanup). */
 let skipPopstateCount = 0;
 
+const HISTORY_STATE = { overlay: true } as const;
+
 function onPopstate(event: Event): void {
   if (skipPopstateCount > 0) {
     skipPopstateCount--;
@@ -27,18 +30,18 @@ function onPopstate(event: Event): void {
   }
   if (stack.length === 0) return;
 
-  // Validate that the history state matches the topmost overlay
-  const top = stack[stack.length - 1]!;
-  const state = (event as PopStateEvent).state as { overlayId?: string } | null;
-  if (!state?.overlayId || state.overlayId !== top.id) return;
-
   // Prevent SolidJS router from also handling this popstate
   event.stopImmediatePropagation();
 
-  stack.pop();
+  const entry = stack.pop()!;
   handlingPopstate = true;
-  top.close();
+  entry.close();
   handlingPopstate = false;
+
+  // If overlays remain, re-push the single history guard entry
+  if (stack.length > 0) {
+    history.pushState(HISTORY_STATE, "");
+  }
 }
 
 function ensureListening(): void {
@@ -47,26 +50,26 @@ function ensureListening(): void {
   listening = true;
 }
 
-/** Register an overlay. Pushes a history entry so back-button closes it. */
+/** Register an overlay. Pushes a history entry only for the first overlay. */
 export function pushOverlay(id: string, close: CloseCallback): void {
   ensureListening();
+  const wasEmpty = stack.length === 0;
   stack.push({ id, close });
-  history.pushState({ overlayId: id }, "");
+  if (wasEmpty) {
+    history.pushState(HISTORY_STATE, "");
+  }
 }
 
-/** Unregister an overlay. Cleans up the matching history entry if needed. */
+/** Unregister an overlay. Cleans up the history entry when the last overlay closes. */
 export function popOverlay(id: string): void {
   const idx = stack.findIndex((e) => e.id === id);
   if (idx === -1) return;
-
-  const wasTopmost = idx === stack.length - 1;
   stack.splice(idx, 1);
 
   if (handlingPopstate) return;
 
-  // Only manipulate history for the topmost overlay — non-topmost entries
-  // don't have the matching history state on top of the history stack
-  if (wasTopmost) {
+  // When the last overlay closes via Escape/click, clean up the single history entry
+  if (stack.length === 0) {
     skipPopstateCount++;
     history.back();
   }


### PR DESCRIPTION
## Summary

- Add `viewport-fit=cover` and safe area inset padding on `#app` for notch/home indicator
- `touch-action: manipulation` on interactive elements — prevents double-tap zoom
- `overscroll-behavior: contain` on sidebar content and message list
- Overlay history manager with symmetric cleanup (two suppression paths for stacked overlays)
- Sheet and Dialog both register with overlay history — Android back button closes overlays
- `DialogCloseContext` carries `onOpenChange` from Dialog to DialogContent — all 16 dialog users get back button support without call-site changes
- `data-slot="virtual-message-list"` on VirtualMessageList scroll container for CSS targeting

## Test plan

- [ ] Chrome DevTools mobile emulation with notch: content not clipped
- [ ] No double-tap zoom on buttons/inputs
- [ ] Message list scroll doesn't trigger pull-to-refresh
- [ ] Open Sheet → press back → Sheet closes (not page navigation)
- [ ] Open Dialog → press back → Dialog closes
- [ ] Open/close overlays via Escape/click → back button navigates normally (no dead entries)
- [ ] Stacked overlays: back closes topmost first
- [ ] Desktop: all overlays work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mobile experience with safe-area support (notched devices) and viewport sizing
  * Faster, more responsive touch interactions on interactive elements
  * Reduced overscroll/pull-to-refresh in side panels for smoother scrolling

* **Bug Fixes**
  * Dialogs and sheets now respect back-button navigation and close reliably on mobile
  * More consistent scroll behavior in message lists and panels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->