### PR TITLE
feat: notification settings and DM unread badge

### DIFF
--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -11,7 +11,7 @@ import {
   currentServer,
   currentChannels,
 } from "../stores/app-store.js";
-import { getUnreadCount } from "../stores/notification-store.js";
+import { getUnreadCount, getTotalDmUnread } from "../stores/notification-store.js";
 import {
   Sidebar,
   SidebarHeader,
@@ -458,6 +458,11 @@ const AppSidebar = () => {
                   />
                 </svg>
                 <span>Direct Messages</span>
+                <Show when={getTotalDmUnread() > 0}>
+                  <span class="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-bold text-primary-foreground">
+                    {getTotalDmUnread()}
+                  </span>
+                </Show>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -458,11 +458,16 @@ const AppSidebar = () => {
                   />
                 </svg>
                 <span>Direct Messages</span>
-                <Show when={getTotalDmUnread() > 0}>
-                  <span class="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-bold text-primary-foreground">
-                    {getTotalDmUnread()}
-                  </span>
-                </Show>
+                {(() => {
+                  const count = getTotalDmUnread();
+                  return (
+                    <Show when={count > 0}>
+                      <span class="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-bold text-primary-foreground">
+                        {count}
+                      </span>
+                    </Show>
+                  );
+                })()}
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/apps/web/src/components/settings/notification-settings.tsx
+++ b/apps/web/src/components/settings/notification-settings.tsx
@@ -5,10 +5,16 @@ import {
 } from "../../stores/notification-store.js";
 import { requestPermission } from "../../lib/browser-notifications.js";
 
+function readPermission(): NotificationPermission {
+  try {
+    return "Notification" in window ? Notification.permission : "default";
+  } catch {
+    return "default";
+  }
+}
+
 const NotificationSettings = () => {
-  const [permissionState, setPermissionState] = createSignal(
-    "Notification" in window ? Notification.permission : "default",
-  );
+  const [permissionState, setPermissionState] = createSignal(readPermission());
 
   async function handleRequestPermission() {
     const granted = await requestPermission();

--- a/apps/web/src/components/settings/notification-settings.tsx
+++ b/apps/web/src/components/settings/notification-settings.tsx
@@ -1,0 +1,114 @@
+import { createSignal, Show } from "solid-js";
+import {
+  browserNotificationsEnabled,
+  setBrowserNotifications,
+} from "../../stores/notification-store.js";
+import { requestPermission } from "../../lib/browser-notifications.js";
+
+const NotificationSettings = () => {
+  const [permissionState, setPermissionState] = createSignal(
+    "Notification" in window ? Notification.permission : "default",
+  );
+
+  async function handleRequestPermission() {
+    const granted = await requestPermission();
+    setPermissionState(Notification.permission);
+    if (granted) setBrowserNotifications(true);
+  }
+
+  return (
+    <div class="space-y-8">
+      {/* Browser notifications toggle */}
+      <div>
+        <h3 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Browser Notifications
+        </h3>
+        <div class="flex items-center justify-between gap-4 rounded-md border border-border bg-card px-4 py-3">
+          <div>
+            <p class="text-sm font-medium text-foreground">Enable browser notifications</p>
+            <p class="text-xs text-muted-foreground">
+              Show system notifications for new messages when UnCorded is in the background
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={browserNotificationsEnabled()}
+            class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors"
+            classList={{
+              "bg-primary": browserNotificationsEnabled(),
+              "bg-muted": !browserNotificationsEnabled(),
+            }}
+            onClick={() => setBrowserNotifications(!browserNotificationsEnabled())}
+          >
+            <span
+              class="pointer-events-none block h-5 w-5 rounded-full bg-foreground shadow-sm transition-transform"
+              classList={{
+                "translate-x-5": browserNotificationsEnabled(),
+                "translate-x-0": !browserNotificationsEnabled(),
+              }}
+            />
+          </button>
+        </div>
+      </div>
+
+      {/* Permission status */}
+      <div>
+        <h3 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          Permission Status
+        </h3>
+        <div class="rounded-md border border-border bg-card px-4 py-3">
+          <Show when={permissionState() === "granted"}>
+            <div class="flex items-center gap-2">
+              <span class="inline-flex items-center rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+                Allowed
+              </span>
+              <span class="text-sm text-muted-foreground">Browser notifications are permitted</span>
+            </div>
+          </Show>
+
+          <Show when={permissionState() === "denied"}>
+            <div class="space-y-2">
+              <div class="flex items-center gap-2">
+                <span class="inline-flex items-center rounded-full bg-destructive/15 px-2 py-0.5 text-xs font-medium text-destructive">
+                  Blocked
+                </span>
+                <span class="text-sm text-muted-foreground">
+                  Notifications are blocked by your browser
+                </span>
+              </div>
+              <p class="text-xs text-muted-foreground">
+                To re-enable, open your browser's site settings for this page and allow
+                notifications.
+              </p>
+            </div>
+          </Show>
+
+          <Show when={permissionState() === "default"}>
+            <div class="flex items-center justify-between gap-4">
+              <div class="flex items-center gap-2">
+                <span class="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                  Not asked
+                </span>
+                <span class="text-sm text-muted-foreground">
+                  Browser hasn't been asked for permission yet
+                </span>
+              </div>
+              <Show when={browserNotificationsEnabled()}>
+                <button
+                  type="button"
+                  class="shrink-0 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                  onClick={handleRequestPermission}
+                >
+                  Request Permission
+                </button>
+              </Show>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationSettings;

--- a/apps/web/src/pages/settings/notification-settings.tsx
+++ b/apps/web/src/pages/settings/notification-settings.tsx
@@ -1,7 +1,1 @@
-import FallbackPage from "../FallbackPage.js";
-
-const NotificationSettings = () => (
-  <FallbackPage title="Notifications" description="Notification preferences are coming soon." />
-);
-
-export default NotificationSettings;
+export { default } from "../../components/settings/notification-settings.js";

--- a/apps/web/src/stores/notification-store.ts
+++ b/apps/web/src/stores/notification-store.ts
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store";
-import { createEffect, createMemo, createRoot } from "solid-js";
+import { createEffect, createMemo, createRoot, createSignal } from "solid-js";
 import { Opcode } from "@uncorded/protocol";
 import type { AnyChannelId, DmChannelId } from "@uncorded/protocol";
 import {
@@ -42,6 +42,38 @@ export function markRead(chId: AnyChannelId): void {
   }
 }
 
+export function getTotalDmUnread(): number {
+  const dms = readyData.data?.dmChannels;
+  if (!dms) return 0;
+  let total = 0;
+  for (const dm of dms) total += getUnreadCount(dm.id);
+  return total;
+}
+
+// ── Browser notification preference ─────────────────────────────────────────
+
+const BROWSER_NOTIF_KEY = "uncorded:browser-notifications";
+
+function readBrowserNotifPref(): boolean {
+  try {
+    return localStorage.getItem(BROWSER_NOTIF_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+const [browserNotificationsEnabled, setBrowserNotificationsEnabledSignal] =
+  createSignal(readBrowserNotifPref());
+
+export function setBrowserNotifications(enabled: boolean): void {
+  setBrowserNotificationsEnabledSignal(enabled);
+  try {
+    localStorage.setItem(BROWSER_NOTIF_KEY, String(enabled));
+  } catch {}
+}
+
+export { browserNotificationsEnabled };
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function incrementUnread(chId: string): void {
@@ -76,6 +108,7 @@ function findDmChannelBySender(senderId: string): string | null {
 let permissionRequested = false;
 
 function notifyBrowser(title: string, body: string): void {
+  if (!browserNotificationsEnabled()) return;
   if (!permissionRequested) {
     permissionRequested = true;
     requestPermission().then((granted) => {

--- a/apps/web/src/stores/notification-store.ts
+++ b/apps/web/src/stores/notification-store.ts
@@ -69,7 +69,11 @@ export function setBrowserNotifications(enabled: boolean): void {
   setBrowserNotificationsEnabledSignal(enabled);
   try {
     localStorage.setItem(BROWSER_NOTIF_KEY, String(enabled));
-  } catch {}
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error(`Failed to persist ${BROWSER_NOTIF_KEY}:`, err);
+    }
+  }
 }
 
 export { browserNotificationsEnabled };


### PR DESCRIPTION
## Summary

- Add `browserNotificationsEnabled` preference (localStorage, default on) that gates `requestPermission()` and `showBrowserNotification()` only
- Build notification settings page with toggle switch and browser permission status display
- Follow existing `components/settings/` + page re-export pattern
- Add `getTotalDmUnread()` helper and aggregate DM unread badge on sidebar nav item
- Unread counts, in-app toasts, and document title badge are completely unaffected

## Test plan

- [ ] Toggle off → receive message → no browser notification, but toast and unread badge appear
- [ ] Toggle on → permission prompt if not yet granted → browser notification fires
- [ ] Permission "denied" → shows re-enable instructions
- [ ] Preference persists across page reloads
- [ ] From non-DM route, receive DM → "Direct Messages" sidebar item shows aggregate badge
- [ ] Per-conversation badges still work inside DM list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct Messages sidebar now displays an unread count badge
  * Added browser notification settings with permission management
  * Toggle to enable or disable browser notifications
  * View current browser notification permission status and request access when needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->