### PR TITLE
test: add tests for overlay history and browser notifications

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@solidjs/router": "^0.15",
@@ -26,10 +27,12 @@
   },
   "devDependencies": {
     "@types/webtorrent": "^0.110.1",
+    "happy-dom": "^20.8.9",
     "solid-js": "^1",
     "vite": "^6",
     "vite-plugin-node-polyfills": "^0.25.0",
     "vite-plugin-pwa": "^1.2.0",
-    "vite-plugin-solid": "^2"
+    "vite-plugin-solid": "^2",
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("browser-notifications", () => {
+  let initBrowserNotifications: typeof import("./browser-notifications.js").initBrowserNotifications;
+  let requestPermission: typeof import("./browser-notifications.js").requestPermission;
+  let showBrowserNotification: typeof import("./browser-notifications.js").showBrowserNotification;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("./browser-notifications.js");
+    initBrowserNotifications = mod.initBrowserNotifications;
+    requestPermission = mod.requestPermission;
+    showBrowserNotification = mod.showBrowserNotification;
+  });
+
+  describe("initBrowserNotifications", () => {
+    it("reads Notification.permission on init", () => {
+      Object.defineProperty(window, "Notification", {
+        value: { permission: "granted", requestPermission: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
+      initBrowserNotifications();
+      // After init with granted, requestPermission should return true immediately
+    });
+
+    it("handles missing Notification API gracefully", () => {
+      const orig = (window as unknown as Record<string, unknown>).Notification;
+      delete (window as unknown as Record<string, unknown>).Notification;
+      expect(() => initBrowserNotifications()).not.toThrow();
+      (window as unknown as Record<string, unknown>).Notification = orig;
+    });
+  });
+
+  describe("requestPermission", () => {
+    it("returns false when Notification API is missing", async () => {
+      const orig = (window as unknown as Record<string, unknown>).Notification;
+      delete (window as unknown as Record<string, unknown>).Notification;
+      const result = await requestPermission();
+      expect(result).toBe(false);
+      (window as unknown as Record<string, unknown>).Notification = orig;
+    });
+
+    it("returns true immediately when already granted", async () => {
+      Object.defineProperty(window, "Notification", {
+        value: { permission: "granted", requestPermission: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
+      initBrowserNotifications();
+      const result = await requestPermission();
+      expect(result).toBe(true);
+    });
+
+    it("returns false immediately when denied", async () => {
+      Object.defineProperty(window, "Notification", {
+        value: { permission: "denied", requestPermission: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
+      initBrowserNotifications();
+      const result = await requestPermission();
+      expect(result).toBe(false);
+    });
+
+    it("requests permission when state is default", async () => {
+      const mockRequest = vi.fn().mockResolvedValue("granted");
+      Object.defineProperty(window, "Notification", {
+        value: { permission: "default", requestPermission: mockRequest },
+        writable: true,
+        configurable: true,
+      });
+      initBrowserNotifications();
+      const result = await requestPermission();
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+    });
+
+    it("returns false when user denies permission prompt", async () => {
+      const mockRequest = vi.fn().mockResolvedValue("denied");
+      Object.defineProperty(window, "Notification", {
+        value: { permission: "default", requestPermission: mockRequest },
+        writable: true,
+        configurable: true,
+      });
+      initBrowserNotifications();
+      const result = await requestPermission();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("showBrowserNotification", () => {
+    it("does not create notification when permission is not granted", () => {
+      const MockNotification = vi.fn();
+      Object.defineProperty(window, "Notification", {
+        value: Object.assign(MockNotification, {
+          permission: "default",
+          requestPermission: vi.fn(),
+        }),
+        writable: true,
+        configurable: true,
+      });
+      initBrowserNotifications();
+      showBrowserNotification("Test", "Body");
+      expect(MockNotification).not.toHaveBeenCalled();
+    });
+
+    it("does not create notification when document has focus", () => {
+      const calls: unknown[][] = [];
+      const MockNotification = vi.fn().mockImplementation(function (
+        this: unknown,
+        ...args: unknown[]
+      ) {
+        calls.push(args);
+        return { addEventListener: vi.fn() };
+      });
+      Object.defineProperty(window, "Notification", {
+        value: Object.assign(MockNotification, {
+          permission: "granted",
+          requestPermission: vi.fn(),
+        }),
+        writable: true,
+        configurable: true,
+      });
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      initBrowserNotifications();
+      showBrowserNotification("Test", "Body");
+      expect(calls).toHaveLength(0);
+    });
+
+    it("creates notification when granted and not focused", () => {
+      const calls: unknown[][] = [];
+      const MockNotification = vi.fn().mockImplementation(function (
+        this: unknown,
+        ...args: unknown[]
+      ) {
+        calls.push(args);
+        return { addEventListener: vi.fn() };
+      });
+      Object.defineProperty(window, "Notification", {
+        value: Object.assign(MockNotification, {
+          permission: "granted",
+          requestPermission: vi.fn(),
+        }),
+        writable: true,
+        configurable: true,
+      });
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+      initBrowserNotifications();
+      showBrowserNotification("Test Title", "Test Body");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual([
+        "Test Title",
+        {
+          body: "Test Body",
+          icon: "/icon-192.png",
+          tag: "uncorded-message",
+        },
+      ]);
+    });
+  });
+});

--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -14,14 +14,19 @@ describe("browser-notifications", () => {
   });
 
   describe("initBrowserNotifications", () => {
-    it("reads Notification.permission on init", () => {
+    it("reads Notification.permission on init", async () => {
+      const mockRequest = vi.fn();
       Object.defineProperty(window, "Notification", {
-        value: { permission: "granted", requestPermission: vi.fn() },
+        value: { permission: "granted", requestPermission: mockRequest },
         writable: true,
         configurable: true,
       });
       initBrowserNotifications();
-      // After init with granted, requestPermission should return true immediately
+      // After init with "granted", requestPermission should resolve true
+      // without calling the browser's requestPermission
+      const result = await requestPermission();
+      expect(result).toBe(true);
+      expect(mockRequest).not.toHaveBeenCalled();
     });
 
     it("handles missing Notification API gracefully", () => {

--- a/apps/web/src/lib/overlay-history.test.ts
+++ b/apps/web/src/lib/overlay-history.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("overlay-history", () => {
+  let pushOverlay: typeof import("./overlay-history.js").pushOverlay;
+  let popOverlay: typeof import("./overlay-history.js").popOverlay;
+
+  let pushStateSpy: ReturnType<typeof vi.spyOn>;
+  let backSpy: ReturnType<typeof vi.spyOn>;
+  const closers: Record<string, ReturnType<typeof vi.fn<() => void>>> = {};
+
+  // Track the popstate handler so we can clean it up between tests
+  let popstateHandler: ((e: Event) => void) | null = null;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    // Intercept addEventListener to capture the popstate handler.
+    // Must stay active until after pushOverlay's first call to ensureListening().
+    const origAdd = window.addEventListener.bind(window);
+    vi.spyOn(window, "addEventListener").mockImplementation(((
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      if (type === "popstate") {
+        popstateHandler = listener as (e: Event) => void;
+      }
+      origAdd(type, listener, options);
+    }) as typeof window.addEventListener);
+
+    const mod = await import("./overlay-history.js");
+    pushOverlay = mod.pushOverlay;
+    popOverlay = mod.popOverlay;
+
+    pushStateSpy = vi.spyOn(history, "pushState").mockImplementation(() => {});
+    backSpy = vi.spyOn(history, "back").mockImplementation(() => {});
+
+    closers.a = vi.fn();
+    closers.b = vi.fn();
+    closers.c = vi.fn();
+  });
+
+  afterEach(() => {
+    if (popstateHandler) {
+      window.removeEventListener("popstate", popstateHandler);
+      popstateHandler = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  /** Simulate a browser back-button popstate event */
+  function firePopstate() {
+    // Call the handler directly since dispatchEvent may not work reliably
+    // when history.back is mocked
+    if (popstateHandler) {
+      popstateHandler(new Event("popstate"));
+    }
+  }
+
+  it("pushes a history entry on first overlay", () => {
+    pushOverlay("a", closers.a!);
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    expect(pushStateSpy).toHaveBeenCalledWith({ overlay: true }, "");
+  });
+
+  it("does not push additional history entries for subsequent overlays", () => {
+    pushOverlay("a", closers.a!);
+    pushOverlay("b", closers.b!);
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls history.back when the last overlay is popped via Escape/click", () => {
+    pushOverlay("a", closers.a!);
+    popOverlay("a");
+    expect(backSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call history.back when non-last overlay is popped", () => {
+    pushOverlay("a", closers.a!);
+    pushOverlay("b", closers.b!);
+    popOverlay("a");
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls history.back only when the final overlay is popped", () => {
+    pushOverlay("a", closers.a!);
+    pushOverlay("b", closers.b!);
+    popOverlay("a"); // non-topmost, no history.back
+    popOverlay("b"); // last one, should call history.back
+    expect(backSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores popOverlay for unknown ids", () => {
+    pushOverlay("a", closers.a!);
+    popOverlay("unknown");
+    // "a" is still there, so no history.back
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles popstate by closing topmost overlay", () => {
+    pushOverlay("a", closers.a!);
+    pushOverlay("b", closers.b!);
+
+    firePopstate();
+
+    expect(closers.b).toHaveBeenCalledTimes(1);
+    expect(closers.a).not.toHaveBeenCalled();
+  });
+
+  it("re-pushes history entry after popstate if overlays remain", () => {
+    pushOverlay("a", closers.a!);
+    pushOverlay("b", closers.b!);
+    pushStateSpy.mockClear();
+
+    firePopstate();
+
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    expect(pushStateSpy).toHaveBeenCalledWith({ overlay: true }, "");
+  });
+
+  it("does not re-push after popstate if no overlays remain", () => {
+    pushOverlay("a", closers.a!);
+    pushStateSpy.mockClear();
+
+    firePopstate();
+
+    expect(pushStateSpy).not.toHaveBeenCalled();
+  });
+
+  it("popstate does nothing when stack is empty", () => {
+    firePopstate();
+    expect(closers.a).not.toHaveBeenCalled();
+  });
+
+  it("suppresses popstate triggered by our own history.back cleanup", () => {
+    pushOverlay("a", closers.a!);
+
+    // Pop "a" via Escape — last overlay, so it calls history.back()
+    popOverlay("a");
+    expect(backSpy).toHaveBeenCalledTimes(1);
+
+    // Simulate the popstate that history.back() would trigger
+    // skipPopstateCount should suppress this — no overlay should close
+    // (stack is already empty anyway, but the suppression prevents side effects)
+    firePopstate();
+
+    // Verify the suppression counter consumed the event
+    expect(closers.a).not.toHaveBeenCalled();
+  });
+
+  it("does not call history.back when popping non-last overlay", () => {
+    pushOverlay("a", closers.a!);
+    pushOverlay("b", closers.b!);
+
+    // Pop "b" via Escape — "a" still open, so no history.back needed
+    popOverlay("b");
+    expect(backSpy).not.toHaveBeenCalled();
+
+    // A subsequent popstate (real back button) should close "a"
+    firePopstate();
+    expect(closers.a).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles three stacked overlays correctly", () => {
+    pushOverlay("a", closers.a!);
+    pushOverlay("b", closers.b!);
+    pushOverlay("c", closers.c!);
+
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+
+    // Close middle one via Escape
+    popOverlay("b");
+    expect(backSpy).not.toHaveBeenCalled(); // not last
+
+    // Close top via back button
+    firePopstate();
+    expect(closers.c).toHaveBeenCalledTimes(1);
+
+    // "a" still open — popstate handler should have re-pushed
+    expect(pushStateSpy).toHaveBeenCalledTimes(2);
+
+    // Close "a" via Escape — last one
+    popOverlay("a");
+    expect(backSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "happy-dom",
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -103,11 +103,13 @@
       },
       "devDependencies": {
         "@types/webtorrent": "^0.110.1",
+        "happy-dom": "^20.8.9",
         "solid-js": "^1",
         "vite": "^6",
         "vite-plugin-node-polyfills": "^0.25.0",
         "vite-plugin-pwa": "^1.2.0",
         "vite-plugin-solid": "^2",
+        "vitest": "^4.1.2",
       },
     },
     "packages/create-uncorded-plugin": {
@@ -1180,19 +1182,19 @@
 
     "@valibot/to-json-schema": ["@valibot/to-json-schema@1.0.0", "", { "peerDependencies": { "valibot": "^1.0.0" } }, "sha512-/9crJgPptVsGCL6X+JPDQyaJwkalSZ/52WuF8DiRUxJgcmpNdzYRfZ+gqMEP8W3CTVfuMWPqqvIgfwJ97f9Etw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+    "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.2", "", { "dependencies": { "@vitest/spy": "4.1.2", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.2", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA=="],
 
-    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+    "@vitest/runner": ["@vitest/runner@4.1.2", "", { "dependencies": { "@vitest/utils": "4.1.2", "pathe": "^2.0.3" } }, "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A=="],
 
-    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+    "@vitest/spy": ["@vitest/spy@4.1.2", "", {}, "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA=="],
 
-    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+    "@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
 
     "@webtorrent/http-node": ["@webtorrent/http-node@1.3.0", "", { "dependencies": { "freelist": "^1.0.3", "http-parser-js": "^0.4.3" } }, "sha512-GWZQKroPES4z91Ijx6zsOsb7+USOxjy66s8AoTWg0HiBBdfnbtf9aeh3Uav0MgYn4BL8Q7tVSUpd0gGpngKGEQ=="],
 
@@ -1458,7 +1460,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
 
@@ -1640,7 +1642,7 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -2568,7 +2570,7 @@
 
     "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
 
-    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -2664,7 +2666,7 @@
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
-    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
@@ -2794,7 +2796,7 @@
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
-    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+    "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
 
     "vm-browserify": ["vm-browserify@1.1.2", "", {}, "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="],
 
@@ -2914,6 +2916,8 @@
 
     "@develar/schema-utils/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
+    "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
+
     "@electron/asar/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "@electron/asar/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -2939,6 +2943,8 @@
     "@neondatabase/serverless/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "@prisma/config/empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
+
+    "@prisma/dev/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "@prisma/dev/valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
@@ -2983,6 +2989,8 @@
     "@types/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@uncorded/server/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@uncorded/web/@types/webtorrent": ["@types/webtorrent@0.110.1", "", { "dependencies": { "@types/bittorrent-protocol": "*", "@types/node": "*", "@types/parse-torrent": "*", "@types/simple-peer": "*" } }, "sha512-fyW/LbaphpGWXdmmuXuerUb+dba/VlWAunMI7MLk44wbA27yIeSHZGuprf4FvXm9M9iqnLu1fmiPlMitg5nhJQ=="],
 
@@ -3132,8 +3140,6 @@
 
     "teex/streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
 
-    "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
-
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -3225,6 +3231,26 @@
     "@rollup/plugin-replace/@rollup/pluginutils/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@uncorded/server/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+
+    "@uncorded/server/vitest/@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+
+    "@uncorded/server/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+
+    "@uncorded/server/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+
+    "@uncorded/server/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+
+    "@uncorded/server/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+
+    "@uncorded/server/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+
+    "@uncorded/server/vitest/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "@uncorded/server/vitest/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@uncorded/server/vitest/tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
 
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 


### PR DESCRIPTION
## Summary

- Set up vitest + happy-dom test infrastructure for `apps/web`
- Add `vitest.config.ts` and `"test": "vitest run"` script
- 13 tests for `overlay-history.ts`: push/pop lifecycle, popstate handling, stacked overlays, suppression counter, history cleanup
- 10 tests for `browser-notifications.ts`: init, all permission states, notification guards (focus, permission)
- All 33 tests pass (including existing plugin-errors tests)

## Test plan

- [ ] `bun run test` from repo root passes all packages
- [ ] `cd apps/web && bunx vitest run` — 33 tests, 3 files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test suites for browser notification functionality, validating initialization, permission handling, and notification display behavior.
  * Added test suite for overlay history management, covering overlay stack operations, navigation state synchronization, and back-button interactions.

* **Chores**
  * Introduced testing framework configuration and dependencies to the development environment for improved code quality assurance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->