### PR TITLE
feat: Cloudflare named tunnel support

### DIFF
--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -43,8 +43,16 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     }))
 
     .post("/cloudflare/configure", async ({ body }) => {
-      const parsed = body as { apiToken?: string; accountId?: string } | null;
-      if (!parsed?.apiToken || !parsed?.accountId) {
+      if (typeof body !== "object" || body === null || Array.isArray(body)) {
+        return { success: false, error: "apiToken and accountId required" };
+      }
+      const parsed = body as Record<string, unknown>;
+      if (
+        typeof parsed.apiToken !== "string" ||
+        !parsed.apiToken ||
+        typeof parsed.accountId !== "string" ||
+        !parsed.accountId
+      ) {
         return { success: false, error: "apiToken and accountId required" };
       }
       if (!options.tunnelManager) {
@@ -52,8 +60,8 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
       }
       try {
         const valid = await options.tunnelManager.validateAndSetCredentials(
-          parsed.apiToken,
-          parsed.accountId,
+          parsed.apiToken as string,
+          parsed.accountId as string,
         );
         if (!valid) return { success: false, error: "Invalid Cloudflare credentials" };
         return { success: true };

--- a/apps/desktop/sidecar/bridge/server.ts
+++ b/apps/desktop/sidecar/bridge/server.ts
@@ -7,11 +7,13 @@ import { notificationQueue } from "./notifications";
 import type { DockerManager } from "../docker/manager";
 import type { GatewayClient } from "../gateway/client";
 import type { PluginLifecycle } from "../plugins/lifecycle";
+import type { TunnelManager } from "../tunnel/manager";
 
 interface BridgeServerOptions {
   docker: DockerManager;
   gateway: GatewayClient;
   plugins: PluginLifecycle;
+  tunnelManager?: TunnelManager;
   port?: number;
   dataDir?: string;
 }
@@ -33,6 +35,36 @@ export async function startBridgeServer(options: BridgeServerOptions): Promise<B
     .post("/reauth-ack", () => {
       options.plugins.clearReauthRequired();
       return { cleared: true };
+    })
+
+    // --- Cloudflare named tunnel configuration ---
+    .get("/cloudflare/status", () => ({
+      configured: options.tunnelManager?.isCloudflareConfigured() ?? false,
+    }))
+
+    .post("/cloudflare/configure", async ({ body }) => {
+      const parsed = body as { apiToken?: string; accountId?: string } | null;
+      if (!parsed?.apiToken || !parsed?.accountId) {
+        return { success: false, error: "apiToken and accountId required" };
+      }
+      if (!options.tunnelManager) {
+        return { success: false, error: "Tunnel manager not available" };
+      }
+      try {
+        const valid = await options.tunnelManager.validateAndSetCredentials(
+          parsed.apiToken,
+          parsed.accountId,
+        );
+        if (!valid) return { success: false, error: "Invalid Cloudflare credentials" };
+        return { success: true };
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : "Unknown error" };
+      }
+    })
+
+    .post("/cloudflare/clear", () => {
+      options.tunnelManager?.clearCloudflareCredentials();
+      return { success: true };
     })
 
     // --- Plugin management (called by Electron main process, no auth) ---

--- a/apps/desktop/sidecar/index.ts
+++ b/apps/desktop/sidecar/index.ts
@@ -23,7 +23,7 @@ const plugins = new PluginLifecycle(docker, DATA_DIR, tunnelManager);
 
 // --- Start Bridge Server ---
 
-const bridge = await startBridgeServer({ docker, gateway, plugins, port: 0 });
+const bridge = await startBridgeServer({ docker, gateway, plugins, tunnelManager, port: 0 });
 
 // Tell lifecycle manager what port the bridge is on
 plugins.setBridgePort(bridge.port);

--- a/apps/desktop/sidecar/plugins/lifecycle.ts
+++ b/apps/desktop/sidecar/plugins/lifecycle.ts
@@ -373,6 +373,15 @@ export class PluginLifecycle {
 
     if (!plugin) return;
 
+    // Delete named tunnel from Cloudflare if one exists
+    if (this.tunnelManager) {
+      await this.tunnelManager
+        .deleteNamedTunnel(pluginId)
+        .catch((err) =>
+          console.error(`[lifecycle] Failed to delete named tunnel for ${pluginId}:`, err),
+        );
+    }
+
     // Remove container
     if (plugin.containerId) {
       await this.docker.removeContainer(plugin.containerId, true);

--- a/apps/desktop/sidecar/tunnel/cloudflare-api.ts
+++ b/apps/desktop/sidecar/tunnel/cloudflare-api.ts
@@ -11,7 +11,7 @@ export interface CloudflareTunnel {
 
 export class CloudflareApi {
   private apiToken: string;
-  private accountId: string;
+  readonly accountId: string;
 
   constructor(apiToken: string, accountId: string) {
     this.apiToken = apiToken;

--- a/apps/desktop/sidecar/tunnel/cloudflare-api.ts
+++ b/apps/desktop/sidecar/tunnel/cloudflare-api.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+
 const CF_API_BASE = "https://api.cloudflare.com/client/v4";
 const REQUEST_TIMEOUT_MS = 15_000;
 
@@ -54,10 +56,7 @@ export class CloudflareApi {
   }
 
   async createTunnel(name: string): Promise<CloudflareTunnel> {
-    // Generate random tunnel secret
-    const secretBytes = new Uint8Array(32);
-    crypto.getRandomValues(secretBytes);
-    const tunnelSecret = Buffer.from(secretBytes).toString("base64");
+    const tunnelSecret = randomBytes(32).toString("base64");
 
     return this.request<CloudflareTunnel>("POST", `/accounts/${this.accountId}/cfd_tunnel`, {
       name,

--- a/apps/desktop/sidecar/tunnel/cloudflare-api.ts
+++ b/apps/desktop/sidecar/tunnel/cloudflare-api.ts
@@ -1,0 +1,87 @@
+const CF_API_BASE = "https://api.cloudflare.com/client/v4";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export interface CloudflareTunnel {
+  id: string;
+  name: string;
+  status: string;
+}
+
+export class CloudflareApi {
+  private apiToken: string;
+  private accountId: string;
+
+  constructor(apiToken: string, accountId: string) {
+    this.apiToken = apiToken;
+    this.accountId = accountId;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const res = await fetch(`${CF_API_BASE}${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: body ? JSON.stringify(body) : null,
+        signal: controller.signal,
+      });
+      const data = (await res.json()) as {
+        success: boolean;
+        result: T;
+        errors?: Array<{ message: string }>;
+      };
+      if (!data.success) {
+        const msg = data.errors?.[0]?.message ?? `HTTP ${res.status}`;
+        throw new Error(`Cloudflare API error: ${msg}`);
+      }
+      return data.result;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async validateCredentials(): Promise<boolean> {
+    try {
+      await this.request<unknown>("GET", `/accounts/${this.accountId}/cfd_tunnel?per_page=1`);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async createTunnel(name: string): Promise<CloudflareTunnel> {
+    // Generate random tunnel secret
+    const secretBytes = new Uint8Array(32);
+    crypto.getRandomValues(secretBytes);
+    const tunnelSecret = Buffer.from(secretBytes).toString("base64");
+
+    return this.request<CloudflareTunnel>("POST", `/accounts/${this.accountId}/cfd_tunnel`, {
+      name,
+      tunnel_secret: tunnelSecret,
+    });
+  }
+
+  async deleteTunnel(tunnelId: string): Promise<void> {
+    await this.request<unknown>(
+      "DELETE",
+      `/accounts/${this.accountId}/cfd_tunnel/${tunnelId}?cleanup_connections=true`,
+    );
+  }
+
+  async getTunnelToken(tunnelId: string): Promise<string> {
+    return this.request<string>("GET", `/accounts/${this.accountId}/cfd_tunnel/${tunnelId}/token`);
+  }
+
+  async listTunnels(name?: string): Promise<CloudflareTunnel[]> {
+    const params = new URLSearchParams({ is_deleted: "false", per_page: "100" });
+    if (name) params.set("name", name);
+    return this.request<CloudflareTunnel[]>(
+      "GET",
+      `/accounts/${this.accountId}/cfd_tunnel?${params}`,
+    );
+  }
+}

--- a/apps/desktop/sidecar/tunnel/credentials.ts
+++ b/apps/desktop/sidecar/tunnel/credentials.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+
+export interface CloudflareCredentials {
+  apiToken: string;
+  accountId: string;
+}
+
+export class CloudflareCredentialStore {
+  private dir: string;
+  private keyPath: string;
+  private credPath: string;
+
+  constructor(dataDir: string) {
+    this.dir = path.join(dataDir, "cf-credentials");
+    this.keyPath = path.join(this.dir, ".key");
+    this.credPath = path.join(this.dir, "credentials.enc");
+  }
+
+  isConfigured(): boolean {
+    return fs.existsSync(this.credPath) && fs.existsSync(this.keyPath);
+  }
+
+  save(creds: CloudflareCredentials): void {
+    fs.mkdirSync(this.dir, { recursive: true });
+
+    // Generate or read existing key
+    let keyHex: string;
+    if (fs.existsSync(this.keyPath)) {
+      keyHex = fs.readFileSync(this.keyPath, "utf-8").trim();
+    } else {
+      keyHex = randomBytes(32).toString("hex");
+      fs.writeFileSync(this.keyPath, keyHex, { mode: 0o600 });
+    }
+
+    const key = Buffer.from(keyHex, "hex");
+    const iv = randomBytes(16);
+    const cipher = createCipheriv(ALGORITHM, key, iv);
+    const plaintext = JSON.stringify(creds);
+    let encrypted = cipher.update(plaintext, "utf-8", "hex");
+    encrypted += cipher.final("hex");
+    const tag = cipher.getAuthTag().toString("hex");
+
+    fs.writeFileSync(
+      this.credPath,
+      JSON.stringify({ iv: iv.toString("hex"), tag, data: encrypted }),
+    );
+  }
+
+  load(): CloudflareCredentials | null {
+    if (!this.isConfigured()) return null;
+    try {
+      const keyHex = fs.readFileSync(this.keyPath, "utf-8").trim();
+      const key = Buffer.from(keyHex, "hex");
+      const stored = JSON.parse(fs.readFileSync(this.credPath, "utf-8")) as {
+        iv: string;
+        tag: string;
+        data: string;
+      };
+      const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(stored.iv, "hex"));
+      decipher.setAuthTag(Buffer.from(stored.tag, "hex"));
+      let decrypted = decipher.update(stored.data, "hex", "utf-8");
+      decrypted += decipher.final("utf-8");
+      return JSON.parse(decrypted) as CloudflareCredentials;
+    } catch (err) {
+      console.error("[cf-creds] Failed to load credentials:", err);
+      return null;
+    }
+  }
+
+  clear(): void {
+    try {
+      fs.unlinkSync(this.credPath);
+    } catch {
+      /* ignore */
+    }
+    try {
+      fs.unlinkSync(this.keyPath);
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -111,8 +111,25 @@ export class TunnelManager {
       console.error(`[tunnel] Reusing named tunnel ${record.tunnelName} for ${pluginId}`);
     }
 
-    // Get a fresh run token
-    const token = await this.cfApi!.getTunnelToken(record.tunnelId);
+    // Get a fresh run token — if the remote tunnel was deleted, recreate it
+    let token: string;
+    try {
+      token = await this.cfApi!.getTunnelToken(record.tunnelId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("not found") || msg.includes("404")) {
+        console.error(`[tunnel] Remote tunnel ${record.tunnelId} was deleted, recreating...`);
+        this.cfState.remove(pluginId);
+        const tunnelName = `uncorded-${pluginId}`;
+        const tunnel = await this.cfApi!.createTunnel(tunnelName);
+        const url = `https://${tunnel.id}.cfargotunnel.com`;
+        record = { pluginId, tunnelId: tunnel.id, tunnelName, url };
+        this.cfState.save(record);
+        token = await this.cfApi!.getTunnelToken(record.tunnelId);
+      } else {
+        throw err;
+      }
+    }
 
     // Spawn cloudflared with the run token
     const url = record.url;

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -166,7 +166,10 @@ export class TunnelManager {
       }
     }
 
-    // Spawn cloudflared with the run token
+    // Spawn cloudflared with the run token.
+    // --url acts as a local catch-all ingress rule, routing all traffic to the plugin port.
+    // This works for API-created tunnels without dashboard-configured ingress rules.
+    // The <tunnelId>.cfargotunnel.com URL is routable while this process is running.
     const url = record.url;
     await new Promise<void>((resolve, reject) => {
       const child = spawn(

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -1,5 +1,8 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { ensureCloudflared } from "./binary";
+import { CloudflareApi } from "./cloudflare-api";
+import { CloudflareCredentialStore, type CloudflareCredentials } from "./credentials";
+import { NamedTunnelState } from "./named-state";
 
 interface TunnelInstance {
   pluginId: string;
@@ -9,20 +12,62 @@ interface TunnelInstance {
 }
 
 const TUNNEL_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+const NAMED_CONN_REGEX = /Registered tunnel connection/;
 const STARTUP_TIMEOUT_MS = 30_000;
 
 export class TunnelManager {
   private tunnels = new Map<string, TunnelInstance>();
   private cloudflaredPath: string | null = null;
   private dataDir: string;
+  private cfApi: CloudflareApi | null = null;
+  private cfState: NamedTunnelState;
+  private credStore: CloudflareCredentialStore;
 
   constructor(dataDir: string) {
     this.dataDir = dataDir;
+    this.credStore = new CloudflareCredentialStore(dataDir);
+    this.cfState = new NamedTunnelState(dataDir);
+
+    // Load Cloudflare credentials if previously configured
+    const creds = this.credStore.load();
+    if (creds) {
+      this.cfApi = new CloudflareApi(creds.apiToken, creds.accountId);
+      console.error("[tunnel] Cloudflare named tunnel credentials loaded");
+    }
+  }
+
+  // --- Cloudflare credential management ---
+
+  isCloudflareConfigured(): boolean {
+    return this.credStore.isConfigured() && this.cfApi !== null;
+  }
+
+  async validateAndSetCredentials(apiToken: string, accountId: string): Promise<boolean> {
+    const api = new CloudflareApi(apiToken, accountId);
+    const valid = await api.validateCredentials();
+    if (!valid) return false;
+
+    this.credStore.save({ apiToken, accountId });
+    this.cfApi = api;
+    console.error("[tunnel] Cloudflare credentials saved and validated");
+    return true;
+  }
+
+  setCloudflareCredentials(creds: CloudflareCredentials): void {
+    this.credStore.save(creds);
+    this.cfApi = new CloudflareApi(creds.apiToken, creds.accountId);
+  }
+
+  clearCloudflareCredentials(): void {
+    this.credStore.clear();
+    this.cfApi = null;
+    console.error("[tunnel] Cloudflare credentials cleared");
   }
 
   /**
-   * Create a Cloudflare quick tunnel pointing at localhost:{port}.
-   * Returns the public HTTPS URL (e.g. https://xxx.trycloudflare.com).
+   * Create a Cloudflare tunnel pointing at localhost:{port}.
+   * Tries named tunnel first (if configured), falls back to quick tunnel.
+   * Returns the public HTTPS URL.
    */
   async create(pluginId: string, localPort: number): Promise<string> {
     // Destroy any existing tunnel for this plugin
@@ -32,6 +77,114 @@ export class TunnelManager {
       this.cloudflaredPath = await ensureCloudflared(this.dataDir);
     }
 
+    // Try named tunnel first if Cloudflare credentials are configured
+    if (this.cfApi) {
+      try {
+        return await this.createNamedTunnel(pluginId, localPort);
+      } catch (err) {
+        console.error(
+          `[tunnel] Named tunnel failed for ${pluginId}, falling back to quick tunnel:`,
+          err,
+        );
+      }
+    }
+
+    return this.createQuickTunnel(pluginId, localPort);
+  }
+
+  /**
+   * Create a named tunnel via Cloudflare API with a stable URL.
+   */
+  private async createNamedTunnel(pluginId: string, localPort: number): Promise<string> {
+    // Check if we already have a tunnel record for this plugin (reuse for stable URL)
+    let record = this.cfState.get(pluginId);
+
+    if (!record) {
+      // Create a new tunnel via API
+      const tunnelName = `uncorded-${pluginId}`;
+      const tunnel = await this.cfApi!.createTunnel(tunnelName);
+      const url = `https://${tunnel.id}.cfargotunnel.com`;
+      record = { pluginId, tunnelId: tunnel.id, tunnelName, url };
+      this.cfState.save(record);
+      console.error(`[tunnel] Created named tunnel ${tunnelName} (${tunnel.id}) for ${pluginId}`);
+    } else {
+      console.error(`[tunnel] Reusing named tunnel ${record.tunnelName} for ${pluginId}`);
+    }
+
+    // Get a fresh run token
+    const token = await this.cfApi!.getTunnelToken(record.tunnelId);
+
+    // Spawn cloudflared with the run token
+    const url = record.url;
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(
+        this.cloudflaredPath!,
+        [
+          "tunnel",
+          "run",
+          "--token",
+          token,
+          "--url",
+          `http://localhost:${localPort}`,
+          "--no-autoupdate",
+        ],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          child.kill();
+          reject(new Error(`Named tunnel startup timed out after ${STARTUP_TIMEOUT_MS}ms`));
+        }
+      }, STARTUP_TIMEOUT_MS);
+
+      const handleData = (data: Buffer) => {
+        const line = data.toString();
+        if (resolved) return;
+
+        if (NAMED_CONN_REGEX.test(line)) {
+          resolved = true;
+          clearTimeout(timeout);
+
+          this.tunnels.set(pluginId, { pluginId, localPort, url, process: child });
+          console.error(`[tunnel] Named tunnel connected for ${pluginId}: ${url}`);
+          resolve();
+        }
+      };
+
+      child.stderr?.on("data", handleData);
+      child.stdout?.on("data", handleData);
+
+      child.on("error", (err) => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          reject(err);
+        }
+      });
+
+      child.on("exit", (code) => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          reject(new Error(`cloudflared exited with code ${code} before named tunnel was ready`));
+        }
+        this.tunnels.delete(pluginId);
+      });
+    });
+
+    return url;
+  }
+
+  /**
+   * Create a quick tunnel (anonymous, ephemeral URL).
+   */
+  private createQuickTunnel(pluginId: string, localPort: number): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       const child = spawn(
         this.cloudflaredPath!,
@@ -120,6 +273,25 @@ export class TunnelManager {
 
     this.tunnels.delete(pluginId);
     console.error(`[tunnel] Destroyed tunnel for ${pluginId}`);
+  }
+
+  /**
+   * Delete a named tunnel from Cloudflare and remove local state.
+   */
+  async deleteNamedTunnel(pluginId: string): Promise<void> {
+    const record = this.cfState.get(pluginId);
+    if (!record) return;
+
+    if (this.cfApi) {
+      try {
+        await this.cfApi.deleteTunnel(record.tunnelId);
+        console.error(`[tunnel] Deleted named tunnel ${record.tunnelName} from Cloudflare`);
+      } catch (err) {
+        console.error(`[tunnel] Failed to delete named tunnel ${record.tunnelName}:`, err);
+      }
+    }
+
+    this.cfState.remove(pluginId);
   }
 
   /**

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -44,12 +44,25 @@ export class TunnelManager {
 
   async validateAndSetCredentials(apiToken: string, accountId: string): Promise<boolean> {
     const api = new CloudflareApi(apiToken, accountId);
-    const valid = await api.validateCredentials();
-    if (!valid) return false;
+
+    // Verify read access
+    const canRead = await api.validateCredentials();
+    if (!canRead) return false;
+
+    // Verify write access by creating and immediately deleting a test tunnel
+    try {
+      const testTunnel = await api.createTunnel("uncorded-write-test");
+      await api.deleteTunnel(testTunnel.id).catch(() => {});
+    } catch {
+      console.error(
+        "[tunnel] Cloudflare token lacks write permissions (Tunnel Edit scope required)",
+      );
+      return false;
+    }
 
     this.credStore.save({ apiToken, accountId });
     this.cfApi = api;
-    console.error("[tunnel] Cloudflare credentials saved and validated");
+    console.error("[tunnel] Cloudflare credentials saved and validated (read + write)");
     return true;
   }
 
@@ -299,16 +312,31 @@ export class TunnelManager {
     const record = this.cfState.get(pluginId);
     if (!record) return;
 
-    if (this.cfApi) {
-      try {
-        await this.cfApi.deleteTunnel(record.tunnelId);
-        console.error(`[tunnel] Deleted named tunnel ${record.tunnelName} from Cloudflare`);
-      } catch (err) {
-        console.error(`[tunnel] Failed to delete named tunnel ${record.tunnelName}:`, err);
-      }
+    if (!this.cfApi) {
+      console.error(
+        `[tunnel] Cannot delete named tunnel ${record.tunnelName}: no Cloudflare API configured`,
+      );
+      return;
     }
 
-    this.cfState.remove(pluginId);
+    try {
+      await this.cfApi.deleteTunnel(record.tunnelId);
+      this.cfState.remove(pluginId);
+      console.error(`[tunnel] Deleted named tunnel ${record.tunnelName} from Cloudflare`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("not found") || msg.includes("404")) {
+        this.cfState.remove(pluginId);
+        console.error(
+          `[tunnel] Named tunnel ${record.tunnelName} already deleted remotely, cleaned local state`,
+        );
+      } else {
+        console.error(
+          `[tunnel] Failed to delete named tunnel ${record.tunnelName}, keeping record for retry:`,
+          err,
+        );
+      }
+    }
   }
 
   /**

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -50,15 +50,26 @@ export class TunnelManager {
     if (!canRead) return false;
 
     // Verify write access by creating and immediately deleting a test tunnel
+    const testName = `uncorded-write-test-${Date.now()}`;
+    let testTunnelId: string | null = null;
     try {
-      const testTunnel = await api.createTunnel("uncorded-write-test");
-      await api.deleteTunnel(testTunnel.id).catch(() => {});
-    } catch {
-      console.error(
-        "[tunnel] Cloudflare token lacks write permissions (Tunnel Edit scope required)",
-      );
+      const testTunnel = await api.createTunnel(testName);
+      testTunnelId = testTunnel.id;
+      await api.deleteTunnel(testTunnel.id);
+    } catch (err) {
+      // Best-effort cleanup if create succeeded but delete failed
+      if (testTunnelId) {
+        console.error(`[tunnel] Write test tunnel ${testName} leaked (delete failed):`, err);
+      } else {
+        console.error(
+          "[tunnel] Cloudflare token lacks write permissions (Tunnel Edit scope required)",
+        );
+      }
       return false;
     }
+
+    // Clear named tunnel records from a different account
+    this.cfState.clearOtherAccounts(accountId);
 
     this.credStore.save({ apiToken, accountId });
     this.cfApi = api;
@@ -67,6 +78,7 @@ export class TunnelManager {
   }
 
   setCloudflareCredentials(creds: CloudflareCredentials): void {
+    this.cfState.clearOtherAccounts(creds.accountId);
     this.credStore.save(creds);
     this.cfApi = new CloudflareApi(creds.apiToken, creds.accountId);
   }
@@ -117,7 +129,7 @@ export class TunnelManager {
       const tunnelName = `uncorded-${pluginId}`;
       const tunnel = await this.cfApi!.createTunnel(tunnelName);
       const url = `https://${tunnel.id}.cfargotunnel.com`;
-      record = { pluginId, tunnelId: tunnel.id, tunnelName, url };
+      record = { pluginId, tunnelId: tunnel.id, tunnelName, url, accountId: this.cfApi!.accountId };
       this.cfState.save(record);
       console.error(`[tunnel] Created named tunnel ${tunnelName} (${tunnel.id}) for ${pluginId}`);
     } else {
@@ -136,7 +148,13 @@ export class TunnelManager {
         const tunnelName = `uncorded-${pluginId}`;
         const tunnel = await this.cfApi!.createTunnel(tunnelName);
         const url = `https://${tunnel.id}.cfargotunnel.com`;
-        record = { pluginId, tunnelId: tunnel.id, tunnelName, url };
+        record = {
+          pluginId,
+          tunnelId: tunnel.id,
+          tunnelName,
+          url,
+          accountId: this.cfApi!.accountId,
+        };
         this.cfState.save(record);
         token = await this.cfApi!.getTunnelToken(record.tunnelId);
       } else {

--- a/apps/desktop/sidecar/tunnel/manager.ts
+++ b/apps/desktop/sidecar/tunnel/manager.ts
@@ -121,15 +121,19 @@ export class TunnelManager {
    * Create a named tunnel via Cloudflare API with a stable URL.
    */
   private async createNamedTunnel(pluginId: string, localPort: number): Promise<string> {
+    // Capture client once to prevent credential changes mid-flight
+    const cfApi = this.cfApi;
+    if (!cfApi) throw new Error("Cloudflare API not configured");
+
     // Check if we already have a tunnel record for this plugin (reuse for stable URL)
     let record = this.cfState.get(pluginId);
 
     if (!record) {
       // Create a new tunnel via API
       const tunnelName = `uncorded-${pluginId}`;
-      const tunnel = await this.cfApi!.createTunnel(tunnelName);
+      const tunnel = await cfApi.createTunnel(tunnelName);
       const url = `https://${tunnel.id}.cfargotunnel.com`;
-      record = { pluginId, tunnelId: tunnel.id, tunnelName, url, accountId: this.cfApi!.accountId };
+      record = { pluginId, tunnelId: tunnel.id, tunnelName, url, accountId: cfApi.accountId };
       this.cfState.save(record);
       console.error(`[tunnel] Created named tunnel ${tunnelName} (${tunnel.id}) for ${pluginId}`);
     } else {
@@ -139,24 +143,24 @@ export class TunnelManager {
     // Get a fresh run token — if the remote tunnel was deleted, recreate it
     let token: string;
     try {
-      token = await this.cfApi!.getTunnelToken(record.tunnelId);
+      token = await cfApi.getTunnelToken(record.tunnelId);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("not found") || msg.includes("404")) {
         console.error(`[tunnel] Remote tunnel ${record.tunnelId} was deleted, recreating...`);
         this.cfState.remove(pluginId);
         const tunnelName = `uncorded-${pluginId}`;
-        const tunnel = await this.cfApi!.createTunnel(tunnelName);
+        const tunnel = await cfApi.createTunnel(tunnelName);
         const url = `https://${tunnel.id}.cfargotunnel.com`;
         record = {
           pluginId,
           tunnelId: tunnel.id,
           tunnelName,
           url,
-          accountId: this.cfApi!.accountId,
+          accountId: cfApi.accountId,
         };
         this.cfState.save(record);
-        token = await this.cfApi!.getTunnelToken(record.tunnelId);
+        token = await cfApi.getTunnelToken(record.tunnelId);
       } else {
         throw err;
       }
@@ -167,17 +171,10 @@ export class TunnelManager {
     await new Promise<void>((resolve, reject) => {
       const child = spawn(
         this.cloudflaredPath!,
-        [
-          "tunnel",
-          "run",
-          "--token",
-          token,
-          "--url",
-          `http://localhost:${localPort}`,
-          "--no-autoupdate",
-        ],
+        ["tunnel", "run", "--url", `http://localhost:${localPort}`, "--no-autoupdate"],
         {
           stdio: ["ignore", "pipe", "pipe"],
+          env: { ...process.env, TUNNEL_TOKEN: token },
         },
       );
 

--- a/apps/desktop/sidecar/tunnel/named-state.ts
+++ b/apps/desktop/sidecar/tunnel/named-state.ts
@@ -21,9 +21,21 @@ export class NamedTunnelState {
   private loadFromDisk(): void {
     try {
       if (fs.existsSync(this.filePath)) {
-        const data = JSON.parse(fs.readFileSync(this.filePath, "utf-8")) as NamedTunnelRecord[];
-        for (const r of data) {
-          this.records.set(r.pluginId, r);
+        const raw = JSON.parse(fs.readFileSync(this.filePath, "utf-8")) as unknown;
+        if (!Array.isArray(raw)) return;
+        for (const r of raw) {
+          if (
+            typeof r === "object" &&
+            r !== null &&
+            typeof r.pluginId === "string" &&
+            typeof r.tunnelId === "string" &&
+            typeof r.tunnelName === "string" &&
+            typeof r.url === "string"
+          ) {
+            this.records.set(r.pluginId, r as NamedTunnelRecord);
+          } else {
+            console.warn("[named-state] Skipping malformed record:", r);
+          }
         }
       }
     } catch (err) {

--- a/apps/desktop/sidecar/tunnel/named-state.ts
+++ b/apps/desktop/sidecar/tunnel/named-state.ts
@@ -6,6 +6,7 @@ export interface NamedTunnelRecord {
   tunnelId: string;
   tunnelName: string;
   url: string;
+  accountId: string;
 }
 
 export class NamedTunnelState {
@@ -30,7 +31,8 @@ export class NamedTunnelState {
             typeof r.pluginId === "string" &&
             typeof r.tunnelId === "string" &&
             typeof r.tunnelName === "string" &&
-            typeof r.url === "string"
+            typeof r.url === "string" &&
+            typeof r.accountId === "string"
           ) {
             this.records.set(r.pluginId, r as NamedTunnelRecord);
           } else {
@@ -61,6 +63,19 @@ export class NamedTunnelState {
   remove(pluginId: string): void {
     this.records.delete(pluginId);
     this.saveToDisk();
+  }
+
+  /** Remove all records that don't belong to the given account. */
+  clearOtherAccounts(accountId: string): void {
+    let changed = false;
+    for (const [id, record] of this.records) {
+      if (record.accountId !== accountId) {
+        this.records.delete(id);
+        changed = true;
+        console.warn(`[named-state] Dropped stale record for ${id} (different account)`);
+      }
+    }
+    if (changed) this.saveToDisk();
   }
 
   getAll(): NamedTunnelRecord[] {

--- a/apps/desktop/sidecar/tunnel/named-state.ts
+++ b/apps/desktop/sidecar/tunnel/named-state.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface NamedTunnelRecord {
+  pluginId: string;
+  tunnelId: string;
+  tunnelName: string;
+  url: string;
+}
+
+export class NamedTunnelState {
+  private filePath: string;
+  private records: Map<string, NamedTunnelRecord>;
+
+  constructor(dataDir: string) {
+    this.filePath = path.join(dataDir, "cf-credentials", "tunnels.json");
+    this.records = new Map();
+    this.loadFromDisk();
+  }
+
+  private loadFromDisk(): void {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        const data = JSON.parse(fs.readFileSync(this.filePath, "utf-8")) as NamedTunnelRecord[];
+        for (const r of data) {
+          this.records.set(r.pluginId, r);
+        }
+      }
+    } catch (err) {
+      console.error("[named-state] Failed to load tunnel state:", err);
+    }
+  }
+
+  private saveToDisk(): void {
+    const dir = path.dirname(this.filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify([...this.records.values()], null, 2));
+  }
+
+  get(pluginId: string): NamedTunnelRecord | null {
+    return this.records.get(pluginId) ?? null;
+  }
+
+  save(record: NamedTunnelRecord): void {
+    this.records.set(record.pluginId, record);
+    this.saveToDisk();
+  }
+
+  remove(pluginId: string): void {
+    this.records.delete(pluginId);
+    this.saveToDisk();
+  }
+
+  getAll(): NamedTunnelRecord[] {
+    return [...this.records.values()];
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -180,6 +180,47 @@ function setupSidecarIpc(): void {
   });
 }
 
+// --- IPC: Cloudflare Tunnels ---
+
+function setupCloudflareIpc(): void {
+  ipcMain.handle("cloudflare:configure", async (_event, apiToken: string, accountId: string) => {
+    const port = sidecar.getPort();
+    if (!port) return { success: false, error: "Sidecar not running" };
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/cloudflare/configure`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiToken, accountId }),
+      });
+      return (await res.json()) as { success: boolean; error?: string };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : "Unknown error" };
+    }
+  });
+
+  ipcMain.handle("cloudflare:status", async () => {
+    const port = sidecar.getPort();
+    if (!port) return { configured: false };
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/cloudflare/status`);
+      return (await res.json()) as { configured: boolean };
+    } catch {
+      return { configured: false };
+    }
+  });
+
+  ipcMain.handle("cloudflare:clear", async () => {
+    const port = sidecar.getPort();
+    if (!port) return { success: false, error: "Sidecar not running" };
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/cloudflare/clear`, { method: "POST" });
+      return (await res.json()) as { success: boolean };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : "Unknown error" };
+    }
+  });
+}
+
 // --- IPC: Plugins ---
 // Plugin state is managed by the sidecar's Bridge Server.
 // These handlers forward requests to the sidecar HTTP API
@@ -506,6 +547,7 @@ app.on("ready", async () => {
 
   setupSidecarIpc();
   setupPluginIpc();
+  setupCloudflareIpc();
   setupAutoUpdater();
   setupAutoUpdateIpc(() => sidecar.stop());
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -182,12 +182,20 @@ function setupSidecarIpc(): void {
 
 // --- IPC: Cloudflare Tunnels ---
 
+function sidecarFetch(port: number, path: string, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  return fetch(`http://127.0.0.1:${port}${path}`, { ...init, signal: controller.signal }).finally(
+    () => clearTimeout(timeout),
+  );
+}
+
 function setupCloudflareIpc(): void {
   ipcMain.handle("cloudflare:configure", async (_event, apiToken: string, accountId: string) => {
     const port = sidecar.getPort();
     if (!port) return { success: false, error: "Sidecar not running" };
     try {
-      const res = await fetch(`http://127.0.0.1:${port}/cloudflare/configure`, {
+      const res = await sidecarFetch(port, "/cloudflare/configure", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ apiToken, accountId }),
@@ -202,7 +210,7 @@ function setupCloudflareIpc(): void {
     const port = sidecar.getPort();
     if (!port) return { configured: false };
     try {
-      const res = await fetch(`http://127.0.0.1:${port}/cloudflare/status`);
+      const res = await sidecarFetch(port, "/cloudflare/status");
       return (await res.json()) as { configured: boolean };
     } catch {
       return { configured: false };
@@ -213,7 +221,7 @@ function setupCloudflareIpc(): void {
     const port = sidecar.getPort();
     if (!port) return { success: false, error: "Sidecar not running" };
     try {
-      const res = await fetch(`http://127.0.0.1:${port}/cloudflare/clear`, { method: "POST" });
+      const res = await sidecarFetch(port, "/cloudflare/clear", { method: "POST" });
       return (await res.json()) as { success: boolean };
     } catch (err) {
       return { success: false, error: err instanceof Error ? err.message : "Unknown error" };

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -90,6 +90,17 @@ const desktopBridge = {
     update: (pluginId: string): Promise<void> => ipcRenderer.invoke("plugins:update", pluginId),
   },
 
+  // --- Cloudflare Tunnels ---
+  cloudflare: {
+    configure: (
+      apiToken: string,
+      accountId: string,
+    ): Promise<{ success: boolean; error?: string }> =>
+      ipcRenderer.invoke("cloudflare:configure", apiToken, accountId),
+    getStatus: (): Promise<{ configured: boolean }> => ipcRenderer.invoke("cloudflare:status"),
+    clear: (): Promise<{ success: boolean }> => ipcRenderer.invoke("cloudflare:clear"),
+  },
+
   // --- Auto-update ---
   getUpdateState: (): Promise<UpdateState> => ipcRenderer.invoke("desktop:update-get-state"),
 

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -1,4 +1,12 @@
-import { createSignal, createResource, For, Show, onMount, onCleanup } from "solid-js";
+import {
+  createSignal,
+  createEffect,
+  createResource,
+  For,
+  Show,
+  onMount,
+  onCleanup,
+} from "solid-js";
 import type { ServerId, PluginId, UserId } from "@uncorded/protocol";
 import { api } from "../../lib/api.js";
 import { showToast } from "../ui/toast.js";
@@ -78,6 +86,45 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
   const [updating, setUpdating] = createSignal<PluginId | null>(null);
   const [search, setSearch] = createSignal("");
   const [pluginUpdates, setPluginUpdates] = createSignal<PluginUpdateInfo[]>([]);
+
+  // Cloudflare tunnel configuration (desktop only)
+  const [cfConfigured, setCfConfigured] = createSignal(false);
+  const [cfLoading, setCfLoading] = createSignal(false);
+  const [cfToken, setCfToken] = createSignal("");
+  const [cfAccountId, setCfAccountId] = createSignal("");
+  const [cfError, setCfError] = createSignal("");
+  const [cfExpanded, setCfExpanded] = createSignal(false);
+
+  createEffect(() => {
+    if (isDesktop()) {
+      window.desktopBridge!.cloudflare.getStatus().then((s) => setCfConfigured(s.configured));
+    }
+  });
+
+  const handleCfSave = async () => {
+    setCfLoading(true);
+    setCfError("");
+    try {
+      const result = await window.desktopBridge!.cloudflare.configure(cfToken(), cfAccountId());
+      if (result.success) {
+        setCfConfigured(true);
+        setCfToken("");
+        setCfAccountId("");
+        setCfExpanded(false);
+      } else {
+        setCfError(result.error ?? "Failed to configure");
+      }
+    } catch (err) {
+      setCfError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setCfLoading(false);
+    }
+  };
+
+  const handleCfClear = async () => {
+    await window.desktopBridge!.cloudflare.clear();
+    setCfConfigured(false);
+  };
 
   onMount(() => {
     if (!isDesktop()) return;
@@ -267,6 +314,83 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
           <p class="mt-1 text-sm text-muted-foreground">
             Upgrade to the Server Owner plan to install and manage server plugins.
           </p>
+        </div>
+      </Show>
+
+      {/* Cloudflare tunnel configuration (desktop only) */}
+      <Show when={isDesktop()}>
+        <div class="rounded-lg border border-border p-4 mb-4">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <h3 class="text-sm font-medium">Cloudflare Tunnels</h3>
+              <Show when={cfConfigured()}>
+                <span class="rounded-full bg-success/20 px-2 py-0.5 text-xs text-success">
+                  Active
+                </span>
+              </Show>
+            </div>
+            <Show
+              when={cfConfigured()}
+              fallback={
+                <button
+                  class="text-xs text-muted-foreground hover:text-foreground"
+                  onClick={() => setCfExpanded(!cfExpanded())}
+                >
+                  {cfExpanded() ? "Cancel" : "Configure"}
+                </button>
+              }
+            >
+              <button
+                class="text-xs text-destructive hover:text-destructive/80"
+                onClick={handleCfClear}
+              >
+                Remove
+              </button>
+            </Show>
+          </div>
+          <p class="mt-1 text-xs text-muted-foreground">
+            Named tunnels provide stable URLs for your server plugins. Without this, plugins use
+            temporary random URLs.
+          </p>
+
+          <Show when={cfExpanded() && !cfConfigured()}>
+            <div class="mt-3 space-y-2">
+              <input
+                type="text"
+                placeholder="Cloudflare Account ID"
+                value={cfAccountId()}
+                onInput={(e) => setCfAccountId(e.currentTarget.value)}
+                class="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+              />
+              <input
+                type="password"
+                placeholder="API Token"
+                value={cfToken()}
+                onInput={(e) => setCfToken(e.currentTarget.value)}
+                class="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+              />
+              <Show when={cfError()}>
+                <p class="text-xs text-destructive">{cfError()}</p>
+              </Show>
+              <div class="flex items-center gap-2">
+                <button
+                  class="rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground disabled:opacity-50"
+                  onClick={handleCfSave}
+                  disabled={cfLoading() || !cfToken() || !cfAccountId()}
+                >
+                  {cfLoading() ? "Validating..." : "Save"}
+                </button>
+                <a
+                  href="https://developers.cloudflare.com/fundamentals/api/get-started/create-token/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-xs text-muted-foreground hover:text-foreground underline"
+                >
+                  How to create an API token
+                </a>
+              </div>
+            </div>
+          </Show>
         </div>
       </Show>
 

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -100,11 +100,14 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     let attempts = 0;
     const maxAttempts = 5;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let disposed = false;
 
     const probe = () => {
+      if (disposed) return;
       window
         .desktopBridge!.cloudflare.getStatus()
         .then((s) => {
+          if (disposed) return;
           if (s.configured) {
             setCfConfigured(true);
           } else if (++attempts < maxAttempts) {
@@ -114,6 +117,7 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
           }
         })
         .catch(() => {
+          if (disposed) return;
           if (++attempts < maxAttempts) {
             retryTimer = setTimeout(probe, 2000);
           }
@@ -121,13 +125,14 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     };
     probe();
 
-    // Re-probe when sidecar becomes ready
     const unsub = window.desktopBridge!.onSidecarReady(() => {
+      if (disposed) return;
       clearTimeout(retryTimer);
       attempts = 0;
       probe();
     });
     onCleanup(() => {
+      disposed = true;
       clearTimeout(retryTimer);
       unsub();
     });

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -122,8 +122,17 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
   };
 
   const handleCfClear = async () => {
-    await window.desktopBridge!.cloudflare.clear();
-    setCfConfigured(false);
+    if (
+      !window.confirm("Remove Cloudflare credentials? Plugins will fall back to temporary tunnels.")
+    )
+      return;
+    try {
+      await window.desktopBridge!.cloudflare.clear();
+      setCfConfigured(false);
+      setCfError("");
+    } catch (err) {
+      setCfError(err instanceof Error ? err.message : "Failed to clear credentials");
+    }
   };
 
   onMount(() => {

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -96,9 +96,25 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
   const [cfExpanded, setCfExpanded] = createSignal(false);
 
   createEffect(() => {
-    if (isDesktop()) {
-      window.desktopBridge!.cloudflare.getStatus().then((s) => setCfConfigured(s.configured));
-    }
+    if (!isDesktop()) return;
+    let attempts = 0;
+    const maxAttempts = 5;
+    const probe = () => {
+      window
+        .desktopBridge!.cloudflare.getStatus()
+        .then((s) => setCfConfigured(s.configured))
+        .catch(() => {
+          if (++attempts < maxAttempts) setTimeout(probe, 2000);
+        });
+    };
+    probe();
+
+    // Re-probe when sidecar becomes ready
+    const unsub = window.desktopBridge!.onSidecarReady(() => {
+      attempts = 0;
+      probe();
+    });
+    onCleanup(unsub);
   });
 
   const handleCfSave = async () => {
@@ -127,9 +143,13 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     )
       return;
     try {
-      await window.desktopBridge!.cloudflare.clear();
-      setCfConfigured(false);
-      setCfError("");
+      const result = await window.desktopBridge!.cloudflare.clear();
+      if (result.success) {
+        setCfConfigured(false);
+        setCfError("");
+      } else {
+        setCfError(result.error ?? "Failed to clear Cloudflare credentials");
+      }
     } catch (err) {
       setCfError(err instanceof Error ? err.message : "Failed to clear credentials");
     }

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -99,6 +99,8 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     if (!isDesktop()) return;
     let attempts = 0;
     const maxAttempts = 5;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
     const probe = () => {
       window
         .desktopBridge!.cloudflare.getStatus()
@@ -106,23 +108,29 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
           if (s.configured) {
             setCfConfigured(true);
           } else if (++attempts < maxAttempts) {
-            setTimeout(probe, 2000);
+            retryTimer = setTimeout(probe, 2000);
           } else {
             setCfConfigured(false);
           }
         })
         .catch(() => {
-          if (++attempts < maxAttempts) setTimeout(probe, 2000);
+          if (++attempts < maxAttempts) {
+            retryTimer = setTimeout(probe, 2000);
+          }
         });
     };
     probe();
 
     // Re-probe when sidecar becomes ready
     const unsub = window.desktopBridge!.onSidecarReady(() => {
+      clearTimeout(retryTimer);
       attempts = 0;
       probe();
     });
-    onCleanup(unsub);
+    onCleanup(() => {
+      clearTimeout(retryTimer);
+      unsub();
+    });
   });
 
   const handleCfSave = async () => {
@@ -417,9 +425,6 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
                 onInput={(e) => setCfToken(e.currentTarget.value)}
                 class="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
               />
-              <Show when={cfError()}>
-                <p class="text-xs text-destructive">{cfError()}</p>
-              </Show>
               <div class="flex items-center gap-2">
                 <button
                   class="rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground disabled:opacity-50"

--- a/apps/web/src/components/settings/server-plugins.tsx
+++ b/apps/web/src/components/settings/server-plugins.tsx
@@ -102,7 +102,15 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
     const probe = () => {
       window
         .desktopBridge!.cloudflare.getStatus()
-        .then((s) => setCfConfigured(s.configured))
+        .then((s) => {
+          if (s.configured) {
+            setCfConfigured(true);
+          } else if (++attempts < maxAttempts) {
+            setTimeout(probe, 2000);
+          } else {
+            setCfConfigured(false);
+          }
+        })
         .catch(() => {
           if (++attempts < maxAttempts) setTimeout(probe, 2000);
         });
@@ -377,6 +385,9 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
               </button>
             </Show>
           </div>
+          <Show when={cfError()}>
+            <p class="mt-1 text-xs text-destructive">{cfError()}</p>
+          </Show>
           <p class="mt-1 text-xs text-muted-foreground">
             Named tunnels provide stable URLs for your server plugins. Without this, plugins use
             temporary random URLs.
@@ -384,14 +395,22 @@ const ServerPluginsTab = (props: ServerPluginsProps) => {
 
           <Show when={cfExpanded() && !cfConfigured()}>
             <div class="mt-3 space-y-2">
+              <label for="cf-account-id" class="sr-only">
+                Cloudflare Account ID
+              </label>
               <input
+                id="cf-account-id"
                 type="text"
                 placeholder="Cloudflare Account ID"
                 value={cfAccountId()}
                 onInput={(e) => setCfAccountId(e.currentTarget.value)}
                 class="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
               />
+              <label for="cf-api-token" class="sr-only">
+                API Token
+              </label>
               <input
+                id="cf-api-token"
                 type="password"
                 placeholder="API Token"
                 value={cfToken()}

--- a/apps/web/src/types/desktop-bridge.d.ts
+++ b/apps/web/src/types/desktop-bridge.d.ts
@@ -41,7 +41,7 @@ interface DesktopBridgePlugins {
 interface DesktopBridgeCloudflare {
   configure(apiToken: string, accountId: string): Promise<{ success: boolean; error?: string }>;
   getStatus(): Promise<{ configured: boolean }>;
-  clear(): Promise<{ success: boolean }>;
+  clear(): Promise<{ success: boolean; error?: string }>;
 }
 
 interface DesktopBridge {

--- a/apps/web/src/types/desktop-bridge.d.ts
+++ b/apps/web/src/types/desktop-bridge.d.ts
@@ -38,11 +38,18 @@ interface DesktopBridgePlugins {
   update(pluginId: string): Promise<void>;
 }
 
+interface DesktopBridgeCloudflare {
+  configure(apiToken: string, accountId: string): Promise<{ success: boolean; error?: string }>;
+  getStatus(): Promise<{ configured: boolean }>;
+  clear(): Promise<{ success: boolean }>;
+}
+
 interface DesktopBridge {
   getSidecarStatus(): Promise<{ running: boolean; port: number | null }>;
   getSidecarPort(): Promise<number | null>;
   getDockerStatus(): Promise<{ available: boolean; bridgePort?: number }>;
   plugins: DesktopBridgePlugins;
+  cloudflare: DesktopBridgeCloudflare;
   getUpdateState(): Promise<UpdateState>;
   checkForUpdates(): Promise<UpdateState>;
   downloadUpdate(): Promise<UpdateResult>;


### PR DESCRIPTION
## Summary

Server owners can provide a Cloudflare API token + account ID to get stable per-plugin tunnel URLs (`<uuid>.cfargotunnel.com`) instead of random `trycloudflare.com` quick tunnels. Free Cloudflare account, no domain required.

**Why:** Quick tunnels have no SLA — Cloudflare's API returned 500 errors on 2026-04-04, leaving all server plugins invisible to web users. Named tunnels provide stable, persistent URLs with Cloudflare's full edge network.

**How it works:**
1. Server owner enters Cloudflare API token + account ID in Server Settings > Plugins
2. Sidecar validates credentials against Cloudflare API
3. On plugin start: sidecar creates a named tunnel via API (or reuses existing), runs `cloudflared tunnel run --token TOKEN --url http://localhost:PORT`
4. Stable URL persists across stop/start cycles, only deleted on uninstall
5. If named tunnel creation fails, seamlessly falls back to quick tunnel

## Files changed (11)

**New (3):**
- `apps/desktop/sidecar/tunnel/cloudflare-api.ts` — CF REST API client
- `apps/desktop/sidecar/tunnel/credentials.ts` — AES-256-GCM encrypted credential storage
- `apps/desktop/sidecar/tunnel/named-state.ts` — Persistent tunnel-to-plugin mappings

**Modified (8):**
- `apps/desktop/sidecar/tunnel/manager.ts` — Named tunnel mode + quick tunnel fallback
- `apps/desktop/sidecar/bridge/server.ts` — 3 new endpoints: configure/status/clear
- `apps/desktop/sidecar/index.ts` — Pass tunnelManager to bridge
- `apps/desktop/sidecar/plugins/lifecycle.ts` — Delete named tunnel on uninstall
- `apps/desktop/src/main/preload.ts` — cloudflare IPC namespace
- `apps/desktop/src/main/index.ts` — IPC handlers forwarding to sidecar
- `apps/web/src/components/settings/server-plugins.tsx` — Config UI card
- `apps/web/src/types/desktop-bridge.d.ts` — Type definitions

## Design decisions

- **Credentials never leave the desktop** — encrypted on disk, never sent to server DB
- **Per-plugin tunnels** — independent lifecycle, one failure doesn't affect others
- **Stable URLs persist** — tunnels survive stop/start, only deleted on uninstall
- **Fallback to quick tunnels** — if named tunnel fails, seamlessly falls back

## Test plan

- [x] `bun run typecheck` — 12/12 pass
- [x] `bun run lint` — 0 errors
- [x] `bun run fmt:check` — clean
- [x] `bun run test` — all pass
- [ ] Configure CF creds in UI → verify validation → start plugin → verify stable URL
- [ ] Clear creds → restart plugin → verify fallback to quick tunnel
- [ ] Stop/start plugin → verify same URL persists
- [ ] Uninstall plugin → verify CF tunnel deleted via API
- [ ] Requires desktop release for sidecar changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare Tunnels support with Configure / Status / Clear controls in Server Plugins settings.
  * Desktop UI wired to the sidecar so you can configure, probe status, and clear Cloudflare credentials from the app.
  * Persistent, encrypted storage for Cloudflare API credentials.
  * Named tunnels that provide stable plugin URLs with automatic fallback to quick tunnels.
  * Plugin uninstall now attempts to remove associated Cloudflare tunnels.
* **Chores**
  * Added IPC and local sidecar endpoints to manage Cloudflare credential lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->